### PR TITLE
Catch the correct exception for child_structure_dfs in dimod

### DIFF
--- a/dwave/system/composites/embedding.py
+++ b/dwave/system/composites/embedding.py
@@ -518,7 +518,9 @@ class AutoEmbeddingComposite(EmbeddingComposite):
         def permissive_child_structure(sampler):
             try:
                 return child_search(sampler)
-            except (TypeError, AttributeError):
+            except ValueError:
+                return None
+            except (AttributeError, TypeError):  # support legacy dimod
                 return None
 
         super(AutoEmbeddingComposite, self).__init__(child_sampler,


### PR DESCRIPTION
Should fix the failing tests in https://circleci.com/gh/dwavesystems/dwave-hybrid/2779

https://github.com/dwavesystems/dimod/pull/500 changed `child_structure_dfs` to raise a `ValueError`, this PR updates `AutoEmbeddingComposite` to match.