### PR TITLE
Partial refactor of Virtual Graph

### DIFF
--- a/dwave/system/composites/virtual_graph.py
+++ b/dwave/system/composites/virtual_graph.py
@@ -12,7 +12,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #
-# ================================================================================================
+# =============================================================================
 """
 A :std:doc:`dimod composite <dimod:reference/samplers>` that uses the D-Wave virtual
 graph feature for improved :std:doc:`minor-embedding <system:intro>`.
@@ -26,9 +26,6 @@ couplings.
 See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/latest/glossary.html>`_
 for explanations of technical terms in descriptions of Ocean tools.
 """
-
-from six import iteritems
-
 import dimod
 
 from dwave.system.composites.embedding import FixedEmbeddingComposite
@@ -40,7 +37,7 @@ FLUX_BIAS_KWARG = 'flux_biases'
 __all__ = ['VirtualGraphComposite']
 
 
-class VirtualGraphComposite(dimod.ComposedSampler, dimod.Structured):
+class VirtualGraphComposite(FixedEmbeddingComposite):
     """Composite to use the D-Wave virtual graph feature for minor-embedding.
 
     Inherits from :class:`dimod.ComposedSampler` and :class:`dimod.Structured`.
@@ -129,14 +126,8 @@ class VirtualGraphComposite(dimod.ComposedSampler, dimod.Structured):
                  flux_bias_num_reads=1000,
                  flux_bias_max_age=3600):
 
-        child, = self.children = [FixedEmbeddingComposite(sampler, embedding)]
-        self.nodelist, self.edgelist, self.adjacency = child.structure
-        self.embedding = child.embedding
-
-        self.parameters = parameters = {'apply_flux_bias_offsets': []}
-        parameters.update(child.parameters)
-
-        self.properties = child.properties.copy()  # shallow copy
+        super(VirtualGraphComposite, self).__init__(sampler, embedding)
+        self.parameters.update(apply_flux_bias_offsets=[])
 
         # Validate the chain strength, or obtain it from J-range if chain strength is not provided.
         self.chain_strength = _validate_chain_strength(sampler, chain_strength)
@@ -158,142 +149,6 @@ class VirtualGraphComposite(dimod.ComposedSampler, dimod.Structured):
         self.flux_biases = [flux_biases.get(v, 0.0) for v in range(sampler.properties['num_qubits'])]
 
         return
-
-    # override the abstract properties
-    nodelist = None
-    """list:
-           Nodes available to the composed sampler.
-
-    Examples:
-       This example uses :class:`.VirtualGraphComposite` to instantiate a composed sampler
-       that uses a D-Wave solver selected by the user's default
-       :std:doc:`D-Wave Cloud Client configuration file <cloud-client:intro>`.
-       Because qubits 0, 1, 4, 5 are active on the selected D-Wave solver, the three nodes, x, y, and z,
-       specified by the embedding, are all available to problems using this composed sampler.
-
-       >>> from dwave.system.samplers import DWaveSampler
-       >>> from dwave.system.composites import VirtualGraphComposite
-       >>> embedding = {'x': {1}, 'y': {5}, 'z': {0, 4}}
-       >>> sampler = VirtualGraphComposite(DWaveSampler(), embedding)  # doctest: +SKIP
-       >>> sampler.nodelist  # doctest: +SKIP
-       ['x', 'y', 'z']
-
-    See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/latest/glossary.html>`_
-    for explanations of technical terms in descriptions of Ocean tools.
-
-    """
-
-    edgelist = None
-    """list:
-           Edges available to the composed sampler.
-
-    Examples:
-       This example uses :class:`.VirtualGraphComposite` to instantiate a composed sampler
-       that uses a D-Wave solver selected by the user's default
-       :std:doc:`D-Wave Cloud Client configuration file <cloud-client:intro>`.
-       Because qubits 0, 5, and coupled qubits {0, 4} are all coupled on the selected D-Wave solver, edges
-       between three nodes, x, y, and z, as specified by the embedding, are available to problems using this
-       composed sampler. However, qubit 8 is in an adjacent unit cell on the D-Wave solver and not directly
-       connected to the other four qubits, so node `a` does not share an edge with any other nodes.
-
-       >>> from dwave.system.samplers import DWaveSampler
-       >>> from dwave.system.composites import VirtualGraphComposite
-       >>> embedding = {'x': {1}, 'y': {5}, 'z': {0, 4}, 'a': {8}}
-       >>> sampler = VirtualGraphComposite(DWaveSampler(), embedding)  # doctest: +SKIP
-       >>> sampler.edgelist  # doctest: +SKIP
-       [('x', 'y'), ('x', 'z'), ('y', 'z')]
-
-    See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/latest/glossary.html>`_
-    for explanations of technical terms in descriptions of Ocean tools.
-
-    """
-
-    adjacency = None
-    """dict[variable, set]:
-           Adjacency structure for the composed sampler.
-
-    Examples:
-       This example uses :class:`.VirtualGraphComposite` to instantiate a composed sampler
-       that uses a D-Wave solver selected by the user's default
-       :std:doc:`D-Wave Cloud Client configuration file <cloud-client:intro>`.
-       Because qubits 0, 5, and coupled qubits {0, 4} are all coupled on the selected D-Wave solver, edges
-       between three nodes, x, y, and z, as specified by the embedding, are available to problems using this
-       composed sampler. However, qubit 8 is in an adjacent unit cell on the D-Wave solver and not directly
-       connected to the other four qubits, so node `a` does not share an edge with any other nodes.
-
-       >>> from dwave.system.samplers import DWaveSampler
-       >>> from dwave.system.composites import VirtualGraphComposite
-       >>> embedding = {'x': {1}, 'y': {5}, 'z': {0, 4}, 'a': {8}}
-       >>> sampler = VirtualGraphComposite(DWaveSampler(), embedding)  # doctest: +SKIP
-       >>> sampler.adjacency  # doctest: +SKIP
-       {'a': set(), 'x': {'y', 'z'}, 'y': {'x', 'z'}, 'z': {'x', 'y'}}
-
-    See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/latest/glossary.html>`_
-    for explanations of technical terms in descriptions of Ocean tools.
-
-    """
-
-    children = None
-    """list: List containing the FixedEmbeddingComposite-wrapped sampler."""
-
-    parameters = None
-    """dict[str, list]: Parameters in the form of a dict.
-
-    For an instantiated composed sampler, keys are the keyword parameters accepted by the child
-    sampler with an additional parameter, 'apply_flux_bias_offsets'.
-
-    Examples:
-       This example uses :class:`.VirtualGraphComposite` to instantiate a composed sampler
-       that uses a D-Wave solver selected by the user's default
-       :std:doc:`D-Wave Cloud Client configuration file <cloud-client:intro>`
-       and views the composed sampler's parameters.
-
-       >>> from dwave.system.samplers import DWaveSampler
-       >>> from dwave.system.composites import VirtualGraphComposite
-       >>> embedding = {'x': {1}, 'y': {5}, 'z': {0, 4}}
-       >>> sampler = VirtualGraphComposite(DWaveSampler(), embedding)  # doctest: +SKIP
-       >>> sampler.parameters  # doctest: +SKIP
-       {u'anneal_offsets': ['parameters'],
-        u'anneal_schedule': ['parameters'],
-        u'annealing_time': ['parameters'],
-        u'answer_mode': ['parameters'],
-        'apply_flux_bias_offsets': [],
-        u'auto_scale': ['parameters'],
-       >>>  # Snipped above response for brevity
-
-    See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/latest/glossary.html>`_
-    for explanations of technical terms in descriptions of Ocean tools.
-
-    """
-
-    properties = None
-    """dict: Properties in the form of a dict.
-
-    For an instantiated composed sampler, contains one key :code:`'child_properties'` that
-    has a copy of the child sampler's properties.
-
-    Examples:
-       This example uses :class:`.VirtualGraphComposite` to instantiate a composed sampler
-       that uses a D-Wave solver selected by the user's default
-       :std:doc:`D-Wave Cloud Client configuration file <cloud-client:intro>`
-       and views the composed sampler's properties.
-
-       >>> from dwave.system.samplers import DWaveSampler
-       >>> from dwave.system.composites import VirtualGraphComposite
-       >>> embedding = {'x': {1}, 'y': {5}, 'z': {0, 4}}
-       >>> sampler = VirtualGraphComposite(DWaveSampler(), embedding)  # doctest: +SKIP
-       >>> sampler.properties  # doctest: +SKIP
-       {'child_properties': {u'anneal_offset_ranges': [[-0.2197463755538704,
-           0.03821687759418928],
-          [-0.2242514597680286, 0.01718456460967399],
-          [-0.20860153999435985, 0.05511969218508182],
-          [-0.2108920134230625, 0.056392603743884134],
-       >>>  # Snipped above response for brevity
-
-    See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/latest/glossary.html>`_
-    for explanations of technical terms in descriptions of Ocean tools.
-
-    """
 
     @dimod.bqm_structured
     def sample(self, bqm, apply_flux_bias_offsets=True, **kwargs):
@@ -356,13 +211,12 @@ class VirtualGraphComposite(dimod.ComposedSampler, dimod.Structured):
         for explanations of technical terms in descriptions of Ocean tools.
 
         """
-        child = self.child
 
         if apply_flux_bias_offsets:
             if self.flux_biases is not None:
                 kwargs[FLUX_BIAS_KWARG] = self.flux_biases
 
-        return child.sample(bqm, **kwargs)
+        return super(VirtualGraphComposite, self).sample(bqm, **kwargs)
 
 
 def _validate_chain_strength(sampler, chain_strength):

--- a/dwave/system/composites/virtual_graph.py
+++ b/dwave/system/composites/virtual_graph.py
@@ -216,6 +216,8 @@ class VirtualGraphComposite(FixedEmbeddingComposite):
             if self.flux_biases is not None:
                 kwargs[FLUX_BIAS_KWARG] = self.flux_biases
 
+        kwargs.setdefault('chain_strength', self.chain_strength)
+
         return super(VirtualGraphComposite, self).sample(bqm, **kwargs)
 
 

--- a/tests/qpu/test_virtual_graph_composite.py
+++ b/tests/qpu/test_virtual_graph_composite.py
@@ -12,7 +12,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #
-# ================================================================================================
+# =============================================================================
 import itertools
 import unittest
 
@@ -24,17 +24,27 @@ from dwave.cloud.exceptions import ConfigFileError
 from dwave.system.composites import VirtualGraphComposite
 from dwave.system.samplers import DWaveSampler
 
-try:
-    DWaveSampler()
-    _config_found = True
-except (ValueError, ConfigFileError):
-    _config_found = False
 
-
-@unittest.skipUnless(_config_found, "no configuration found to connect to a system")
 class TestVirtualGraphComposite(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            cls.qpu = DWaveSampler(solver=dict(qpu=True))
+        except (ValueError, ConfigFileError):
+            cls.qpu = False
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls.qpu:
+            cls.qpu.client.close()
+
+    def setUp(self):
+        if not self.qpu:
+            self.skipTest("no qpu available")
+
     def test_construction(self):
-        child_sampler = DWaveSampler()
+        child_sampler = self.qpu
 
         # get an embedding
         K10_edges = list(itertools.combinations(range(10), 2))
@@ -46,24 +56,9 @@ class TestVirtualGraphComposite(unittest.TestCase):
 
         h = {}
         J = {edge: -1 for edge in K10_edges}
-        sampler.sample_ising(h, J)
 
-        sampler.sample_ising(h, J, apply_flux_bias_offsets=False)
+        # run with fbo
+        sampler.sample_ising(h, J).resolve()
 
-    def test_reverse_annealing(self):
-        child_sampler = DWaveSampler()
-
-        # get an embedding
-        K10_edges = list(itertools.combinations(range(10), 2))
-        embedding = minorminer.find_embedding(K10_edges, child_sampler.edgelist)
-
-        sampler = VirtualGraphComposite(child_sampler, embedding)
-
-        h = {}
-        J = {edge: -1 for edge in K10_edges}
-
-        kwargs = {'initial_state': {v: 0 for v in set().union(*J)},
-                  'anneal_schedule': [(0, 1), (55.0, 0.45), (155.0, 0.45), (210.0, 1)]}
-
-        # sample and resolve
-        sampler.sample_ising(h, J, **kwargs).samples()
+        # and again without
+        sampler.sample_ising(h, J, apply_flux_bias_offsets=False).resolve()


### PR DESCRIPTION
Fixes a chain strength bug and simplifies the code. But the main virtual graph logic still could use some refactoring, and this does not address #104 (though it gets part-way there by subclassing `FixedEmbeddingComposite`).