### PR TITLE
Improve error message

### DIFF
--- a/dwave/embedding/chimera.py
+++ b/dwave/embedding/chimera.py
@@ -101,7 +101,7 @@ def find_clique_embedding(k, m, n=None, t=None, target_edges=None):
         embedding = processor(target_edges, M=m, N=n, L=t).tightestNativeClique(len(nodes))
 
     if not embedding:
-        raise ValueError("cannot find a K{} embedding for given Chimera lattice".format(k))
+        raise ValueError("cannot find a K{} embedding for given Chimera lattice".format(len(nodes)))
 
     return dict(zip(nodes, embedding))
 


### PR DESCRIPTION
Currently gives something like this for an iterable, for example BQM.variables:
```
ValueError: cannot find a K(KeysView(<dimod.views.bqm.LinearView object at 0x7f9bee7b0348>), ()) embedding for given Chimera lattice 
```
which would have been clearer as, for example, "cannot find a K8 embedding for given Chimera lattice"
Might also consider showing both: "cannot find a K8 embedding for KeysView(<dimod.views.bqm.LinearView object at 0x7f9bee7b0348>), () for given Chimera lattice"

```
raise ValueError("cannot find a K{} embedding for {} for given Chimera lattice".format(len(nodes), k))
```