### PR TITLE
Parameterized Embedding Composite

### DIFF
--- a/dwave/system/composites/embedding.py
+++ b/dwave/system/composites/embedding.py
@@ -24,6 +24,7 @@ from dwave.embedding import target_to_source, unembed_sampleset, embed_bqm
 __all__ = ('EmbeddingComposite',
            'FixedEmbeddingComposite',
            'LazyFixedEmbeddingComposite',
+           'ParamEmbeddingComposite',
            'LazyEmbeddingComposite',  # deprecated
            )
 
@@ -494,6 +495,171 @@ class LazyFixedEmbeddingComposite(FixedEmbeddingComposite):
         return super(LazyFixedEmbeddingComposite, self).sample(bqm, chain_strength=chain_strength,
                                                                chain_break_fraction=chain_break_fraction, **parameters)
 
+class ParamEmbeddingComposite(dimod.ComposedSampler):
+    """Composite that maps problems to a structured sampler using a
+    parameterized embedding method.
+
+    Args:
+       sampler (dimod.Sampler)
+            Structured dimod sampler.
+
+       embedding_method (object, optional, default=minorminer)
+            Any object with a find_embedding(S,T,**params) method.
+            Where S and T are edgelists or NetworkX Graphs.
+
+       embedding_parameters (dict, optional, default={}):
+            Parameter dictionary to be passed to the embedding method.
+
+    """
+    def __init__(self, child_sampler, embedding_method=minorminer, **embedding_parameters):
+        if not isinstance(child_sampler, dimod.Structured):
+            raise dimod.InvalidComposition("ParamEmbeddingComposite should only be applied to a Structured sampler")
+        self._children = [child_sampler]
+        self._embedding_method = embedding_method
+        self._embedding_parameters = embedding_parameters
+
+        self.embedding = None
+        self.child_response = None
+
+    @property
+    def children(self):
+        """list [child_sampler]: List containing the structured sampler."""
+        return self._children
+
+    @property
+    def parameters(self):
+        """dict[str, list]: Parameters in the form of a dict.
+
+        #TODO: Ideally, the `embedding_method` object should also have a
+        `parameters` attribute.
+        """
+
+        param = self.child.parameters.copy()
+        param['force_embed'] = []
+        param['chain_strength'] = []
+        param['chain_break_fraction'] = []
+        # Ideally
+        # param['embedding_parameters'] = self._embedding_method.parameters.copy()
+
+        return param
+
+    @property
+    def properties(self):
+        """dict: Properties in the form of a dict.
+        """
+        return {'child_properties': self.child.properties.copy()}
+
+    def get_embedding(self, bqm, target_edgelist=None,
+                        force_embed=False,
+                        embedding_method=None,
+                        **embedding_parameters):
+        """Retrieve or create a minor-embedding from BinaryQuadraticModel
+
+        Args:
+            bqm (:obj:`dimod.BinaryQuadraticModel`):
+                Binary quadratic model to be sampled from.
+
+            target_edgelist (list, optional, default=<Child Structure>):
+                An iterable of label pairs representing the edges in the target graph.
+
+            force_embed (bool, optional, default=False):
+                If the sampler has an embedding return it. Otherwise, embed problem.
+
+            **embedding_parameters:
+                Parameters for the embedding method.
+
+        Returns:
+            embedding (dict):
+                Dictionary that maps labels in S_edgelist to lists of labels in the
+                graph of the structured sampler.
+        """
+        embedding = self.embedding
+
+        if not embedding_parameters:
+            embedding_parameters = self._embedding_parameters
+
+        if embedding_method is None:
+            embedding_method = self._embedding_method
+
+        if target_edgelist is None:
+            _, target_edgelist, _ = self.child.structure
+
+        # add self-loops to edgelist to handle singleton variables
+        source_edgelist = list(bqm.quadratic) + [(v, v) for v in bqm.linear]
+
+        if force_embed or not embedding:
+            embedding = embedding_method.find_embedding(source_edgelist,
+                                                        target_edgelist,
+                                                        **embedding_parameters)
+        if bqm and not embedding:
+            raise ValueError("no embedding found")
+
+        self.embedding = self.properties['embedding'] = embedding
+
+        return embedding
+
+    def sample(self, bqm, chain_strength=1.0, chain_break_fraction=True, force_embed=False, **parameters):
+        """Sample from the provided binary quadratic model.
+
+        Also set parameters for handling a chain, the set of vertices in a target graph that
+        represents a source-graph vertex; when a D-Wave system is the sampler, it is a set
+        of qubits that together represent a variable of the binary quadratic model being
+        minor-embedded.
+
+        Args:
+            bqm (:obj:`dimod.BinaryQuadraticModel`):
+                Binary quadratic model to be sampled from.
+
+            chain_strength (float, optional, default=1.0):
+                Magnitude of the quadratic bias (in SPIN-space) applied between variables to create
+                chains. The energy penalty of chain breaks is 2 * `chain_strength`.
+
+            chain_break_fraction (bool, optional, default=True):
+                If True, the unembedded response contains a ‘chain_break_fraction’ field that
+                reports the fraction of chains broken before unembedding.
+
+            force_embed (bool, optional, default=False):
+                If True, regardless of `embedding`, a new embedding is obtained.
+
+            **parameters:
+                Parameters for the sampling method, specified by the child sampler.
+
+        Returns:
+            :class:`dimod.SampleSet`: A `dimod` :obj:`~dimod.SampleSet` object.
+
+        """
+
+        # solve the problem on the child system
+        child = self.child
+
+        # apply the embedding to the given problem to map it to the child sampler
+        __, target_edgelist, target_adjacency = child.structure
+
+        # pass the corresponding parameters
+        embedding_parameters = self._embedding_parameters
+
+        # get the embedding
+        embedding = self.get_embedding(bqm, target_edgelist=target_edgelist,
+                                            force_embed=force_embed,
+                                            **embedding_parameters)
+
+        if bqm and not embedding:
+            raise ValueError("no embedding found")
+
+        bqm_embedded = embed_bqm(bqm, embedding, target_adjacency,
+                                 chain_strength=chain_strength,
+                                 smear_vartype=dimod.SPIN)
+
+        if 'initial_state' in parameters:
+            parameters['initial_state'] = _embed_state(embedding, parameters['initial_state'])
+
+        response = child.sample(bqm_embedded, **parameters)
+
+        # Store embedded response
+        self.child_response = response
+
+        return unembed_sampleset(response, embedding, source_bqm=bqm,
+                                 chain_break_fraction=chain_break_fraction)
 
 class LazyEmbeddingComposite(LazyFixedEmbeddingComposite):
     """Deprecated Class. 'LazyEmbeddingComposite' has been deprecated and renamed to 'LazyFixedEmbeddingComposite'.


### PR DESCRIPTION
This is a _cute_ way to have completely parameterized embedding `Composites`.

An embedding_method can be any object with a find_embedding(S, T, **params) method.
Where S and T are edgelists or NetworkX Graphs.

It relates to [minorminer/#82](https://github.com/dwavesystems/minorminer/pull/82) since it would benefit from having parameters visible from the embedding_method.

It also relates to #100, in that, it's an idea on how to pass complex objects/methods to a composite.

And it would easily allow the inclusion of other methods, as well as more control over `minorminer`'s
features.

```
# Example usage
import minorminer
import dwave_networkx as dnx

from dwave.system import DWaveSampler, ParamEmbeddingComposite
from dimod import StructureComposite, SimulatedAnnealingSampler

Tg = dnx.chimera_graph(4)
structsampler = StructureComposite(SimulatedAnnealingSampler(), Tg.nodes, Tg.edges)

sampler = ParamEmbeddingComposite(structsampler, minorminer, random_seed=42)
# Same as:
# sampler = ParamEmbeddingComposite(structsampler, random_seed=42)

h = {'a': -1., 'b': 2}
J = {('a', 'b'): 1.5}
response = sampler.sample_ising(h, J)
for sample in response.samples():    # doctest: +SKIP
       print(sample)

sampler.embedding

```