### PR TITLE
Use latest and greatest `dwave-cloud-client`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 --extra-index-url https://pypi.dwavesys.com/simple
 
 dimod==0.6.7
-dwave-cloud-client==0.4.0
+dwave-cloud-client==0.4.2
 dwave-networkx==0.6.0
 dwave-system-tuning==0.1.1
 homebase==1.0.0

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ else:
     exec(open(os.path.join(".", "dwave", "system", "package_info", "package_info.py")).read())
 
 install_requires = ['dimod>=0.6.7,<0.7.0',
-                    'dwave_cloud_client>=0.4.0,<0.5.0',
+                    'dwave-cloud-client>=0.4.0,<0.5.0',
                     'dwave-networkx>=0.6.0,<0.7.0',
                     'homebase>=1.0.0,<2.0.0',
                     'minorminer>=0.1.3,<0.2.0',


### PR DESCRIPTION
Patch version number increase doesn't indicate this, but `0.4.2` adds some significant improvements!