### PR TITLE
DWaveSampler fixes

### DIFF
--- a/dwave/system/samplers/dwave_sampler.py
+++ b/dwave/system/samplers/dwave_sampler.py
@@ -114,9 +114,7 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
         self.client = Client.from_config(**config)
         self.solver = self.client.get_solver()
 
-        # need to set up the nodelist and edgelist, properties, parameters
-        self._nodelist = sorted(self.solver.nodes)
-        self._edgelist = sorted(set(tuple(sorted(edge)) for edge in self.solver.edges))
+        # need to set up the properties, parameters
         self._properties = self.solver.properties.copy()  # shallow copy
         self._parameters = {param: ['parameters'] for param in self.solver.properties['parameters']}
 
@@ -200,7 +198,13 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
         for explanations of technical terms in descriptions of Ocean tools.
 
         """
-        return self._edgelist
+        # Assumption: cloud client nodes are always integer-labelled
+        try:
+            edgelist = self._edgelist
+        except AttributeError:
+            self._edgelist = edgelist = sorted(set((u, v) if u < v else (v, u)
+                                               for u, v in self.solver.edges))
+        return edgelist
 
     @property
     def nodelist(self):
@@ -223,7 +227,12 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
         for explanations of technical terms in descriptions of Ocean tools.
 
         """
-        return self._nodelist
+        # Assumption: cloud client nodes are always integer-labelled
+        try:
+            nodelist = self._nodelist
+        except AttributeError:
+            self._nodelist = nodelist = sorted(self.solver.nodes)
+        return nodelist
 
     def sample_ising(self, h, J, **kwargs):
         """Sample from the specified Ising model.

--- a/tests/qpu/test_dwavesampler.py
+++ b/tests/qpu/test_dwavesampler.py
@@ -91,4 +91,7 @@ class TestMissingQubits(unittest.TestCase):
         h = [0 for _ in range(2048)]
         J = {edge: 0 for edge in sampler.edgelist}
 
-        sampler.sample_ising(h, J).resolve()
+        sampleset = sampler.sample_ising(h, J)
+
+        self.assertEqual(set(sampleset.variables), set(sampler.nodelist))
+        assert len(sampleset.variables) < 2048  # sanity check

--- a/tests/test_dwavesampler.py
+++ b/tests/test_dwavesampler.py
@@ -12,7 +12,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #
-# ================================================================================================
+# =============================================================================
 import unittest
 import random
 import warnings


### PR DESCRIPTION
The main change is altering the behaviour introduced in #201 (which fixed bug #200) to match the cloud-client's behaviour which does not ignore all the 0 biases, but rather ignores 0 biases on missing qubits.

This makes the sampler inconsistent with `BQM.from_ising` which _does not_ ignore any variables. However
```
sampler.sample_ising([0, 0, 0], {})
```
is a valid use case (wanting to sample randomly from 3 qubits) and should be supported.

Note that we don't (yet) support
```
sampler.sample_ising([0, float('nan'), 0], {})

```
nor
```
sampler.sample_ising(np.asarray([0, np.nan, 0])
```
or numpy arrays at all.