### PR TITLE
Add new composites

### DIFF
--- a/docs/reference/composites.rst
+++ b/docs/reference/composites.rst
@@ -268,9 +268,6 @@ states or anneal schedules.
 ReverseBatchStatesComposite
 ---------------------------
 
-Accepts multiple initial states to initialize from. Each submission is independent from
-one another.
-
 .. autoclass:: ReverseBatchStatesComposite
 
 
@@ -298,9 +295,6 @@ Methods
 
 ReverseAdvanceComposite
 -----------------------
-
-Advances an initial state using reverse annealing along a given set of anneal schedules.
-Initial states are chosen from the previous submission.
 
 .. autoclass:: ReverseAdvanceComposite
 

--- a/docs/reference/composites.rst
+++ b/docs/reference/composites.rst
@@ -259,18 +259,19 @@ Methods
    VirtualGraphComposite.sample_ising
    VirtualGraphComposite.sample_qubo
 
-Reverse
-=======
+Reverse Anneal
+==============
 
-Composites that do batch reverse annealing. Can accept batch initial states or a set
-of schedules.
+Composites that do batch operations for reverse annealing based on sets of initial
+states or anneal schedules.
 
-BatchReverseComposite
----------------------
+ReverseBatchStatesComposite
+---------------------------
 
-Accepts multiple initial states to initialize from.
+Accepts multiple initial states to initialize from. Each submission is independent from
+one another.
 
-.. autoclass:: BatchReverseComposite
+.. autoclass:: ReverseBatchStatesComposite
 
 
 Properties
@@ -279,10 +280,10 @@ Properties
 .. autosummary::
    :toctree: generated/
 
-   BatchReverseComposite.child
-   BatchReverseComposite.children
-   BatchReverseComposite.properties
-   BatchReverseComposite.parameters
+   ReverseBatchStatesComposite.child
+   ReverseBatchStatesComposite.children
+   ReverseBatchStatesComposite.properties
+   ReverseBatchStatesComposite.parameters
 
 
 Methods
@@ -291,15 +292,15 @@ Methods
 .. autosummary::
    :toctree: generated/
 
-   BatchReverseComposite.sample
-   BatchReverseComposite.sample_ising
-   BatchReverseComposite.sample_qubo
+   ReverseBatchStatesComposite.sample
+   ReverseBatchStatesComposite.sample_ising
+   ReverseBatchStatesComposite.sample_qubo
 
 ReverseAdvanceComposite
 -----------------------
 
-Advances an initial state using reverse annealing along a
-given set of anneal schedules.
+Advances an initial state using reverse annealing along a given set of anneal schedules.
+Initial states are chosen from the previous submission.
 
 .. autoclass:: ReverseAdvanceComposite
 

--- a/docs/reference/composites.rst
+++ b/docs/reference/composites.rst
@@ -258,3 +258,69 @@ Methods
    VirtualGraphComposite.sample
    VirtualGraphComposite.sample_ising
    VirtualGraphComposite.sample_qubo
+
+Reverse
+=======
+
+Composites that do batch reverse annealing. Can accept batch initial states or a set
+of schedules.
+
+BatchReverseComposite
+---------------------
+
+Accepts multiple initial states to initialize from.
+
+.. autoclass:: BatchReverseComposite
+
+
+Properties
+~~~~~~~~~~
+
+.. autosummary::
+   :toctree: generated/
+
+   BatchReverseComposite.child
+   BatchReverseComposite.children
+   BatchReverseComposite.properties
+   BatchReverseComposite.parameters
+
+
+Methods
+~~~~~~~
+
+.. autosummary::
+   :toctree: generated/
+
+   BatchReverseComposite.sample
+   BatchReverseComposite.sample_ising
+   BatchReverseComposite.sample_qubo
+
+ReverseAdvanceComposite
+-----------------------
+
+Advances an initial state using reverse annealing along a
+given set of anneal schedules.
+
+.. autoclass:: ReverseAdvanceComposite
+
+Properties
+~~~~~~~~~~
+
+.. autosummary::
+   :toctree: generated/
+
+   ReverseAdvanceComposite.child
+   ReverseAdvanceComposite.children
+   ReverseAdvanceComposite.properties
+   ReverseAdvanceComposite.parameters
+
+
+Methods
+~~~~~~~
+
+.. autosummary::
+   :toctree: generated/
+
+   ReverseAdvanceComposite.sample
+   ReverseAdvanceComposite.sample_ising
+   ReverseAdvanceComposite.sample_qubo

--- a/dwave/system/composites/__init__.py
+++ b/dwave/system/composites/__init__.py
@@ -17,3 +17,4 @@ from dwave.system.composites.cutoffcomposite import *
 from dwave.system.composites.embedding import *
 from dwave.system.composites.tiling import *
 from dwave.system.composites.virtual_graph import *
+from dwave.system.composites.reversecomposite import *

--- a/dwave/system/composites/reversecomposite.py
+++ b/dwave/system/composites/reversecomposite.py
@@ -17,7 +17,11 @@
 Composites that do batch operations for reverse annealing.
 """
 
-import collections
+try:
+    import collections.abc as abc
+except ImportError:
+    import collections as abc
+
 import dimod
 import numpy as np
 
@@ -88,7 +92,7 @@ class ReverseAdvanceComposite(dimod.ComposedSampler):
         else:
             initial_state = parameters.pop('initial_state')
 
-        if not isinstance(initial_state, collections.abc.Mapping):
+        if not isinstance(initial_state, abc.Mapping):
             raise TypeError("initial state provided must be a dict, but received {}".format(initial_state))
 
         if 'reinitialize_state' not in parameters:

--- a/dwave/system/composites/reversecomposite.py
+++ b/dwave/system/composites/reversecomposite.py
@@ -24,11 +24,12 @@ __all__ = 'ReverseAdvanceComposite', 'ReverseBatchStatesComposite'
 
 
 class ReverseAdvanceComposite(dimod.ComposedSampler):
-    """Composite that advances a sample using reverse annealing along a given set of anneal
-        schedules. if reinitialize_state = False is sent in as an argument, the composite will
-        select the last sample returned as the initial_state of the next submission. if not, the
-        composite selects the most probable (highest occurence) lowest energy sample as the
-        initial_state.
+    """Composite that reverse anneals an initial sample through a sequence of anneal
+     schedules. If you don not specify an initial sample, a random sample is used for the first
+     submission. By default, each subsequent submission selects the most-found lowest-energy
+     sample as its initial state. If you set reinitialize_state to False, which makes each submission
+     behave like a random walk, the subsequent submission selects the last returned sample as
+     its initial state.
 
     Args:
        sampler (:obj:`dimod.Sampler`):

--- a/dwave/system/composites/reversecomposite.py
+++ b/dwave/system/composites/reversecomposite.py
@@ -191,14 +191,14 @@ def _update_data_vector(vectors, sampleset,additional_parameters=None):
     var_names = sampleset.record.dtype.names
     for name in var_names:
         try:
-            vectors[name] = [*vectors[name], *sampleset.record[name]]
+            vectors[name] = vectors[name] + list(sampleset.record[name])
         except KeyError:
-            vectors[name] = sampleset.record[name]
+            vectors[name] = list(sampleset.record[name])
 
     for key,val in additional_parameters.items():
         if key not in var_names:
             try:
-                vectors[key] = [*vectors[key], *val]
+                vectors[key] = vectors[key] + list(val)
             except KeyError:
-                vectors[key] = val
+                vectors[key] = list(val)
     return vectors

--- a/dwave/system/composites/reversecomposite.py
+++ b/dwave/system/composites/reversecomposite.py
@@ -49,7 +49,7 @@ class ReverseAdvanceComposite(dimod.ComposedSampler):
     def properties(self):
         return {'child_properties': self.child.properties.copy()}
 
-    def sample(self, bqm, schedules=None, **parameters):
+    def sample(self, bqm, anneal_schedules=None, **parameters):
         """ Composite that advances a sample using reverse annealing along a
         given set of anneal schedules. Always selects the most probable lowest energy sample out of
         the previous steps return
@@ -71,7 +71,7 @@ class ReverseAdvanceComposite(dimod.ComposedSampler):
         """
         child = self.child
 
-        if schedules is None:
+        if anneal_schedules is None:
             return child.sample(bqm, **parameters)
 
         vartype_values = list(bqm.vartype.value)
@@ -80,52 +80,38 @@ class ReverseAdvanceComposite(dimod.ComposedSampler):
         else:
             initial_state = parameters.pop('initial_state')
 
+        if not isinstance(initial_state,dict):
+            raise TypeError("initial state provided must be a dict, received {}".format(initial_state))
+
         if 'reinitialize_state' not in parameters:
             parameters['reinitialize_state'] = True
+            parameters['answer_mode'] = 'histogram'
 
-        # there is gonna be way too much data generated - better to histogram them
-        parameters['answer_mode'] = 'histogram'
-
-        # prepare data fields for the new sampleset object
-        samples = []
-        energy = []
-        num_occurrences = []
-        initial_states = []
-        schedule_idxs = []
-        sample, variables = dimod.as_samples(initial_state)
-        datatypes = [('sample', sample.dtype, (len(variables),)),
-                     ('energy', np.float16),
-                     ('num_occurrences', np.int8),
-                     ('initial_state', sample.dtype, (len(variables),)),
-                     ('schedule_index', np.int8)]
-
-        for schedule_idx, anneal_schedule in enumerate(schedules):
-            sampleset = child.sample(bqm, anneal_schedule=anneal_schedule, initial_state=initial_state,
+        vectors = {}
+        for schedule_idx, anneal_schedule in enumerate(anneal_schedules):
+            sampleset = child.sample(bqm, anneal_schedule=anneal_schedule,initial_state = initial_state,
                                      **parameters)
 
-            # collect data from sampleset object
-            samples = [*samples, *sampleset.record.sample]
-            energy = [*energy, *sampleset.record.energy]
-            num_occurrences = [*num_occurrences, *sampleset.record.num_occurrences]
+            initial_state,_ = dimod.as_samples(initial_state)
+            vectors = _update_data_vector(vectors,sampleset,
+                                           {'initial_state':[initial_state[0]]*len(sampleset.record.energy),
+                                            'schedule_index':[schedule_idx]*len(sampleset.record.energy)})
 
-            initial_state, _ = dimod.as_samples(initial_state)
-            initial_states = [*initial_states, *[initial_state] * len(sampleset.record.energy)]
-            schedule_idxs = [*schedule_idxs, *[schedule_idx] * len(sampleset.record.energy)]
+            if parameters['reinitialize_state']:
+                # if reinitialize is on, choose the lowest energy, most probable state for next iteration
+                gse = sampleset.first.energy
+                b = sampleset.record[sampleset.record.energy == gse]
+                b.sort(order='num_occurrences')
+                initial_state = dict(zip(sampleset.variables, b[-1].sample))
+            else:
+                # if not reinitialized, take the last state as the next initial state
+                initial_state = dict(zip(sampleset.variables, sampleset.record.sample[-1]))
 
-            # initialize the new initial_state as the lowest energy, most probable sample
-            gse = sampleset.first.energy
-            b = sampleset.record[sampleset.record.energy == gse]
-            b.sort(order='num_occurrences')
-            initial_state = dict(zip(sampleset.variables, b[-1].sample))
-
-        record = np.rec.array(np.zeros(len(energy), dtype=datatypes))
-        record['sample'] = samples
-        record['energy'] = energy
-        record['num_occurrences'] = num_occurrences
-        record['schedule_index'] = schedule_idxs
-        record['initial_state'] = initial_states
-
-        return dimod.SampleSet(record, variables, {'schedules': schedules}, bqm.vartype)
+        samples = vectors.pop('sample')
+        return dimod.SampleSet.from_samples((samples, bqm.variables),
+                                bqm.vartype,
+                                info={'anneal_schedules': anneal_schedules},
+                                **vectors)
 
 
 class BatchReverseComposite(dimod.ComposedSampler):
@@ -180,34 +166,39 @@ class BatchReverseComposite(dimod.ComposedSampler):
         parameters['answer_mode'] = 'histogram'
 
         # prepare data fields for the new sampleset object
-        samples = []
-        energy = []
-        num_occurrences = []
-        initial_states_array = []
 
-        datatypes = [('sample', np.int8, (len(bqm),)),
-                     ('energy', np.float16),
-                     ('num_occurrences', np.int8),
-                     ('initial_state', np.int8, (len(bqm),))]
-
+        vectors = {}
         for initial_state in initial_states:
+
             if not isinstance(initial_state, dict):
                 initial_state = dict(zip(bqm.variables, initial_state))
 
             sampleset = child.sample(bqm, initial_state=initial_state, **parameters)
+            initial_state_, _ = dimod.as_samples(initial_state)
+            vectors = _update_data_vector(vectors, sampleset,
+                                          {'initial_state': [initial_state_[0]] * len(sampleset.record.energy)})
 
-            # collect data from sampleset object
-            samples = [*samples, *sampleset.record.sample]
-            energy = [*energy, *sampleset.record.energy]
-            num_occurrences = [*num_occurrences, *sampleset.record.num_occurrences]
+        samples = vectors.pop('sample')
 
-            initial_state, _ = dimod.as_samples(initial_state)
-            initial_states_array = [*initial_states_array, *[initial_state] * len(sampleset.record.energy)]
+        return dimod.SampleSet.from_samples((samples, bqm.variables),
+                                bqm.vartype,
+                                info={},
+                                **vectors)
 
-        record = np.rec.array(np.zeros(len(energy), dtype=datatypes))
-        record['sample'] = samples
-        record['energy'] = energy
-        record['num_occurrences'] = num_occurrences
-        record['initial_state'] = initial_states_array
 
-        return dimod.SampleSet(record, bqm.variables, {}, bqm.vartype)
+def _update_data_vector(vectors, sampleset,additional_parameters=None):
+
+    var_names = sampleset.record.dtype.names
+    for name in var_names:
+        try:
+            vectors[name] = [*vectors[name], *sampleset.record[name]]
+        except KeyError:
+            vectors[name] = sampleset.record[name]
+
+    for key,val in additional_parameters.items():
+        if key not in var_names:
+            try:
+                vectors[key] = [*vectors[key], *val]
+            except KeyError:
+                vectors[key] = val
+    return vectors

--- a/dwave/system/composites/reversecomposite.py
+++ b/dwave/system/composites/reversecomposite.py
@@ -1,0 +1,207 @@
+# Copyright 2019 D-Wave Systems Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+# =============================================================================
+"""
+Composite that do batch operations on initial samples provided for reverse annealing.
+"""
+import dimod
+import numpy as np
+
+__all__ = 'ReverseAdvanceComposite', 'BatchReverseComposite'
+
+
+class ReverseAdvanceComposite(dimod.ComposedSampler):
+    """ Composite that advances a sample using reverse annealing along a
+        given set of anneal schedules.
+
+    Args:
+       sampler (:obj:`dimod.Sampler`):
+            A dimod sampler
+
+    """
+
+    def __init__(self, child_sampler):
+        self._children = [child_sampler]
+
+    @property
+    def children(self):
+        return self._children
+
+    @property
+    def parameters(self):
+        param = self.child.parameters.copy()
+        param['schedules'] = []
+        return param
+
+    @property
+    def properties(self):
+        return {'child_properties': self.child.properties.copy()}
+
+    def sample(self, bqm, schedules=None, **parameters):
+        """ Composite that advances a sample using reverse annealing along a
+        given set of anneal schedules. Always selects the most probable lowest energy sample out of
+        the previous steps return
+
+        Args:
+            bqm (:obj:`dimod.BinaryQuadraticModel`):
+                Binary quadratic model to be sampled from.
+
+            schedules (list): an ordered list of anneal schedules. The first element of the
+                list should correspond to the first anneal schedule.
+
+            **parameters:
+                Parameters for the sampling method, specified by the child sampler.
+
+        Returns:
+            :obj:`dimod.SampleSet` that has initial_state and schedule_index fields in addition to
+            'energy' and 'num_occurrences'
+
+        """
+        child = self.child
+
+        vartype_values = list(bqm.vartype.value)
+        if 'initial_state' not in parameters:
+            initial_state = dict(zip(list(bqm.variables), np.random.choice(vartype_values, len(bqm))))
+        else:
+            initial_state = parameters.pop('initial_state')
+
+        if 'reinitialize_state' not in parameters:
+            parameters['reinitialize_state'] = True
+            parameters['answer_mode'] = 'histogram'
+
+        # prepare data fields for the new sampleset object
+        samples = []
+        energy = []
+        num_occurrences = []
+        initial_states = []
+        schedule_idxs = []
+        sample, variables = dimod.as_samples(initial_state)
+        datatypes = [('sample', sample.dtype, (len(variables),)),
+                     ('energy', np.float16),
+                     ('num_occurrences', np.int8),
+                     ('initial_state', sample.dtype, (len(variables),)),
+                     ('schedule_index', np.int8)]
+
+        for schedule_idx, anneal_schedule in enumerate(schedules):
+            sampleset = child.sample(bqm, anneal_schedule=anneal_schedule, initial_state=initial_state,
+                                     **parameters)
+
+            # collect data from sampleset object
+            samples = [*samples, *sampleset.record.sample]
+            energy = [*energy, *sampleset.record.energy]
+            num_occurrences = [*num_occurrences, *sampleset.record.num_occurrences]
+
+            initial_state, _ = dimod.as_samples(initial_state)
+            initial_states = [*initial_states, *[initial_state] * len(sampleset.record.energy)]
+            schedule_idxs = [*schedule_idxs, *[schedule_idx] * len(sampleset.record.energy)]
+
+            # initialize the new initial_state as the lowest energy, most probable sample
+            gse = sampleset.first.energy
+            b = sampleset.record[sampleset.record.energy == gse]
+            b.sort(order='num_occurrences')
+            initial_state = dict(zip(sampleset.variables, b[-1].sample))
+
+        record = np.rec.array(np.zeros(len(energy), dtype=datatypes))
+        record['sample'] = samples
+        record['energy'] = energy
+        record['num_occurrences'] = num_occurrences
+        record['schedule_index'] = schedule_idxs
+        record['initial_state'] = initial_states
+
+        return dimod.SampleSet(record, variables, {'schedules': schedules}, bqm.vartype)
+
+
+class BatchReverseComposite(dimod.ComposedSampler):
+    """ Composite that accepts multiple samples to initialize from.
+
+    Args:
+       sampler (:obj:`dimod.Sampler`):
+            A dimod sampler
+
+    """
+
+    def __init__(self, child_sampler):
+        self._children = [child_sampler]
+
+    @property
+    def children(self):
+        return self._children
+
+    @property
+    def parameters(self):
+        param = self.child.parameters.copy()
+        param['initial_states'] = []
+        return param
+
+    @property
+    def properties(self):
+        return {'child_properties': self.child.properties.copy()}
+
+    def sample(self, bqm, schedules=None, **parameters):
+        """ Composite that accepts multiple initial states to reverse annealing from
+
+        Args:
+            bqm (:obj:`dimod.BinaryQuadraticModel`):
+                Binary quadratic model to be sampled from.
+
+            **parameters:
+                Parameters for the sampling method, specified by the child sampler.
+
+        Returns:
+            :obj:`dimod.SampleSet` that has initial_state and schedule_index fields in addition to
+            'energy' and 'num_occurrences'
+
+        """
+        child = self.child
+
+        vartype_values = list(bqm.vartype.value)
+        if 'initial_states' not in parameters:
+            return child.sample(bqm, **parameters)
+
+        # there is gonna be way too much data generated - better to histogram them
+        parameters['answer_mode'] = 'histogram'
+
+        # prepare data fields for the new sampleset object
+        samples = []
+        energy = []
+        num_occurrences = []
+        initial_states = []
+
+        datatypes = [('sample', np.int8, (len(bqm),)),
+                     ('energy', np.float16),
+                     ('num_occurrences', np.int8),
+                     ('initial_state', np.int8, (len(bqm),))]
+
+        for initial_state in initial_states:
+            if not isinstance(initial_state, dict):
+                initial_state = dict(zip(bqm.variables, initial_state))
+
+            sampleset = child.sample(bqm, initial_state=initial_state, **parameters)
+
+            # collect data from sampleset object
+            samples = [*samples, *sampleset.record.sample]
+            energy = [*energy, *sampleset.record.energy]
+            num_occurrences = [*num_occurrences, *sampleset.record.num_occurrences]
+
+            initial_state, _ = dimod.as_samples(initial_state)
+            initial_states = [*initial_states, *[initial_state] * len(sampleset.record.energy)]
+
+        record = np.rec.array(np.zeros(len(energy), dtype=datatypes))
+        record['sample'] = samples
+        record['energy'] = energy
+        record['num_occurrences'] = num_occurrences
+        record['initial_state'] = initial_states
+
+        return dimod.SampleSet(record, bqm.variables, {}, bqm.vartype)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 
 dimod==0.8.15
 dwave-cloud-client==0.6.1
-dwave-networkx==0.8.1
+dwave-networkx==0.8.2
 dwave-drivers==0.4.2
 homebase==1.0.1
 minorminer==0.1.8

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ else:
 
 install_requires = ['dimod>=0.8.13,<0.9.0',
                     'dwave-cloud-client>=0.6.0,<0.7.0',
-                    'dwave-networkx>=0.8.0',
+                    'dwave-networkx>=0.8.2',
                     'networkx>=2.0,<3.0',
                     'homebase>=1.0.0,<2.0.0',
                     'minorminer>=0.1.3,<0.2.0',

--- a/tests/test_reverse_composite.py
+++ b/tests/test_reverse_composite.py
@@ -1,0 +1,212 @@
+# Copyright 2019 D-Wave Systems Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+# =============================================================================
+import unittest
+
+import dimod
+import dimod.testing as dtest
+import dwave_networkx
+from dimod import ExactSolver
+
+from dwave.system import BatchReverseComposite, ReverseAdvanceComposite
+
+C4 = dwave_networkx.chimera_graph(4, 4, 4)
+
+
+class MockReverseSampler(dimod.Sampler, dimod.Structured):
+    nodelist = None
+    edgelist = None
+    properties = None
+    parameters = None
+
+    def __init__(self, broken_nodes=None):
+        if broken_nodes is None:
+            self.nodelist = sorted(C4.nodes)
+            self.edgelist = sorted(sorted(edge) for edge in C4.edges)
+        else:
+            self.nodelist = sorted(v for v in C4.nodes if v not in broken_nodes)
+            self.edgelist = sorted(sorted((u, v)) for u, v in C4.edges
+                                   if u not in broken_nodes and v not in broken_nodes)
+
+        # mark the sample kwargs
+        self.parameters = parameters = {}
+        parameters['num_reads'] = []
+        parameters['initial_state'] = []
+        parameters['reinitialize_state'] = []
+        parameters['anneal_schedule'] = []
+
+        # add the interesting properties manually
+        self.properties = properties = {}
+        properties['j_range'] = [-2.0, 1.0]
+        properties['h_range'] = [-2.0, 2.0]
+        properties['num_reads_range'] = [1, 10000]
+        properties['num_qubits'] = len(C4)
+
+    @dimod.bqm_structured
+    def sample(self, bqm, **parameters):
+        # we are altering the bqm
+        return ExactSolver().sample(bqm)
+
+
+class TestConstruction(unittest.TestCase):
+    def test_instantiation_smoketest_advance(self):
+        sampler = ReverseAdvanceComposite(dimod.ExactSolver())
+        dtest.assert_sampler_api(sampler)
+
+    def test_instantiation_smoketest_batch(self):
+        sampler = BatchReverseComposite(dimod.ExactSolver())
+        dtest.assert_sampler_api(sampler)
+
+
+class TestReverseIsing(unittest.TestCase):
+    def test_sample_ising_batch(self):
+        sampler = BatchReverseComposite(MockReverseSampler())
+
+        h = {0: -1., 4: 2}
+        J = {(0, 4): 1.5}
+
+        response = sampler.sample_ising(h, J, initial_states=[{0: 1, 4: 1}, {0: -1, 4: -1}, {0: 1, 4: -1}])
+
+        # nothing failed and we got at least three responses back for each initial state
+        self.assertGreaterEqual(len(response), 3)
+
+    def test_sample_ising_advance(self):
+        sampler = ReverseAdvanceComposite(MockReverseSampler())
+
+        h = {0: -1., 4: 2}
+        J = {(0, 4): 1.5}
+        schedules = [[[0, 1], [1, 0.5], [2, 0.5], [3, 1]], [[0, 1], [1, 0.5], [2, 0.5], [3, 1]]]
+        response = sampler.sample_ising(h, J, anneal_schedules=schedules)
+
+        # nothing failed and we got at least two response back for each schedule point
+        self.assertGreaterEqual(len(response), 2)
+
+    def test_batch_correct_states(self):
+        sampler = BatchReverseComposite(MockReverseSampler())
+
+        h = {0: -1., 4: 2}
+        J = {(0, 4): 1.5}
+        initial_states = [{0: 1, 4: 1}, {0: -1, 4: -1}, {0: 1, 4: -1}]
+        response = sampler.sample_ising(h, J, initial_states=initial_states)
+
+        variables = response.variables
+        initial_state_list = response.record.initial_state
+
+        for state in initial_states:
+            state = [state[var] for var in variables]
+            self.assertIn(state, initial_state_list)
+
+    def test_advance_correct_schedules(self):
+        sampler = ReverseAdvanceComposite(MockReverseSampler())
+
+        h = {0: -1., 4: 2}
+        J = {(0, 4): 1.5}
+        anneal_schedules = [[[0, 1], [1, 0.5], [2, 0.5], [3, 1]], [[0, 1], [1, 0.5], [2, 0.5], [3, 1]]]
+        response = sampler.sample_ising(h, J, anneal_schedules=anneal_schedules)
+
+        anneal_schedule_list = response.record.schedule_index
+
+        for schedule_idx in range(len(anneal_schedules)):
+            self.assertIn(schedule_idx, anneal_schedule_list)
+
+    def test_correct_initial_state_input(self):
+        sampler = ReverseAdvanceComposite(MockReverseSampler())
+
+        h = {0: -1., 4: 2}
+        J = {(0, 4): 1.5}
+        anneal_schedules = [[[0, 1], [1, 0.5], [2, 0.5], [3, 1]], [[0, 1], [1, 0.5], [2, 0.5], [3, 1]]]
+
+        with self.assertRaises(TypeError):
+            response = sampler.sample_ising(h, J, anneal_schedules=anneal_schedules,
+                                            initial_state=[1, 1])
+
+    def test_correct_initial_state_used(self):
+        sampler = ReverseAdvanceComposite(MockReverseSampler())
+
+        h = {0: -1., 4: 2}
+        J = {(0, 4): 1.5}
+        anneal_schedules = [[[0, 1], [1, 0.5], [2, 0.5], [3, 1]], [[0, 1], [1, 0.5], [2, 0.5], [3, 1]]]
+        initial = {0: -1, 4: -1}
+        response = sampler.sample_ising(h, J, anneal_schedules=anneal_schedules,
+                                        initial_state=initial)
+
+        vars = response.variables
+        for datum in response.data(fields=['initial_state', 'schedule_index']):
+            if datum.schedule_index == 0:
+                self.assertListEqual([initial[v] for v in vars], list(datum.initial_state))
+            if datum.schedule_index > 1:
+                self.assertListEqual([1, -1], list(datum.initial_state))
+
+    def test_correct_initial_state_used_reinit(self):
+        sampler = ReverseAdvanceComposite(MockReverseSampler())
+
+        h = {0: -1., 4: 2}
+        J = {(0, 4): 1.5}
+        anneal_schedules = [[[0, 1], [1, 0.5], [2, 0.5], [3, 1]], [[0, 1], [1, 0.5], [2, 0.5], [3, 1]]]
+        initial = {0: -1, 4: -1}
+        response = sampler.sample_ising(h, J, anneal_schedules=anneal_schedules,
+                                        initial_state=initial, reinitialize_state=False)
+
+        vars = response.variables
+        for datum in response.data(fields=['initial_state', 'schedule_index']):
+            if datum.schedule_index == 0:
+                self.assertListEqual([initial[v] for v in vars], list(datum.initial_state))
+            if datum.schedule_index > 1:
+                self.assertListEqual([-1, 1], list(datum.initial_state))
+
+    def test_combination(self):
+        sampler = BatchReverseComposite(ReverseAdvanceComposite(MockReverseSampler()))
+
+        h = {0: -1., 4: 2}
+        J = {(0, 4): 1.5}
+        anneal_schedules = [[[0, 1], [1, 0.5], [2, 0.5], [3, 1]], [[0, 1], [1, 0.5], [2, 0.5], [3, 1]]]
+        initial_states = [{0: 1, 4: 1}, {0: -1, 4: -1}, {0: 1, 4: -1}]
+        response = sampler.sample_ising(h, J, anneal_schedules=anneal_schedules, initial_states=initial_states)
+
+        anneal_schedule_list = response.record.schedule_index
+        variables = response.variables
+        initial_state_list = response.record.initial_state
+
+        for state in initial_states:
+            state = [state[var] for var in variables]
+            self.assertIn(state, initial_state_list)
+
+        for state_idx in range(len(anneal_schedules)):
+            self.assertIn(state_idx, anneal_schedule_list)
+
+        self.assertGreaterEqual(len(response), 6)
+
+
+class TestReverseBinary(unittest.TestCase):
+    def test_sample_qubo_batch(self):
+        sampler = BatchReverseComposite(MockReverseSampler())
+
+        Q = {(0, 4): 1.5}
+
+        response = sampler.sample_qubo(Q, initial_states=[{0: 1, 4: 1}, {0: 0, 4: 0}, {0: 1, 4: 0}])
+
+        # nothing failed and we got at least three responses back for each initial state
+        self.assertGreaterEqual(len(response), 3)
+
+    def test_sample_qubo_advance(self):
+        sampler = ReverseAdvanceComposite(MockReverseSampler())
+
+        h = {0: -1., 4: 2}
+        J = {(0, 4): 1.5}
+        schedules = [[[0, 1], [1, 0.5], [2, 0.5], [3, 1]], [[0, 1], [1, 0.5], [2, 0.5], [3, 1]]]
+        response = sampler.sample_ising(h, J, schedules=schedules)
+
+        # nothing failed and we got at least two response back for each schedule point
+        self.assertGreaterEqual(len(response), 2)

--- a/tests/test_reverse_composite.py
+++ b/tests/test_reverse_composite.py
@@ -20,7 +20,7 @@ import dimod.testing as dtest
 import dwave_networkx
 from dimod import ExactSolver
 
-from dwave.system import BatchReverseComposite, ReverseAdvanceComposite
+from dwave.system import ReverseBatchStatesComposite, ReverseAdvanceComposite
 
 C4 = dwave_networkx.chimera_graph(4, 4, 4)
 
@@ -66,13 +66,13 @@ class TestConstruction(unittest.TestCase):
         dtest.assert_sampler_api(sampler)
 
     def test_instantiation_smoketest_batch(self):
-        sampler = BatchReverseComposite(dimod.ExactSolver())
+        sampler = ReverseBatchStatesComposite(dimod.ExactSolver())
         dtest.assert_sampler_api(sampler)
 
 
 class TestReverseIsing(unittest.TestCase):
     def test_sample_ising_batch(self):
-        sampler = BatchReverseComposite(MockReverseSampler())
+        sampler = ReverseBatchStatesComposite(MockReverseSampler())
 
         h = {0: -1., 4: 2}
         J = {(0, 4): 1.5}
@@ -94,7 +94,7 @@ class TestReverseIsing(unittest.TestCase):
         self.assertGreaterEqual(len(response), 2)
 
     def test_batch_correct_states(self):
-        sampler = BatchReverseComposite(MockReverseSampler())
+        sampler = ReverseBatchStatesComposite(MockReverseSampler())
 
         h = {0: -1., 4: 2}
         J = {(0, 4): 1.5}
@@ -167,7 +167,7 @@ class TestReverseIsing(unittest.TestCase):
                 self.assertListEqual([-1, 1], list(datum.initial_state))
 
     def test_combination(self):
-        sampler = BatchReverseComposite(ReverseAdvanceComposite(MockReverseSampler()))
+        sampler = ReverseBatchStatesComposite(ReverseAdvanceComposite(MockReverseSampler()))
 
         h = {0: -1., 4: 2}
         J = {(0, 4): 1.5}
@@ -191,7 +191,7 @@ class TestReverseIsing(unittest.TestCase):
 
 class TestReverseBinary(unittest.TestCase):
     def test_sample_qubo_batch(self):
-        sampler = BatchReverseComposite(MockReverseSampler())
+        sampler = ReverseBatchStatesComposite(MockReverseSampler())
 
         Q = {(0, 4): 1.5}
 


### PR DESCRIPTION
Adding two new composites. 
1) `BatchReverseComposite`. that takes in `initial_states `and samples from all of the initial states.
2) `ReverseAdvanceComposite`. takes in `anneal_schedules `and a single `initial_state` (generates a random one if not provided) and does a series of reverse anneal along the given schedule points. The next initial state is chosen such that if `reinitialize_state = True`, it will be the lowest energy most probable state. If `reinitialize_state = False`, the last state returned will be initial state for the next schedule point. 