### PR TITLE
Fixing bugs in VirtualGraph 

### DIFF
--- a/dwave/system/composites/virtual_graph.py
+++ b/dwave/system/composites/virtual_graph.py
@@ -282,7 +282,7 @@ class VirtualGraphComposite(dimod.ComposedSampler, dimod.Structured):
         if flux_biases is None and FLUX_BIAS_KWARG in sampler.parameters:
             # If nothing is provided, then we either get them from the cache or generate them
             flux_biases = get_flux_biases(sampler, embedding, num_reads=flux_bias_num_reads,
-                                          max_age=flux_bias_max_age)
+                                          chain_strength=self.chain_strength, max_age=flux_bias_max_age)
         elif flux_biases:
             if FLUX_BIAS_KWARG not in sampler.accepted_kwargs:
                 raise ValueError("Given child sampler does not accept flux_biases.")

--- a/dwave/system/composites/virtual_graph.py
+++ b/dwave/system/composites/virtual_graph.py
@@ -363,7 +363,7 @@ class VirtualGraphComposite(dimod.ComposedSampler, dimod.Structured):
 
         if apply_flux_bias_offsets and self.flux_biases is not None:
             # If self.flux_biases is in the old format (list of lists) convert it to the new format (flat list).
-            if isinstance(self.flux_biases[0], list):
+            if len(self.flux_biases) == 0 or isinstance(self.flux_biases[0], list):
                 flux_bias_dict = dict(self.flux_biases)
                 kwargs[FLUX_BIAS_KWARG] = [flux_bias_dict.get(v, 0.) for v in range(child.properties['num_qubits'])]
             else:

--- a/dwave/system/flux_bias_offsets/flux_bias_offsets.py
+++ b/dwave/system/flux_bias_offsets/flux_bias_offsets.py
@@ -16,6 +16,8 @@ def get_flux_biases(sampler, embedding, num_reads, chain_strength=1, max_age=360
         try:
             import dwave.system.tuning as dst
         except ImportError:
+            import warnings
+            warnings.warn("Package dwave-system-tuning not found.  Flux biases will not be used.")
             return []
 
         fbo = dst.oneshot_flux_bias(sampler, embedding.values(),


### PR DESCRIPTION
This fixes two bugs in VirtualGraph:

* `chain_strength` was not being passed properly to `get_flux_biases`.  This means that the flux biases always assumed the default chain strength of 1, which will give incorrect flux biases for other chain strengths.

* If `dwave-system-tuning` is not installed, the import failed silently.  Now there is a warning.  Additionally, failure gives `flux_biases = []`, which later caused an error.  This is now fixed.
