### PR TITLE
Use intersphinx instead of explicit links

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,3 +1,3 @@
 D-Wave welcomes contributions to Ocean projects.
 
-See how to contribute at `Ocean Contributors <http://dw-docs.readthedocs.io/en/latest/CONTRIBUTING.html>`_.
+See how to contribute at :std:doc:`Ocean Contributors <oceandocs:CONTRIBUTING>`.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+  Apache License
+  Version 2.0, January 2004
+  http://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -194,4 +194,14 @@ epub_exclude_files = ['search.html']
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {'python': ('https://docs.python.org/3', None),
-                       'dimod': ('http://dimod.readthedocs.io/en/latest/', None)}
+    'dimod': ('https://docs.ocean.dwavesys.com/projects/dimod/en/latest/', None),
+    'binarycsp': ('https://docs.ocean.dwavesys.com/projects/binarycsp/en/latest/', None),
+    'cloud-client': ('https://docs.ocean.dwavesys.com/projects/cloud-client/en/latest/', None),
+    'neal': ('https://docs.ocean.dwavesys.com/projects/neal/en/latest/', None),
+    'networkx': ('https://docs.ocean.dwavesys.com/projects/dwave-networkx/en/latest/', None),
+    'system': ('https://docs.ocean.dwavesys.com/projects/system/en/latest/', None),
+    'penaltymodel': ('https://docs.ocean.dwavesys.com/projects/penaltymodel/en/latest/', None),
+    'minorminer': ('https://docs.ocean.dwavesys.com/projects/minorminer/en/latest/', None),
+    'qbsolv': ('https://docs.ocean.dwavesys.com/projects/qbsolv/en/latest/', None),
+    'oceandocs': ('https://docs.ocean.dwavesys.com/en/latest/', None),
+    'sysdocs_gettingstarted': ('https://docs.dwavesys.com/docs/latest/', None)}

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -3,4 +3,4 @@ Glossary
 
 The field of quantum computing has many domain-specific terms.
 
-Learn the relevant terminology at `Ocean Glossary <http://dw-docs.readthedocs.io/en/latest/glossary.html>`_.
+Learn the relevant terminology at :std:doc:`Ocean Glossary <oceandocs:glossary>`.

--- a/docs/ocean.rst
+++ b/docs/ocean.rst
@@ -1,9 +1,9 @@
 Ocean Overview
 ==============
 
-`D-Wave Ocean <http://dw-docs.readthedocs.io/en/latest/index.html>`_ includes
-various projects/repositories on GitHub that help solve problems on the D-Wave 
+:std:doc:`D-Wave Ocean <oceandocs:index>` includes
+various projects/repositories on GitHub that help solve problems on the D-Wave
 system.
 
-Learn about D-Wave's Ocean and how its projects work together at `D-Wave Ocean on Read the Docs
-<http://dw-docs.readthedocs.io/en/latest/index.html>`_.
+Learn about D-Wave's Ocean and how its projects work together at
+:std:doc:`D-Wave Ocean on Read the Docs <oceandocs:index>`.

--- a/docs/reference/composites/index.rst
+++ b/docs/reference/composites/index.rst
@@ -5,8 +5,10 @@ Composites
 ==========
 
 `dwave-system` provides
-`dimod composites <http://dimod.readthedocs.io/en/latest/reference/samplers.html#samplers-and-composites>`_
-for using the D-Wave system.
+:std:doc:`dimod composites <dimod:reference/samplers>` for using the D-Wave system.
+
+
+
 
    :Release: |release|
    :Date: |today|

--- a/docs/reference/composites/tiling.rst
+++ b/docs/reference/composites/tiling.rst
@@ -49,3 +49,11 @@ Methods
    TilingComposite.sample
    TilingComposite.sample_ising
    TilingComposite.sample_qubo
+
+Related Functions
+=================
+
+.. autosummary::
+   :toctree: generated/
+
+   tiling.draw_tiling

--- a/docs/reference/intro.rst
+++ b/docs/reference/intro.rst
@@ -28,7 +28,7 @@ to change the underlying sampler implementation.
 We refer to these layers as `composites`. A composed sampler includes at least one sampler
 and possibly many composites.
 
-.. _chimera:
+.. _chimeraTopology:
 
 D-Wave System Architecture: Chimera
 ===================================

--- a/docs/reference/intro.rst
+++ b/docs/reference/intro.rst
@@ -13,8 +13,8 @@ Samplers
 A binary quadratic model (BQM) sampler samples from low energy states in models such as those
 defined by an Ising equation or a Quadratic Unconstrained Binary Optimization (QUBO) problem
 and returns an iterable of samples, in order of increasing energy. A
-`dimod sampler <http://dimod.readthedocs.io/en/latest/reference/samplers.html#samplers-and-composites>`_
-provides ‘sample_qubo’ and ‘sample_ising’ methods as well as the generic BQM sampler method.
+:std:doc:`dimod sampler <dimod:reference/samplers>` provides ‘sample_qubo’ and
+‘sample_ising’ methods as well as the generic BQM sampler method.
 
 .. _composites:
 

--- a/dwave/system/composites/embedding.py
+++ b/dwave/system/composites/embedding.py
@@ -1,17 +1,16 @@
 # coding: utf-8
 """
-A dimod composite_ that maps unstructured problems to a structured_ sampler.
+A :std:doc:`dimod composite <dimod:reference/samplers>` that maps unstructured problems
+to a structured sampler.
 
-A structured_ sampler can only solve problems that map to a specific graph: the
-D-Wave system's architecture is represented by a Chimera_ graph.
+A structured sampler can only solve problems that map to a specific graph: the
+D-Wave system's architecture is represented by a :std:doc:`Chimera <system:reference/intro>` graph.
 
-The :class:`.EmbeddingComposite` uses the minorminer_ library to map unstructured
-problems to a structured sampler such as a D-Wave system.
+The :class:`.EmbeddingComposite` uses the :std:doc:`minorminer <minorminer:index>` library
+to map unstructured problems to a structured sampler such as a D-Wave system.
 
-.. _composite: http://dimod.readthedocs.io/en/latest/reference/samplers.html
-.. _minorminer: https://github.com/dwavesystems/minorminer
-.. _structured: http://dimod.readthedocs.io/en/latest/reference/samplers.html#module-dimod.core.structured
-.. _Chimera: http://dwave-system.readthedocs.io/en/latest/reference/intro.html#chimera
+See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/latest/glossary.html>`_ for explanations
+of technical terms in descriptions of Ocean tools.
 
 """
 import dimod
@@ -36,7 +35,8 @@ class EmbeddingComposite(dimod.ComposedSampler):
     Examples:
        This example uses :class:`.EmbeddingComposite` to instantiate a composed sampler
        that submits a simple Ising problem to a D-Wave solver selected by the user's
-       default D-Wave Cloud Client configuration_ file. The composed sampler handles
+       default :std:doc:`D-Wave Cloud Client configuration file <cloud-client:reference/intro>`.
+       The composed sampler handles
        minor-embedding of the problem's two generic variables, a and b, to physical
        qubits on the solver.
 
@@ -51,7 +51,8 @@ class EmbeddingComposite(dimod.ComposedSampler):
        ...
        {'a': 1, 'b': -1}
 
-    .. _configuration: http://dwave-cloud-client.readthedocs.io/en/latest/#module-dwave.cloud.config
+    See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/latest/glossary.html>`_ for explanations
+    of technical terms in descriptions of Ocean tools.
 
     """
     def __init__(self, child_sampler):
@@ -67,8 +68,9 @@ class EmbeddingComposite(dimod.ComposedSampler):
 
         Examples:
             This example instantiates a composed sampler using a D-Wave solver selected by
-            the user's default D-Wave Cloud Client configuration_ file and views the
-            solver's parameters.
+            the user's default
+            :std:doc:`D-Wave Cloud Client configuration file <cloud-client:reference/intro>`
+            and views the solver's parameters.
 
             >>> from dwave.system.samplers import DWaveSampler
             >>> from dwave.system.composites import EmbeddingComposite
@@ -76,7 +78,7 @@ class EmbeddingComposite(dimod.ComposedSampler):
             >>> sampler.children   # doctest: +SKIP
             [<dwave.system.samplers.dwave_sampler.DWaveSampler at 0x7f45b20a8d50>]
 
-        .. _configuration: http://dwave-cloud-client.readthedocs.io/en/latest/#module-dwave.cloud.config
+        See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/latest/glossary.html>`_ for explanations of technical terms in descriptions of Ocean tools.
 
         """
         return self._children
@@ -89,8 +91,9 @@ class EmbeddingComposite(dimod.ComposedSampler):
 
         Examples:
             This example instantiates a composed sampler using a D-Wave solver selected by
-            the user's default D-Wave Cloud Client configuration_ file and views the
-            solver's parameters.
+            the user's default
+            :std:doc:`D-Wave Cloud Client configuration file <cloud-client:reference/intro>`
+            and views the solver's parameters.
 
             >>> from dwave.system.samplers import DWaveSampler
             >>> from dwave.system.composites import EmbeddingComposite
@@ -103,7 +106,7 @@ class EmbeddingComposite(dimod.ComposedSampler):
              'auto_scale': ['parameters'],
             >>> # Snipped above response for brevity
 
-        .. _configuration: http://dwave-cloud-client.readthedocs.io/en/latest/#module-dwave.cloud.config
+        See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/latest/glossary.html>`_ for explanations of technical terms in descriptions of Ocean tools.
 
         """
         # does not add or remove any parameters
@@ -120,8 +123,9 @@ class EmbeddingComposite(dimod.ComposedSampler):
 
         Examples:
             This example instantiates a composed sampler using a D-Wave solver selected by
-            the user's default D-Wave Cloud Client configuration_ file and views the
-            solver's properties.
+            the user's default
+            :std:doc:`D-Wave Cloud Client configuration file <cloud-client:reference/intro>`
+            and views the solver's properties.
 
             >>> from dwave.system.samplers import DWaveSampler
             >>> from dwave.system.composites import EmbeddingComposite
@@ -133,7 +137,7 @@ class EmbeddingComposite(dimod.ComposedSampler):
                [-0.20860153999435985, 0.05511969218508182],
             >>> # Snipped above response for brevity
 
-        .. _configuration: http://dwave-cloud-client.readthedocs.io/en/latest/#module-dwave.cloud.config
+        See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/latest/glossary.html>`_ for explanations of technical terms in descriptions of Ocean tools.
 
         """
         return {'child_properties': self.child.properties.copy()}
@@ -158,8 +162,9 @@ class EmbeddingComposite(dimod.ComposedSampler):
         Examples:
             This example uses :class:`.EmbeddingComposite` to instantiate a composed sampler
             that submits an unstructured Ising problem to a D-Wave solver, selected by the user's
-            default D-Wave Cloud Client configuration_ file, while minor-embedding the problem's
-            variables to physical qubits on the solver.
+            default
+            :std:doc:`D-Wave Cloud Client configuration file <cloud-client:reference/intro>`,
+            while minor-embedding the problem's variables to physical qubits on the solver.
 
             >>> from dwave.system.samplers import DWaveSampler
             >>> from dwave.system.composites import EmbeddingComposite

--- a/dwave/system/composites/embedding.py
+++ b/dwave/system/composites/embedding.py
@@ -181,6 +181,8 @@ class EmbeddingComposite(dimod.ComposedSampler):
             ...
             {1: -1, 2: 1, 3: 1, 4: -1}
 
+        See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/latest/glossary.html>`_
+        for explanations of technical terms in descriptions of Ocean tools.
         """
 
         # solve the problem on the child system
@@ -316,14 +318,18 @@ class FixedEmbeddingComposite(dimod.ComposedSampler, dimod.Structured):
         Examples:
             This example uses :class:`.FixedEmbeddingComposite` to instantiate a composed sampler
             that submits an unstructured Ising problem to a D-Wave solver, selected by the user's
-            default D-Wave Cloud Client configuration_ file, while minor-embedding the problem's
-            variables to physical qubits on the solver.
+            default
+            :std:doc:`D-Wave Cloud Client configuration file <cloud-client:reference/intro>`,
+            while minor-embedding the problem's variables to physical qubits on the solver.
 
             >>> from dwave.system.samplers import DWaveSampler
             >>> from dwave.system.composites import FixedEmbeddingComposite
             >>> import dimod
             >>> sampler = FixedEmbeddingComposite(DWaveSampler(), {'a': [0, 4], 'b': [1, 5], 'c': [2, 6]})
             >>> resp = sampler.sample_ising({'a': .5, 'c': 0}, {('a', 'c'): -1})
+
+        See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/latest/glossary.html>`_
+        for explanations of technical terms in descriptions of Ocean tools.
 
         """
 

--- a/dwave/system/composites/tiling.py
+++ b/dwave/system/composites/tiling.py
@@ -1,13 +1,15 @@
 """
-A dimod composite_ that tiles small problems multiple times to a Chimera-structured sampler.
+A :std:doc:`dimod composite <dimod:reference/samplers>` that tiles small problems
+multiple times to a Chimera-structured sampler.
 
-The :class:`.TilingComposite` takes a problem that can fit on a small Chimera_ graph
-and replicates it across a larger Chimera graph to obtain samples from multiple areas
-of the solver in one call. For example, a 2x2 Chimera lattice could be tiled 64 times
-(8x8) on a fully-yielded D-Wave 2000Q system (16x16).
+The :class:`.TilingComposite` takes a problem that can fit on a small
+:std:doc:`Chimera <system:reference/intro>` graph and replicates it across a larger
+Chimera graph to obtain samples from multiple areas of the solver in one call.
+For example, a 2x2 Chimera lattice could be tiled 64 times (8x8) on a fully-yielded
+D-Wave 2000Q system (16x16).
 
-.. _composite: http://dimod.readthedocs.io/en/latest/reference/samplers.html
-.. _Chimera: http://dwave-system.readthedocs.io/en/latest/reference/intro.html#chimera
+See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/latest/glossary.html>`_ for explanations
+of technical terms in descriptions of Ocean tools.
 
 """
 from __future__ import division
@@ -18,7 +20,7 @@ import dwave_networkx as dnx
 
 import numpy as np
 
-__all__ = ['TilingComposite']
+__all__ = ['TilingComposite', 'draw_tiling']
 
 
 class TilingComposite(dimod.Sampler, dimod.Composite, dimod.Structured):
@@ -27,7 +29,7 @@ class TilingComposite(dimod.Sampler, dimod.Composite, dimod.Structured):
     Inherits from :class:`dimod.Sampler`, :class:`dimod.Composite`, and :class:`dimod.Structured`.
 
     Enables parallel sampling for small problems (problems that are minor-embeddable in
-    a small part of a D-Wave solver's Chimera_ graph).
+    a small part of a D-Wave solver's :std:doc:`Chimera <system:reference/intro>` graph).
 
     The notation *CN* refers to a Chimera graph consisting of an NxN grid of unit cells.
     Each Chimera unit cell is itself a bipartite graph with shores of size t. The D-Wave 2000Q QPU
@@ -37,8 +39,6 @@ class TilingComposite(dimod.Sampler, dimod.Composite, dimod.Structured):
     A problem that can be minor-embedded in a single unit cell, for example, can therefore
     be tiled across the unit cells of a D-Wave 2000Q as 16x16 duplicates. This enables
     sampling 256 solutions in a single call.
-
-    .. _Chimera: http://dwave-system.readthedocs.io/en/latest/reference/intro.html#chimera
 
     Args:
        sampler (:class:`dimod.Sampler`): Structured dimod sampler to be wrapped.
@@ -50,7 +50,8 @@ class TilingComposite(dimod.Sampler, dimod.Composite, dimod.Structured):
        This example instantiates a composed sampler using composite :class:`.TilingComposite`
        to tile a QUBO problem on a D-Wave solver, embedding it with composite
        :class:`.EmbeddingComposite` and selecting the D-Wave solver with the user's
-       default D-Wave Cloud Client configuration_ file. The two-variable QUBO represents a
+       default :std:doc:`D-Wave Cloud Client configuration file <cloud-client:reference/intro>`.
+       The two-variable QUBO represents a
        logical NOT gate (two nodes with biases of -1 that are coupled with strength 2) and is
        easily minor-embedded in a single Chimera cell (it needs only any two coupled qubits) and
        so can be tiled multiple times across a D-Wave solver for parallel solution (the two
@@ -76,7 +77,8 @@ class TilingComposite(dimod.Sampler, dimod.Composite, dimod.Structured):
        {1: 1, 2: 0}
        >>> # Snipped above response for brevity
 
-    .. _configuration: http://dwave-cloud-client.readthedocs.io/en/latest/#module-dwave.cloud.config
+    See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/latest/glossary.html>`_
+    for explanations of technical terms in descriptions of Ocean tools.
 
     """
     nodelist = None
@@ -86,7 +88,8 @@ class TilingComposite(dimod.Sampler, dimod.Composite, dimod.Structured):
        This example creates a :class:`.TilingComposite` for a problem that requires
        a 2x1 Chimera lattice to solve with a :class:`DWaveSampler` as the sampler.
        It prints the active qubits retrieved from a D-Wave solver selected by
-       the user's default D-Wave Cloud Client configuration_ file.
+       the user's default
+       :std:doc:`D-Wave Cloud Client configuration file <cloud-client:reference/intro>`.
 
        >>> from dwave.system.samplers import DWaveSampler
        >>> from dwave.system.composites import TilingComposite
@@ -94,7 +97,8 @@ class TilingComposite(dimod.Sampler, dimod.Composite, dimod.Structured):
        >>> sampler_tile.nodelist   # doctest: +SKIP
        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
 
-    .. _configuration: http://dwave-cloud-client.readthedocs.io/en/latest/#module-dwave.cloud.config
+    See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/latest/glossary.html>`_
+    for explanations of technical terms in descriptions of Ocean tools.
 
     """
 
@@ -105,7 +109,8 @@ class TilingComposite(dimod.Sampler, dimod.Composite, dimod.Structured):
        This example creates a :class:`.TilingComposite` for a problem that requires
        a 1x2 Chimera lattice to solve with a :class:`DWaveSampler` as the sampler.
        It prints the active couplers retrieved from a D-Wave solver selected by
-       the user's default D-Wave Cloud Client configuration_ file.
+       the user's default
+       :std:doc:`D-Wave Cloud Client configuration file <cloud-client:reference/intro>`.
 
        >>> from dwave.system.samplers import DWaveSampler
        >>> from dwave.system.composites import TilingComposite
@@ -148,7 +153,8 @@ class TilingComposite(dimod.Sampler, dimod.Composite, dimod.Structured):
        [11, 14],
        [11, 15]]
 
-    .. _configuration: http://dwave-cloud-client.readthedocs.io/en/latest/#module-dwave.cloud.config
+    See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/latest/glossary.html>`_
+    for explanations of technical terms in descriptions of Ocean tools.
 
     """
 
@@ -160,8 +166,9 @@ class TilingComposite(dimod.Sampler, dimod.Composite, dimod.Structured):
 
     Examples:
        This example instantiates a :class:`.TilingComposite` sampler using a D-Wave solver
-       selected by the user's default D-Wave Cloud Client configuration_ file and views the
-       solver's parameters.
+       selected by the user's default
+       :std:doc:`D-Wave Cloud Client configuration file <cloud-client:reference/intro>`
+       and views the solver's parameters.
 
        >>> from dwave.system.samplers import DWaveSampler
        >>> from dwave.system.composites import TilingComposite
@@ -174,7 +181,8 @@ class TilingComposite(dimod.Sampler, dimod.Composite, dimod.Structured):
         u'auto_scale': ['parameters'],
        >>> # Snipped above response for brevity
 
-    .. _configuration: http://dwave-cloud-client.readthedocs.io/en/latest/#module-dwave.cloud.config
+    See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/latest/glossary.html>`_
+    for explanations of technical terms in descriptions of Ocean tools.
 
        """
 
@@ -186,8 +194,9 @@ class TilingComposite(dimod.Sampler, dimod.Composite, dimod.Structured):
 
     Examples:
        This example instantiates a :class:`.TilingComposite` sampler using a D-Wave solver
-       selected by the user's default D-Wave Cloud Client configuration_ file and views the
-       solver's properties.
+       selected by the user's default
+       :std:doc:`D-Wave Cloud Client configuration file <cloud-client:reference/intro>`
+       and views the solver's properties.
 
        >>> from dwave.system.samplers import DWaveSampler
        >>> from dwave.system.composites import TilingComposite
@@ -202,7 +211,8 @@ class TilingComposite(dimod.Sampler, dimod.Composite, dimod.Structured):
           [-0.21700680373359477, 0.005297355417068621],
        >>> # Snipped above response for brevity
 
-    .. _configuration: http://dwave-cloud-client.readthedocs.io/en/latest/#module-dwave.cloud.config
+    See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/latest/glossary.html>`_
+    for explanations of technical terms in descriptions of Ocean tools.
 
        """
 
@@ -301,9 +311,11 @@ class TilingComposite(dimod.Sampler, dimod.Composite, dimod.Structured):
         Examples:
             This example uses :class:`.TilingComposite` to instantiate a composed sampler
             that submits a simple Ising problem of just two variables that map to qubits 0 and 1
-            on the D-Wave solver selected by the user's default D-Wave Cloud Client
-            configuration_ file. (The simplicity of this example obviates the need for an embedding
-            composite.) Because the problem fits in a single Chimera_ unit cell, it is tiled
+            on the D-Wave solver selected by the user's default
+            :std:doc:`D-Wave Cloud Client configuration file <cloud-client:reference/intro>`.
+            (The simplicity of this example obviates the need for an embedding
+            composite.) Because the problem fits in a single
+            :std:doc:`Chimera <system:reference/intro>` unit cell, it is tiled
             across the solver's entire Chimera graph, resulting in multiple samples.
 
             >>> from dwave.system.samplers import DWaveSampler
@@ -323,8 +335,8 @@ class TilingComposite(dimod.Sampler, dimod.Composite, dimod.Structured):
             {0: 1, 1: -1}
             >>> # Snipped above response for brevity
 
-        .. _configuration: http://dwave-cloud-client.readthedocs.io/en/latest/#module-dwave.cloud.config
-        .. _Chimera: http://dwave-system.readthedocs.io/en/latest/reference/intro.html#chimera
+        See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/latest/glossary.html>`_
+        for explanations of technical terms in descriptions of Ocean tools.
 
         """
 
@@ -369,13 +381,17 @@ def draw_tiling(sampler, t=4):
     """Draw Chimera graph of sampler with colored tiles.
 
     Args:
-        sampler (:class:`dwave_micro_client_dimod.TilingComposite`): A tiled dimod sampler to be drawn.
-        t (int): The size of the shore within each Chimera cell.
+        sampler (:class:`dwave_micro_client_dimod.TilingComposite`): A tiled dimod
+            sampler to be drawn.
+        t (int): The size of the shore within each
+            :std:doc:`Chimera <system:reference/intro>` cell.
 
-    Uses `dwave_networkx.draw_chimera` (see draw_chimera_).
+    Uses :std:doc:`dwave_networkx.draw_chimera <networkx:index>`.
+
     Linear biases are overloaded to color the graph according to which tile each Chimera cell belongs to.
 
-    .. _draw_chimera: http://dwave-networkx.readthedocs.io/en/latest/reference/generated/dwave_networkx.drawing.chimera_layout.draw_chimera.html
+    See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/latest/glossary.html>`_
+    for explanations of technical terms in descriptions of Ocean tools.
 
     """
 

--- a/dwave/system/composites/virtual_graph.py
+++ b/dwave/system/composites/virtual_graph.py
@@ -1,5 +1,6 @@
 """
-A dimod composite_ that uses the D-Wave virtual graph feature for improved minor-embedding_.
+A :std:doc:`dimod composite <dimod:reference/samplers>` that uses the D-Wave virtual
+graph feature for improved :std:doc:`minor-embedding <system:reference/intro>`.
 
 D-Wave *virtual graphs* simplify the process of minor-embedding by enabling you to more
 easily create, optimize, use, and reuse an embedding for a given working graph. When you submit an
@@ -7,8 +8,8 @@ embedding and specify a chain strength using these tools, they automatically cal
 in a chain to compensate for the effects of biases that may be introduced as a result of strong
 couplings.
 
-.. _composite: http://dimod.readthedocs.io/en/latest/reference/samplers.html
-.. _minor-embedding: http://dwave-system.readthedocs.io/en/latest/reference/intro.html#minorEmbedding
+See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/latest/glossary.html>`_
+for explanations of technical terms in descriptions of Ocean tools.
 """
 
 from six import iteritems
@@ -64,11 +65,13 @@ class VirtualGraphComposite(dimod.ComposedSampler, dimod.Structured):
     Examples:
        This example uses :class:`.VirtualGraphComposite` to instantiate a composed sampler
        that submits a QUBO problem to a D-Wave solver selected by the user's
-       default D-Wave Cloud Client configuration_ file. The problem represents a logical
+       default :std:doc:`D-Wave Cloud Client configuration file <cloud-client:reference/intro>`.
+       The problem represents a logical
        AND gate using penalty function :math:`P = xy - 2(x+y)z +3z`, where variables x and y
        are the gate's inputs and z the output. This simple three-variable problem is manually
-       minor-embedded to a single Chimera_ unit cell: variables x and y are represented by
-       qubits 1 and 5, respectively, and z by a two-qubit chain consisting of qubits 0 and 4.
+       minor-embedded to a single :std:doc:`Chimera <system:reference/intro>` unit cell:
+       variables x and y are represented by qubits 1 and 5, respectively, and z by a
+       two-qubit chain consisting of qubits 0 and 4.
        The chain strength is set to the maximum allowed found from querying the solver's extended
        J range. In this example, the ten returned samples all represent valid states of
        the AND gate.
@@ -95,8 +98,8 @@ class VirtualGraphComposite(dimod.ComposedSampler, dimod.Structured):
        {'y': 0, 'x': 0, 'z': 0}
        {'y': 1, 'x': 0, 'z': 0}
 
-    .. _configuration: http://dwave-cloud-client.readthedocs.io/en/latest/#module-dwave.cloud.config
-    .. _Chimera: http://dwave-system.readthedocs.io/en/latest/reference/intro.html#chimera
+    See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/latest/glossary.html>`_
+    for explanations of technical terms in descriptions of Ocean tools.
 
     """
 
@@ -143,7 +146,8 @@ class VirtualGraphComposite(dimod.ComposedSampler, dimod.Structured):
 
     Examples:
        This example uses :class:`.VirtualGraphComposite` to instantiate a composed sampler
-       that uses a D-Wave solver selected by the user's default D-Wave Cloud Client configuration_ file.
+       that uses a D-Wave solver selected by the user's default
+       :std:doc:`D-Wave Cloud Client configuration file <cloud-client:reference/intro>`.
        Because qubits 0, 1, 4, 5 are active on the selected D-Wave solver, the three nodes, x, y, and z,
        specified by the embedding, are all available to problems using this composed sampler.
 
@@ -154,7 +158,8 @@ class VirtualGraphComposite(dimod.ComposedSampler, dimod.Structured):
        >>> sampler.nodelist  # doctest: +SKIP
        ['x', 'y', 'z']
 
-    .. _configuration: http://dwave-cloud-client.readthedocs.io/en/latest/#module-dwave.cloud.config
+    See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/latest/glossary.html>`_
+    for explanations of technical terms in descriptions of Ocean tools.
 
     """
 
@@ -164,7 +169,8 @@ class VirtualGraphComposite(dimod.ComposedSampler, dimod.Structured):
 
     Examples:
        This example uses :class:`.VirtualGraphComposite` to instantiate a composed sampler
-       that uses a D-Wave solver selected by the user's default D-Wave Cloud Client configuration_ file.
+       that uses a D-Wave solver selected by the user's default
+       :std:doc:`D-Wave Cloud Client configuration file <cloud-client:reference/intro>`.
        Because qubits 0, 5, and coupled qubits {0, 4} are all coupled on the selected D-Wave solver, edges
        between three nodes, x, y, and z, as specified by the embedding, are available to problems using this
        composed sampler. However, qubit 8 is in an adjacent unit cell on the D-Wave solver and not directly
@@ -177,7 +183,8 @@ class VirtualGraphComposite(dimod.ComposedSampler, dimod.Structured):
        >>> sampler.edgelist  # doctest: +SKIP
        [('x', 'y'), ('x', 'z'), ('y', 'z')]
 
-    .. _configuration: http://dwave-cloud-client.readthedocs.io/en/latest/#module-dwave.cloud.config
+    See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/latest/glossary.html>`_
+    for explanations of technical terms in descriptions of Ocean tools.
 
     """
 
@@ -187,7 +194,8 @@ class VirtualGraphComposite(dimod.ComposedSampler, dimod.Structured):
 
     Examples:
        This example uses :class:`.VirtualGraphComposite` to instantiate a composed sampler
-       that uses a D-Wave solver selected by the user's default D-Wave Cloud Client configuration_ file.
+       that uses a D-Wave solver selected by the user's default
+       :std:doc:`D-Wave Cloud Client configuration file <cloud-client:reference/intro>`.
        Because qubits 0, 5, and coupled qubits {0, 4} are all coupled on the selected D-Wave solver, edges
        between three nodes, x, y, and z, as specified by the embedding, are available to problems using this
        composed sampler. However, qubit 8 is in an adjacent unit cell on the D-Wave solver and not directly
@@ -200,7 +208,8 @@ class VirtualGraphComposite(dimod.ComposedSampler, dimod.Structured):
        >>> sampler.adjacency  # doctest: +SKIP
        {'a': set(), 'x': {'y', 'z'}, 'y': {'x', 'z'}, 'z': {'x', 'y'}}
 
-    .. _configuration: http://dwave-cloud-client.readthedocs.io/en/latest/#module-dwave.cloud.config
+    See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/latest/glossary.html>`_
+    for explanations of technical terms in descriptions of Ocean tools.
 
     """
 
@@ -215,7 +224,8 @@ class VirtualGraphComposite(dimod.ComposedSampler, dimod.Structured):
 
     Examples:
        This example uses :class:`.VirtualGraphComposite` to instantiate a composed sampler
-       that uses a D-Wave solver selected by the user's default D-Wave Cloud Client configuration_ file
+       that uses a D-Wave solver selected by the user's default
+       :std:doc:`D-Wave Cloud Client configuration file <cloud-client:reference/intro>`
        and views the composed sampler's parameters.
 
        >>> from dwave.system.samplers import DWaveSampler
@@ -231,7 +241,8 @@ class VirtualGraphComposite(dimod.ComposedSampler, dimod.Structured):
         u'auto_scale': ['parameters'],
        >>>  # Snipped above response for brevity
 
-    .. _configuration: http://dwave-cloud-client.readthedocs.io/en/latest/#module-dwave.cloud.config
+    See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/latest/glossary.html>`_
+    for explanations of technical terms in descriptions of Ocean tools.
 
     """
 
@@ -243,7 +254,8 @@ class VirtualGraphComposite(dimod.ComposedSampler, dimod.Structured):
 
     Examples:
        This example uses :class:`.VirtualGraphComposite` to instantiate a composed sampler
-       that uses a D-Wave solver selected by the user's default D-Wave Cloud Client configuration_ file
+       that uses a D-Wave solver selected by the user's default
+       :std:doc:`D-Wave Cloud Client configuration file <cloud-client:reference/intro>`
        and views the composed sampler's properties.
 
        >>> from dwave.system.samplers import DWaveSampler
@@ -258,7 +270,8 @@ class VirtualGraphComposite(dimod.ComposedSampler, dimod.Structured):
           [-0.2108920134230625, 0.056392603743884134],
        >>>  # Snipped above response for brevity
 
-    .. _configuration: http://dwave-cloud-client.readthedocs.io/en/latest/#module-dwave.cloud.config
+    See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/latest/glossary.html>`_
+    for explanations of technical terms in descriptions of Ocean tools.
 
     """
 
@@ -284,11 +297,14 @@ class VirtualGraphComposite(dimod.ComposedSampler, dimod.Structured):
         Examples:
            This example uses :class:`.VirtualGraphComposite` to instantiate a composed sampler
            that submits an Ising problem to a D-Wave solver selected by the user's
-           default D-Wave Cloud Client configuration_ file. The problem represents a logical
+           default
+           :std:doc:`D-Wave Cloud Client configuration file <cloud-client:reference/intro>`.
+           The problem represents a logical
            NOT gate using penalty function :math:`P = xy`, where variable x is the gate's input
-           and y the output. This simple two-variable problem is manually
-           minor-embedded to a single Chimera_ unit cell: each variable is represented by a
-           chain of half the cell's qubits, x as qubits 0, 1, 4, 5, and y as qubits 2, 3, 6, 7.
+           and y the output. This simple two-variable problem is manually minor-embedded
+           to a single :std:doc:`Chimera <system:reference/intro>` unit cell: each variable
+           is represented by a chain of half the cell's qubits, x as qubits 0, 1, 4, 5,
+           and y as qubits 2, 3, 6, 7.
            The chain strength is set to half the maximum allowed found from querying the solver's extended
            J range. In this example, the ten returned samples all represent valid states of
            the NOT gate.
@@ -316,8 +332,8 @@ class VirtualGraphComposite(dimod.ComposedSampler, dimod.Structured):
            {'y': -1, 'x': 1}
            {'y': 1, 'x': -1}
 
-        .. _configuration: http://dwave-cloud-client.readthedocs.io/en/latest/#module-dwave.cloud.config
-        .. _Chimera: http://dwave-system.readthedocs.io/en/latest/reference/intro.html#chimera
+        See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/latest/glossary.html>`_
+        for explanations of technical terms in descriptions of Ocean tools.
 
         """
         child = self.child

--- a/dwave/system/samplers/dwave_sampler.py
+++ b/dwave/system/samplers/dwave_sampler.py
@@ -24,33 +24,37 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
 
     Args:
         config_file (str, optional):
-            Path to a D-Wave Cloud Client configuration_ file that identifies a
-            D-Wave system and provides connection information.
+            Path to a
+            :std:doc:`D-Wave Cloud Client configuration file <cloud-client:reference/intro>`
+            that identifies a D-Wave system and provides connection information.
 
         profile (str, optional):
-            Profile to select from a D-Wave Cloud Client configuration_ file.
+            Profile to select from a
+            :std:doc:`D-Wave Cloud Client configuration file <cloud-client:reference/intro>`.
 
         endpoint (str, optional):
             D-Wave API endpoint URL. If specified, used instead of retrieving a value from
-            a D-Wave Cloud Client configuration_ file.
+            a :std:doc:`D-Wave Cloud Client configuration file <cloud-client:reference/intro>`.
 
         token (str, optional):
             Authentication token for the D-Wave API to authenticate the client session.
-            If specified, used instead of retrieving a value from a D-Wave Cloud Client
-            configuration_ file.
+            If specified, used instead of retrieving a value from a
+            :std:doc:`D-Wave Cloud Client configuration file <cloud-client:reference/intro>`.
 
         solver (str, optional):
             Solver (a D-Wave system on which to run submitted problems).
-            If specified, used instead of retrieving a value from a D-Wave Cloud Client
-            configuration_ file.
+            If specified, used instead of retrieving a value from a
+            :std:doc:`D-Wave Cloud Client configuration file <cloud-client:reference/intro>`.
 
         proxy (str, optional):
             Proxy URL to be used for accessing the D-Wave API. If specified, used instead of
-            retrieving a value from a D-Wave Cloud Client configuration_ file.
+            retrieving a value from a
+            :std:doc:`D-Wave Cloud Client configuration file <cloud-client:reference/intro>`.
 
     Examples:
-        This example creates a :class:`DWaveSampler` based on a fictive user's D-Wave Cloud Client
-        configuration_ file and submits a simple Ising problem of just two variables
+        This example creates a :class:`DWaveSampler` based on a fictive user's
+        :std:doc:`D-Wave Cloud Client configuration file <cloud-client:reference/intro>`
+        and submits a simple Ising problem of just two variables
         that map to qubits 0 and 1 on the example system. (The simplicity of this example
         obviates the need for an embedding composite---the presence of qubits 0 and 1 on
         the selected D-Wave system can be verified manually.)
@@ -313,23 +317,24 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
                 current s in the range [0,1]. The resulting schedule is the piecewise-linear curve
                 that connects the provided points.
 
-        An anneal schedule must satisfy the following conditions:
-            * Time t must increase for all points in the schedule.
-            * For forward annealing, the first point must be (0,0) and the anneal fraction s must
-            increase monotonically.
-            * For reverse annealing, the anneal fraction s must start and end at s=1.
-            * In the final point, anneal fraction s must equal 1 and time t must not exceed the maximum
-            value in the annealing_time_range property.
-            * The number of points must be >=2.
-            * The upper bound is system-dependent; check the max_anneal_schedule_points property. For
-            reverse annealing, the maximum number of points allowed is one more than the number given by
-            this property.
-
         Raises:
             ValueError: If any of the above conditions are not satisfied.
 
-            RuntimeError: If the sampler does not accept the anneal_schedule parameter or if it does
-            not have annealing_time_range or max_anneal_schedule_points properties.
+            RuntimeError: If the sampler does not accept the anneal_schedule parameter or
+                if it does not have annealing_time_range or max_anneal_schedule_points properties.
+
+        An anneal schedule must satisfy the following conditions:
+
+            * Time t must increase for all points in the schedule.
+            * For forward annealing, the first point must be (0,0) and the anneal fraction s must
+              increase monotonically.
+            * For reverse annealing, the anneal fraction s must start and end at s=1.
+            * In the final point, anneal fraction s must equal 1 and time t must not exceed the
+              maximum  value in the annealing_time_range property.
+            * The number of points must be >=2.
+            * The upper bound is system-dependent; check the max_anneal_schedule_points property.
+              For reverse annealing, the maximum number of points allowed is one more than the
+              number given by this property.
 
         """
         if 'anneal_schedule' not in self.parameters:

--- a/dwave/system/samplers/dwave_sampler.py
+++ b/dwave/system/samplers/dwave_sampler.py
@@ -1,7 +1,8 @@
 """
-A dimod sampler_ for the D-Wave system.
+A :std:doc:`dimod sampler <dimod:reference/samplers>` for the D-Wave system.
 
-.. _sampler: http://dimod.readthedocs.io/en/latest/reference/samplers.html#samplers-and-composites
+See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/latest/glossary.html>`_
+for explanations of technical terms in descriptions of Ocean tools.
 """
 from __future__ import division
 
@@ -18,7 +19,7 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
 
     Enables quick incorporation of the D-Wave system as a sampler in
     the D-Wave Ocean software stack. Also enables optional customizing of input
-    parameters to `D-Wave Cloud Client <http://dwave-cloud-client.readthedocs.io/en/latest/>`_
+    parameters to :std:doc:`D-Wave Cloud Client <cloud-client:index>`
     (the stack's communication-manager package).
 
     Args:
@@ -70,7 +71,8 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
         ...
         {0: 1, 1: -1}
 
-    .. _configuration: http://dwave-cloud-client.readthedocs.io/en/latest/#module-dwave.cloud.config
+    See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/latest/glossary.html>`_
+    for explanations of technical terms in descriptions of Ocean tools.
 
     """
     def __init__(self, config_file=None, profile=None, endpoint=None, token=None, solver=None,
@@ -96,8 +98,8 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
 
         Examples:
             This example creates a :class:`DWaveSampler` and prints the properties retrieved
-            from a D-Wave solver selected by the user's default D-Wave Cloud Client
-            configuration_ file.
+            from a D-Wave solver selected by the user's default
+            :std:doc:`D-Wave Cloud Client configuration file <cloud-client:reference/intro>`.
 
             >>> from dwave.system.samplers import DWaveSampler
             >>> sampler = DWaveSampler()
@@ -107,7 +109,8 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
               [-0.20860153999435985, 0.05511969218508182],
             # Snipped above response for brevity
 
-        .. _configuration: http://dwave-cloud-client.readthedocs.io/en/latest/#module-dwave.cloud.config
+        See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/latest/glossary.html>`_
+        for explanations of technical terms in descriptions of Ocean tools.
 
         """
         return self._properties
@@ -123,8 +126,8 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
 
         Examples:
             This example creates a :class:`DWaveSampler` and prints the parameters retrieved
-            from a D-Wave solver selected by the user's default D-Wave Cloud Client
-            configuration_ file.
+            from a D-Wave solver selected by the user's default
+            :std:doc:`D-Wave Cloud Client configuration file <cloud-client:reference/intro>`.
 
             >>> from dwave.system.samplers import DWaveSampler
             >>> sampler = DWaveSampler()
@@ -136,7 +139,8 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
             u'auto_scale': ['parameters'],
             # Snipped above response for brevity
 
-        .. _configuration: http://dwave-cloud-client.readthedocs.io/en/latest/#module-dwave.cloud.config
+        See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/latest/glossary.html>`_
+        for explanations of technical terms in descriptions of Ocean tools.
 
         """
         return self._parameters
@@ -147,8 +151,8 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
 
         Examples:
             This example creates a :class:`DWaveSampler` and prints the active couplers retrieved
-            from a D-Wave solver selected by the user's default D-Wave Cloud Client
-            configuration_ file.
+            from a D-Wave solver selected by the user's default
+            :std:doc:`D-Wave Cloud Client configuration file <cloud-client:reference/intro>`.
 
             >>> from dwave.system.samplers import DWaveSampler
             >>> sampler = DWaveSampler()
@@ -166,7 +170,8 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
              (2, 4),
             # Snipped above response for brevity
 
-        .. _configuration: http://dwave-cloud-client.readthedocs.io/en/latest/#module-dwave.cloud.config
+        See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/latest/glossary.html>`_
+        for explanations of technical terms in descriptions of Ocean tools.
 
         """
         return self._edgelist
@@ -177,8 +182,8 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
 
         Examples:
             This example creates a :class:`DWaveSampler` and prints the active qubits retrieved
-            from a D-Wave solver selected by the user's default D-Wave Cloud Client
-            configuration_ file.
+            from a D-Wave solver selected by the user's default
+            :std:doc:`D-Wave Cloud Client configuration file <cloud-client:reference/intro>`.
 
             >>> from dwave.system.samplers import DWaveSampler
             >>> sampler = DWaveSampler()
@@ -191,7 +196,8 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
              5,
             # Snipped above response for brevity
 
-        .. _configuration: http://dwave-cloud-client.readthedocs.io/en/latest/#module-dwave.cloud.config
+        See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/latest/glossary.html>`_
+        for explanations of technical terms in descriptions of Ocean tools.
 
         """
         return self._nodelist
@@ -216,11 +222,12 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
 
         Examples:
             This example creates a :class:`DWaveSampler` based on a D-Wave solver selected by the
-            user's default D-Wave Cloud Client configuration_ file and submits a simple
-            Ising problem of just two variables that map to qubits 0 and 1 on the example
-            system. (The simplicity of this example obviates the need for an embedding
-            composite---the presence of qubits 0 and 1 on the selected D-Wave system can
-            be verified manually.)
+            user's default
+            :std:doc:`D-Wave Cloud Client configuration file <cloud-client:reference/intro>`
+            and submits a simple Ising problem of just two variables that map to qubits
+            0 and 1 on the example system. (The simplicity of this example obviates
+            the need for an embedding composite---the presence of qubits 0 and 1 on
+            the selected D-Wave system can be verified manually.)
 
             >>> from dwave.system.samplers import DWaveSampler
             >>> sampler = DWaveSampler()
@@ -230,7 +237,8 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
             ...
             {0: 1, 1: -1}
 
-        .. _configuration: http://dwave-cloud-client.readthedocs.io/en/latest/#module-dwave.cloud.config
+        See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/latest/glossary.html>`_
+        for explanations of technical terms in descriptions of Ocean tools.
 
         """
         if isinstance(h, list):
@@ -263,11 +271,12 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
 
         Examples:
             This example creates a :class:`DWaveSampler` based on a D-Wave solver selected by the
-            user's default D-Wave Cloud Client configuration_ file and submits a simple
-            QUBO problem of just two variables that map to coupled qubits 0 and 4 on the
-            example system. (The simplicity of this example obviates the need for an embedding
-            composite---the presence of qubits 0 and 4, and their coupling, on the selected
-            D-Wave system can be verified manually.)
+            user's default
+            :std:doc:`D-Wave Cloud Client configuration file <cloud-client:reference/intro>`
+            and submits a simple QUBO problem of just two variables that map to coupled
+            qubits 0 and 4 on the example system. (The simplicity of this example obviates
+            the need for an embedding composite---the presence of qubits 0 and 4, and
+            their coupling, on the selected D-Wave system can be verified manually.)
 
             >>> from dwave.system.samplers import DWaveSampler
             >>> sampler = DWaveSampler()
@@ -278,7 +287,8 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
             ...
             {0: 0, 4: 1}
 
-        .. _configuration: http://dwave-cloud-client.readthedocs.io/en/latest/#module-dwave.cloud.config
+        See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/latest/glossary.html>`_
+        for explanations of technical terms in descriptions of Ocean tools.
 
         """
         variables = set().union(*Q)


### PR DESCRIPTION
@arcondello,  this moves to .com version of RtDs, also adds draw_tiling function to RtD, and fixes some standing build errors ("...dwave_sampler.py:docstring of dwave.system.samplers.DWaveSampler.validate_anneal_schedule:19: WARNING: Unexpected indentation.")