### PR TITLE
Fixes issue #166 by adding special logic for small clique embeddings.

### DIFF
--- a/dwave/embedding/chimera.py
+++ b/dwave/embedding/chimera.py
@@ -92,7 +92,7 @@ def find_clique_embedding(k, m, n=None, t=None, target_edges=None):
 
         if not isinstance(target_edges, list):
             edges = list(target_edges)
-        edge = edges[random.randint(0, len(edges))]
+        edge = edges[random.randrange(len(edges))]
         embedding = [[edge[0]], [edge[1]]]
 
     else:

--- a/dwave/embedding/chimera.py
+++ b/dwave/embedding/chimera.py
@@ -16,7 +16,6 @@
 
 import dwave_networkx as dnx
 import networkx as nx
-import numpy as np
 
 
 from dwave.embedding.polynomialembedder import processor
@@ -72,6 +71,8 @@ def find_clique_embedding(k, m, n=None, t=None, target_edges=None):
         {'a': [20, 16], 'b': [21, 17], 'c': [22, 18]}
 
     """
+    import random
+
     _, nodes = k
 
     m, n, t, target_edges = _chimera_input(m, n, t, target_edges)
@@ -82,18 +83,16 @@ def find_clique_embedding(k, m, n=None, t=None, target_edges=None):
     if len(nodes) == 1:
         # If k == 1 we simply return a single chain consisting of a randomly sampled qubit.
 
-        qubits = set()
-        for edge in target_edges:
-            qubits = qubits.union(edge)
-
-        qubit = np.random.choice(list(qubits))
+        qubits = set().union(*target_edges)
+        qubit = random.choice(tuple(qubits))
         embedding = [[qubit]]
 
     elif len(nodes) == 2:
         # If k == 2 we simply return two one-qubit chains that are the endpoints of a randomly sampled coupler.
 
-        edges = list(target_edges)
-        edge = edges[np.random.randint(0, len(edges))]
+        if not isinstance(target_edges, list):
+            edges = list(target_edges)
+        edge = edges[random.randint(0, len(edges))]
         embedding = [[edge[0]], [edge[1]]]
 
     else:

--- a/tests/test_dwave_sampler.py
+++ b/tests/test_dwave_sampler.py
@@ -144,7 +144,7 @@ class TestDwaveSampler(unittest.TestCase):
 
         MockClient.reset_mock()
         solver = {'qpu': True, 'num_qubits__gt': 1000}
-        sampler = DWaveSampler(solver_features=solver)
+        sampler = DWaveSampler(solver=solver)
         MockClient.from_config.assert_called_once_with(solver=solver)
 
     def test_sample_ising_variables(self):

--- a/tests/test_embedding_composite.py
+++ b/tests/test_embedding_composite.py
@@ -295,7 +295,7 @@ class TestLazyEmbeddingComposite(unittest.TestCase):
     def test_ising_sample(self):
         h = {'a': 1, 'b': -2}
         J = {('a', 'b'): -3}
-        sampler = LazyEmbeddingComposite(MockDWaveSampler())
+        sampler = LazyFixedEmbeddingComposite(MockDWaveSampler())
         response = sampler.sample_ising(h, J)
 
         # Check that at least one response was found


### PR DESCRIPTION
Added special logic to create optimal clique embeddings for cliques of size 1 and 2, which can be done with single-qubit chains.  Previously the dwave.system.chimera.find_clique_embedding method would return embeddings with chains of length 2 for these small cliques, which is suboptimal.

Closes #166 