### PR TITLE
Default return_embedding parameter to False in EmbeddingComposite

### DIFF
--- a/dwave/embedding/transforms.py
+++ b/dwave/embedding/transforms.py
@@ -272,7 +272,7 @@ def embed_qubo(source_Q, embedding, target_adjacency, chain_strength=1.0):
 
 def unembed_sampleset(target_sampleset, embedding, source_bqm,
                       chain_break_method=None, chain_break_fraction=False,
-                      return_embedding=True):
+                      return_embedding=False):
     """Unembed a samples set.
 
     Given samples from a target binary quadratic model (BQM), construct a sample
@@ -298,7 +298,7 @@ def unembed_sampleset(target_sampleset, embedding, source_bqm,
             Add a `chain_break_fraction` field to the unembedded :obj:`dimod.SampleSet`
             with the fraction of chains broken before unembedding.
 
-        return_embedding (bool, optional, default=True):
+        return_embedding (bool, optional, default=False):
             If True, the embedding is added to :attr:`dimod.SampleSet.info`
             of the returned sample set. Note that if an `embedding` key
             already exists in the sample set then it is overwritten.

--- a/dwave/system/composites/embedding.py
+++ b/dwave/system/composites/embedding.py
@@ -135,7 +135,7 @@ class EmbeddingComposite(dimod.ComposedSampler):
                chain_break_method=None,
                chain_break_fraction=True,
                embedding_parameters=None,
-               return_embedding=True,
+               return_embedding=False,
                **parameters):
         """Sample from the provided binary quadratic model.
 
@@ -161,7 +161,7 @@ class EmbeddingComposite(dimod.ComposedSampler):
                 keyword arguments. Overrides any `embedding_parameters` passed
                 to the constructor.
 
-            return_embedding (bool, optional, default=True):
+            return_embedding (bool, optional, default=False):
                 If True, the embedding is added to :attr:`dimod.SampleSet.info`
                 of the returned sample set.
 

--- a/tests/test_embedding_composite.py
+++ b/tests/test_embedding_composite.py
@@ -228,11 +228,15 @@ class TestEmbeddingComposite(unittest.TestCase):
         sampler = EmbeddingComposite(
             dimod.StructureComposite(dimod.NullSampler(), nodelist, edgelist))
 
-        sampleset = sampler.sample_ising({'a': -1}, {'ac': 1})
+        sampleset = sampler.sample_ising({'a': -1}, {'ac': 1}, return_embedding=True)
 
         self.assertIn('embedding', sampleset.info)
         embedding = sampleset.info['embedding']
         self.assertEqual(set(embedding), {'a', 'c'})
+
+        # default False
+        sampleset = sampler.sample_ising({'a': -1}, {'ac': 1})
+        self.assertNotIn('embedding', sampleset.info)
 
 
 class TestFixedEmbeddingComposite(unittest.TestCase):


### PR DESCRIPTION
See https://github.com/dwavesystems/dwave-system/pull/225#issuecomment-532479158

We have not yet deployed so this is not a backwards compatibility break.