### PR TITLE
Add embedding to sample sets returned by embedding composites

### DIFF
--- a/dwave/embedding/transforms.py
+++ b/dwave/embedding/transforms.py
@@ -271,7 +271,8 @@ def embed_qubo(source_Q, embedding, target_adjacency, chain_strength=1.0):
 
 
 def unembed_sampleset(target_sampleset, embedding, source_bqm,
-                      chain_break_method=None, chain_break_fraction=False):
+                      chain_break_method=None, chain_break_fraction=False,
+                      return_embedding=True):
     """Unembed a samples set.
 
     Given samples from a target binary quadratic model (BQM), construct a sample
@@ -296,6 +297,11 @@ def unembed_sampleset(target_sampleset, embedding, source_bqm,
         chain_break_fraction (bool, optional, default=False):
             Add a `chain_break_fraction` field to the unembedded :obj:`dimod.SampleSet`
             with the fraction of chains broken before unembedding.
+
+        return_embedding (bool, optional, default=True):
+            If True, the embedding is added to :attr:`dimod.SampleSet.info`
+            of the returned sample set. Note that if an `embedding` key
+            already exists in the sample set then it is overwritten.
 
     Returns:
         :obj:`.SampleSet`: Sample set in the source BQM.
@@ -341,7 +347,12 @@ def unembed_sampleset(target_sampleset, embedding, source_bqm,
     if chain_break_fraction:
         vectors['chain_break_fraction'] = broken_chains(target_sampleset, chains).mean(axis=1)[idxs]
 
+    info = target_sampleset.info.copy()
+
+    if return_embedding:
+        info.update(embedding=embedding)
+
     return dimod.SampleSet.from_samples_bqm((unembedded, variables),
                                             source_bqm,
-                                            info=target_sampleset.info.copy(),
+                                            info=info,
                                             **vectors)

--- a/dwave/system/composites/embedding.py
+++ b/dwave/system/composites/embedding.py
@@ -135,6 +135,7 @@ class EmbeddingComposite(dimod.ComposedSampler):
                chain_break_method=None,
                chain_break_fraction=True,
                embedding_parameters=None,
+               return_embedding=True,
                **parameters):
         """Sample from the provided binary quadratic model.
 
@@ -159,6 +160,10 @@ class EmbeddingComposite(dimod.ComposedSampler):
                 If provided, parameters are passed to the embedding method as
                 keyword arguments. Overrides any `embedding_parameters` passed
                 to the constructor.
+
+            return_embedding (bool, optional, default=True):
+                If True, the embedding is added to :attr:`dimod.SampleSet.info`
+                of the returned sample set.
 
             **parameters:
                 Parameters for the sampling method, specified by the child
@@ -227,7 +232,8 @@ class EmbeddingComposite(dimod.ComposedSampler):
 
         return unembed_sampleset(response, embedding, source_bqm=bqm,
                                  chain_break_method=chain_break_method,
-                                 chain_break_fraction=chain_break_fraction)
+                                 chain_break_fraction=chain_break_fraction,
+                                 return_embedding=return_embedding)
 
 
 class LazyFixedEmbeddingComposite(EmbeddingComposite, dimod.Structured):

--- a/tests/test_embedding_composite.py
+++ b/tests/test_embedding_composite.py
@@ -221,6 +221,19 @@ class TestEmbeddingComposite(unittest.TestCase):
 
         self.assertTrue(ignored == [(1, 2)] or ignored == [(2, 1)])
 
+    def test_return_embedding(self):
+        nodelist = [0, 1, 2]
+        edgelist = [(0, 1), (1, 2), (0, 2)]
+
+        sampler = EmbeddingComposite(
+            dimod.StructureComposite(dimod.NullSampler(), nodelist, edgelist))
+
+        sampleset = sampler.sample_ising({'a': -1}, {'ac': 1})
+
+        self.assertIn('embedding', sampleset.info)
+        embedding = sampleset.info['embedding']
+        self.assertEqual(set(embedding), {'a', 'c'})
+
 
 class TestFixedEmbeddingComposite(unittest.TestCase):
     def test_without_embedding_and_adjacency(self):


### PR DESCRIPTION
Closes #76 

*Additional Context*
I am of two minds about defaulting to True, on the one hand it is pretty harmless to always include it, on the other hand the embedding composite is conceptually supposed to abstract it away totally so it feels like an abstraction break.