### PR TITLE
Fix missing cmd

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,7 +61,7 @@ To install with optional dependencies:
 .. code-block:: bash
 
     pip install -r requirements.txt
-    python setup.py
+    python setup.py install
 
 Note that installing from source installs ``dwave-drivers``. To uninstall the proprietary components:
 


### PR DESCRIPTION
``
`>python setup.py
usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
   or: setup.py --help [cmd1 cmd2 ...]
   or: setup.py --help-commands
   or: setup.py cmd --help

error: no commands supplied
```