### PR TITLE
Adtt 392/lazy embedding composite v2

### DIFF
--- a/dwave/system/composites/embedding.py
+++ b/dwave/system/composites/embedding.py
@@ -406,6 +406,13 @@ def _embed_state(embedding, state):
 
 
 class LazyEmbeddingComposite(FixedEmbeddingComposite):
+    """ Takes an unstructured problem and maps it to a structured problem. This mapping is stored and gets reused
+    for all following sample(..) calls.
+
+    Args:
+        sampler (dimod.Sampler):
+            Structured dimod sampler.
+    """
     def __init__(self, child_sampler):
         if not isinstance(child_sampler, dimod.Structured):
             raise dimod.InvalidComposition('LazyEmbeddingComposite should only be applied to a Structured sampler')
@@ -414,6 +421,11 @@ class LazyEmbeddingComposite(FixedEmbeddingComposite):
         self.embedding = None
 
     def sample(self, bqm, chain_strength=1.0, chain_break_fraction=True, **parameters):
+        """ Sample the binary quadratic model.
+
+        Note: At the initial sample(..) call, it will find a suitable embedding and initialize the remaining attributes
+        before sampling the bqm. All following sample(..) calls will reuse that initial embedding.
+        """
         if self.embedding is None:
             # Find embedding
             child = self.child   # Solve the problem on the child system

--- a/dwave/system/composites/embedding.py
+++ b/dwave/system/composites/embedding.py
@@ -28,6 +28,8 @@ See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/latest/glossary.html>`_ 
 of technical terms in descriptions of Ocean tools.
 
 """
+from builtins import super      # Adding super from future
+
 import dimod
 import minorminer
 

--- a/dwave/system/composites/embedding.py
+++ b/dwave/system/composites/embedding.py
@@ -28,8 +28,6 @@ See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/latest/glossary.html>`_ 
 of technical terms in descriptions of Ocean tools.
 
 """
-from builtins import super      # Adding super from future
-
 import dimod
 import minorminer
 
@@ -453,6 +451,6 @@ class LazyEmbeddingComposite(FixedEmbeddingComposite):
             embedding = minorminer.find_embedding(source_edgelist, target_edgelist)
 
             # Initialize properties that need embedding
-            super()._set_embedding_init(embedding)
+            super(LazyEmbeddingComposite, self)._set_embedding_init(embedding)
 
-        return super().sample(bqm, chain_strength=chain_strength, chain_break_fraction=chain_break_fraction, **parameters)
+        return super(LazyEmbeddingComposite, self).sample(bqm, chain_strength=chain_strength, chain_break_fraction=chain_break_fraction, **parameters)

--- a/dwave/system/composites/embedding.py
+++ b/dwave/system/composites/embedding.py
@@ -425,6 +425,23 @@ class LazyEmbeddingComposite(FixedEmbeddingComposite):
 
         Note: At the initial sample(..) call, it will find a suitable embedding and initialize the remaining attributes
         before sampling the bqm. All following sample(..) calls will reuse that initial embedding.
+
+        Args:
+            bqm (:obj:`dimod.BinaryQuadraticModel`):
+                Binary quadratic model to be sampled from.
+
+            chain_strength (float, optional, default=1.0):
+                Magnitude of the quadratic bias (in SPIN-space) applied between variables to create
+                chains. Note that the energy penalty of chain breaks is 2 * `chain_strength`.
+
+            chain_break_fraction (bool, optional, default=True):
+                If True, a ‘chain_break_fraction’ field is added to the unembedded response which report
+                what fraction of the chains were broken before unembedding.
+
+            **parameters:
+                Parameters for the sampling method, specified by the child sampler.
+        Returns:
+            :class:`dimod.Response`
         """
         if self.embedding is None:
             # Find embedding
@@ -433,7 +450,7 @@ class LazyEmbeddingComposite(FixedEmbeddingComposite):
             source_edgelist = list(bqm.quadratic) + [(v, v) for v in bqm.linear]  # Add self-loops for single variables
             embedding = minorminer.find_embedding(source_edgelist, target_edgelist)
 
-            # Set up initialize properties that need embedding
+            # Initialize properties that need embedding
             super()._set_embedding_init(embedding)
 
         return super().sample(bqm, chain_strength=chain_strength, chain_break_fraction=chain_break_fraction, **parameters)

--- a/dwave/system/composites/embedding.py
+++ b/dwave/system/composites/embedding.py
@@ -406,29 +406,22 @@ def _embed_state(embedding, state):
 
 
 class LazyEmbeddingComposite(FixedEmbeddingComposite):
-
     def __init__(self, child_sampler):
         if not isinstance(child_sampler, dimod.Structured):
-            raise dimod.InvalidComposition("LazyEmbeddingComposite should only be applied to a Structured sampler")
-        #self.child_sampler = child_sampler
+            raise dimod.InvalidComposition('LazyEmbeddingComposite should only be applied to a Structured sampler')
+
         self.children = [child_sampler]
         self.embedding = None
 
     def sample(self, bqm, chain_strength=1.0, chain_break_fraction=True, **parameters):
         if self.embedding is None:
-            # solve the problem on the child system
-            child = self.child
-
-            # apply the embedding to the given problem to map it to the child sampler
+            # Find embedding
+            child = self.child   # Solve the problem on the child system
             __, target_edgelist, target_adjacency = child.structure
-
-            # add self-loops to edgelist to handle singleton variables
-            source_edgelist = list(bqm.quadratic) + [(v, v) for v in bqm.linear]
-
-            # get the embedding
+            source_edgelist = list(bqm.quadratic) + [(v, v) for v in bqm.linear]  # Add self-loops for single variables
             embedding = minorminer.find_embedding(source_edgelist, target_edgelist)
 
-            #super().__init__(self.child_sampler, embedding)
+            # Set up initialize properties that need embedding
             super()._set_embedding_init(embedding)
 
         return super().sample(bqm, chain_strength=chain_strength, chain_break_fraction=chain_break_fraction, **parameters)

--- a/dwave/system/composites/embedding.py
+++ b/dwave/system/composites/embedding.py
@@ -263,7 +263,10 @@ class FixedEmbeddingComposite(dimod.ComposedSampler, dimod.Structured):
             raise dimod.InvalidComposition("EmbeddingComposite should only be applied to a Structured sampler")
 
         self.children = [child_sampler]
+        self._set_embedding_init(embedding)
 
+    def _set_embedding_init(self, embedding):
+        child_sampler = self.children[0]
         # Derive the structure of our composed sampler from the target graph and the embedding
         source_adjacency = dimod.embedding.target_to_source(child_sampler.adjacency, embedding)
         try:
@@ -407,6 +410,7 @@ class LazyEmbeddingComposite(FixedEmbeddingComposite):
     def __init__(self, child_sampler):
         if not isinstance(child_sampler, dimod.Structured):
             raise dimod.InvalidComposition("LazyEmbeddingComposite should only be applied to a Structured sampler")
+        #self.child_sampler = child_sampler
         self.children = [child_sampler]
         self.embedding = None
 
@@ -424,6 +428,7 @@ class LazyEmbeddingComposite(FixedEmbeddingComposite):
             # get the embedding
             embedding = minorminer.find_embedding(source_edgelist, target_edgelist)
 
-            super().__init__(self.children[0], embedding)
+            #super().__init__(self.child_sampler, embedding)
+            super()._set_embedding_init(embedding)
 
         return super().sample(bqm, chain_strength=chain_strength, chain_break_fraction=chain_break_fraction, **parameters)

--- a/dwave/system/composites/embedding.py
+++ b/dwave/system/composites/embedding.py
@@ -266,9 +266,8 @@ class FixedEmbeddingComposite(dimod.ComposedSampler, dimod.Structured):
         self._set_embedding_init(embedding)
 
     def _set_embedding_init(self, embedding):
-        child_sampler = self.children[0]
         # Derive the structure of our composed sampler from the target graph and the embedding
-        source_adjacency = dimod.embedding.target_to_source(child_sampler.adjacency, embedding)
+        source_adjacency = dimod.embedding.target_to_source(self.child.adjacency, embedding)
         try:
             nodelist = sorted(source_adjacency)
             edgelist = sorted(_adjacency_to_edges(source_adjacency))
@@ -281,11 +280,11 @@ class FixedEmbeddingComposite(dimod.ComposedSampler, dimod.Structured):
         self.edgelist = edgelist
         self.adjacency = source_adjacency
 
-        self.parameters = parameters = child_sampler.parameters.copy()
+        self.parameters = parameters = self.child.parameters.copy()
         parameters['chain_strength'] = []
         parameters['chain_break_fraction'] = []
 
-        self.properties = {'child_properties': child_sampler.properties.copy()}
+        self.properties = {'child_properties': self.child.properties.copy()}
 
         self.embedding = self.properties['embedding'] = embedding
 

--- a/tests/unit/test_embedding_composite.py
+++ b/tests/unit/test_embedding_composite.py
@@ -207,7 +207,7 @@ class TestLazyEmbeddingComposite(unittest.TestCase):
 
         # Check that the same embedding is used
         csp2 = dbc.ConstraintSatisfactionProblem(dbc.BINARY)
-        csp2.add_constraint(or_gate(['a', 'b', 'c']))   #TODO: Same naming must be used. Weird
+        csp2.add_constraint(or_gate(['a', 'b', 'c']))
         bqm2 = dbc.stitch(csp2)
         sampler.sample(bqm2)
 

--- a/tests/unit/test_embedding_composite.py
+++ b/tests/unit/test_embedding_composite.py
@@ -21,7 +21,6 @@ import dimod
 import dimod.testing as dtest
 
 from dwave.system.composites import EmbeddingComposite, FixedEmbeddingComposite, LazyEmbeddingComposite
-import dwavebinarycsp as dbc
 from dwavebinarycsp.factories.constraint.gates import and_gate, or_gate
 
 from tests.unit.mock_sampler import MockSampler
@@ -180,11 +179,9 @@ class TestLazyEmbeddingComposite(unittest.TestCase):
         self.assertIsNone(sampler.parameters)
         self.assertIsNone(sampler.properties)
 
-        # Set up BQM and sample
-        csp = dbc.ConstraintSatisfactionProblem(dbc.BINARY)
-        csp.add_constraint(and_gate(['a', 'b', 'c']))
-        bqm = dbc.stitch(csp)
-        sampler.sample(bqm)
+        # Set up an and_gate BQM and sample
+        Q = {('a', 'a'): 0.0, ('c', 'c'): 6.0, ('b', 'b'): 0.0, ('b', 'a'): 2.0, ('c', 'a'): -4.0, ('c', 'b'): -4.0}
+        sampler.sample_qubo(Q)
 
         # Check that values have been populated
         self.assertIsNotNone(sampler.embedding)
@@ -205,12 +202,11 @@ class TestLazyEmbeddingComposite(unittest.TestCase):
         # Store embedding
         prev_embedding = sampler.embedding
 
-        # Check that the same embedding is used
-        csp2 = dbc.ConstraintSatisfactionProblem(dbc.BINARY)
-        csp2.add_constraint(or_gate(['a', 'b', 'c']))
-        bqm2 = dbc.stitch(csp2)
-        sampler.sample(bqm2)
+        # Set up QUBO of an or_gate
+        Q = {('a', 'a'): 2.0, ('c', 'c'): 2.0, ('b', 'b'): 2.0, ('b', 'a'): 2.0, ('c', 'a'): -4.0, ('c', 'b'): -4.0}
+        sampler.sample_qubo(Q)
 
+        # Check that the same embedding is used
         self.assertEqual(sampler.embedding, prev_embedding)
 
     def test_ising(self):

--- a/tests/unit/test_embedding_composite.py
+++ b/tests/unit/test_embedding_composite.py
@@ -234,3 +234,12 @@ class TestLazyEmbeddingComposite(unittest.TestCase):
         self.assertEqual(sampler.edgelist, [(1, 2), (1, 3), (2, 3)])
         self.assertEqual(sampler.adjacency, {1: {2, 3}, 2: {1, 3}, 3: {1, 2}})
 
+    def test_sparse_qubo(self):
+        # There is no relationship between nodes 2 and 3
+        Q = {(1, 1): 1, (2, 2): 2, (3, 3): 3, (1, 2): 4, (1, 3): 6}
+        sampler = LazyEmbeddingComposite(MockSampler())
+        sampler.sample_qubo(Q)
+
+        self.assertIsNotNone(sampler.embedding)
+        self.assertEqual(sampler.nodelist, [1, 2, 3])
+        self.assertEqual(sampler.edgelist, [(1, 2), (1, 3)])

--- a/tests/unit/test_embedding_composite.py
+++ b/tests/unit/test_embedding_composite.py
@@ -194,9 +194,19 @@ class TestLazyEmbeddingComposite(unittest.TestCase):
         self.assertIsNotNone(sampler.parameters)
         self.assertIsNotNone(sampler.properties)
 
-        # Check that the same embedding is used
+    def test_same_embedding(self):
+        sampler = LazyEmbeddingComposite(MockSampler())
+
+        # Set up BQM and sample
+        csp = dbc.ConstraintSatisfactionProblem(dbc.BINARY)
+        csp.add_constraint(and_gate(['a', 'b', 'c']))
+        bqm = dbc.stitch(csp)
+        sampler.sample(bqm)
+
+        # Store embedding
         prev_embedding = sampler.embedding
 
+        # Check that the same embedding is used
         csp2 = dbc.ConstraintSatisfactionProblem(dbc.BINARY)
         csp2.add_constraint(or_gate(['a', 'b', 'c']))   #TODO: Same naming must be used. Weird
         bqm2 = dbc.stitch(csp2)

--- a/tests/unit/test_embedding_composite.py
+++ b/tests/unit/test_embedding_composite.py
@@ -217,29 +217,41 @@ class TestLazyEmbeddingComposite(unittest.TestCase):
         h = {0: 11, 5: 2}
         J = {(0, 5): -8}
         sampler = LazyEmbeddingComposite(MockSampler())
-        sampler.sample_ising(h, J)
+        response = sampler.sample_ising(h, J)
 
+        # Check embedding
         self.assertIsNotNone(sampler.embedding)
         self.assertEqual(sampler.nodelist, [0, 5])
         self.assertEqual(sampler.edgelist, [(0, 5)])
         self.assertEqual(sampler.adjacency, {0: {5}, 5: {0}})
 
+        # Check that at least one response was found
+        self.assertGreaterEqual(len(response), 1)
+
     def test_qubo(self):
         Q = {(1, 1): 1, (2, 2): 2, (3, 3): 3, (1, 2): 4, (2, 3): 5, (1, 3): 6}
         sampler = LazyEmbeddingComposite(MockSampler())
-        sampler.sample_qubo(Q)
+        response = sampler.sample_qubo(Q)
 
+        # Check embedding
         self.assertIsNotNone(sampler.embedding)
         self.assertEqual(sampler.nodelist, [1, 2, 3])
         self.assertEqual(sampler.edgelist, [(1, 2), (1, 3), (2, 3)])
         self.assertEqual(sampler.adjacency, {1: {2, 3}, 2: {1, 3}, 3: {1, 2}})
 
+        # Check that at least one response was found
+        self.assertGreaterEqual(len(response), 1)
+
     def test_sparse_qubo(self):
         # There is no relationship between nodes 2 and 3
         Q = {(1, 1): 1, (2, 2): 2, (3, 3): 3, (1, 2): 4, (1, 3): 6}
         sampler = LazyEmbeddingComposite(MockSampler())
-        sampler.sample_qubo(Q)
+        response = sampler.sample_qubo(Q)
 
+        # Check embedding
         self.assertIsNotNone(sampler.embedding)
         self.assertEqual(sampler.nodelist, [1, 2, 3])
         self.assertEqual(sampler.edgelist, [(1, 2), (1, 3)])
+
+        # Check that at least one response was found
+        self.assertGreaterEqual(len(response), 1)

--- a/tests/unit/test_embedding_composite.py
+++ b/tests/unit/test_embedding_composite.py
@@ -197,11 +197,10 @@ class TestLazyEmbeddingComposite(unittest.TestCase):
     def test_same_embedding(self):
         sampler = LazyEmbeddingComposite(MockSampler())
 
-        # Set up BQM and sample
-        csp = dbc.ConstraintSatisfactionProblem(dbc.BINARY)
-        csp.add_constraint(and_gate(['a', 'b', 'c']))
-        bqm = dbc.stitch(csp)
-        sampler.sample(bqm)
+        # Set up Ising and sample
+        h = {'a': 1, 'b': 1, 'c': 1}
+        J = {('a', 'b'): 3, ('b', 'c'): -2, ('a', 'c'): 1}
+        sampler.sample_ising(h, J)
 
         # Store embedding
         prev_embedding = sampler.embedding
@@ -213,3 +212,25 @@ class TestLazyEmbeddingComposite(unittest.TestCase):
         sampler.sample(bqm2)
 
         self.assertEqual(sampler.embedding, prev_embedding)
+
+    def test_ising(self):
+        h = {0: 11, 5: 2}
+        J = {(0, 5): -8}
+        sampler = LazyEmbeddingComposite(MockSampler())
+        sampler.sample_ising(h, J)
+
+        self.assertIsNotNone(sampler.embedding)
+        self.assertEqual(sampler.nodelist, [0, 5])
+        self.assertEqual(sampler.edgelist, [(0, 5)])
+        self.assertEqual(sampler.adjacency, {0: {5}, 5: {0}})
+
+    def test_qubo(self):
+        Q = {(1, 1): 1, (2, 2): 2, (3, 3): 3, (1, 2): 4, (2, 3): 5, (1, 3): 6}
+        sampler = LazyEmbeddingComposite(MockSampler())
+        sampler.sample_qubo(Q)
+
+        self.assertIsNotNone(sampler.embedding)
+        self.assertEqual(sampler.nodelist, [1, 2, 3])
+        self.assertEqual(sampler.edgelist, [(1, 2), (1, 3), (2, 3)])
+        self.assertEqual(sampler.adjacency, {1: {2, 3}, 2: {1, 3}, 3: {1, 2}})
+

--- a/tests/unit/test_embedding_composite.py
+++ b/tests/unit/test_embedding_composite.py
@@ -21,7 +21,6 @@ import dimod
 import dimod.testing as dtest
 
 from dwave.system.composites import EmbeddingComposite, FixedEmbeddingComposite, LazyEmbeddingComposite
-from dwavebinarycsp.factories.constraint.gates import and_gate, or_gate
 
 from tests.unit.mock_sampler import MockSampler
 


### PR DESCRIPTION
- Code and unit tests for LazyEmbeddingComposite
- LazyEmbeddingComposite inherits from FixedEmbeddingComposite
- The difference between LazyEC and FixedEC is that the embedding in LazyEC is automatically found by minorminer rather than provided by the user.