### PR TITLE
Handle singletons in EmbeddingComposite

### DIFF
--- a/dwave/system/composites/embedding.py
+++ b/dwave/system/composites/embedding.py
@@ -177,7 +177,7 @@ class EmbeddingComposite(dimod.Sampler, dimod.Composite):
         __, target_edgelist, target_adjacency = child.structure
 
         # add self-loops to edgelist to handle singleton variables
-        source_edgelist = bqm.quadratic.keys() + [(v, v) for v in bqm.linear]
+        source_edgelist = list(bqm.quadratic) + [(v, v) for v in bqm.linear]
 
         # get the embedding
         embedding = minorminer.find_embedding(source_edgelist, target_edgelist)

--- a/dwave/system/composites/embedding.py
+++ b/dwave/system/composites/embedding.py
@@ -182,10 +182,6 @@ class EmbeddingComposite(dimod.Sampler, dimod.Composite):
         if bqm and not embedding:
             raise ValueError("no embedding found")
 
-        # this should change in later versions
-        if isinstance(embedding, list):
-            embedding = dict(enumerate(embedding))
-
         bqm_embedded = dimod.embed_bqm(bqm, embedding, target_adjacency)
 
         response = child.sample(bqm_embedded, **parameters)

--- a/dwave/system/composites/embedding.py
+++ b/dwave/system/composites/embedding.py
@@ -176,8 +176,11 @@ class EmbeddingComposite(dimod.Sampler, dimod.Composite):
         # apply the embedding to the given problem to map it to the child sampler
         __, target_edgelist, target_adjacency = child.structure
 
+        # add self-loops to edgelist to handle singleton variables
+        source_edgelist = bqm.quadratic.keys() + [(v, v) for v in bqm.linear]
+
         # get the embedding
-        embedding = minorminer.find_embedding(bqm.to_qubo()[0], target_edgelist)
+        embedding = minorminer.find_embedding(source_edgelist, target_edgelist)
 
         if bqm and not embedding:
             raise ValueError("no embedding found")

--- a/dwave/system/composites/embedding.py
+++ b/dwave/system/composites/embedding.py
@@ -177,7 +177,7 @@ class EmbeddingComposite(dimod.Sampler, dimod.Composite):
         __, target_edgelist, target_adjacency = child.structure
 
         # get the embedding
-        embedding = minorminer.find_embedding(bqm.quadratic, target_edgelist)
+        embedding = minorminer.find_embedding(bqm.to_qubo()[0], target_edgelist)
 
         if bqm and not embedding:
             raise ValueError("no embedding found")

--- a/tests/test_embedding_composite.py
+++ b/tests/test_embedding_composite.py
@@ -107,3 +107,14 @@ class TestEmbeddingComposite(unittest.TestCase):
         h = {v: 0 for v in set().union(*J)}
 
         response = sampler.sample_ising(h, J)
+
+    def test_singleton_variables(self):
+        sampler = EmbeddingComposite(MockSampler())
+
+        h = {0: -1., 4: 2}
+        J = {}
+
+        response = sampler.sample_ising(h, J)
+
+        # nothing failed and we got at least one response back
+        self.assertGreaterEqual(len(response), 1)


### PR DESCRIPTION
`dimod.embed_bqm()` should be reverted to not handle this edge case, since it is now handled here and `dimod.unembed_response()` does not handle it.