### PR TITLE
Prototype warning generation in EmbeddingComposite

### DIFF
--- a/docs/reference/composites.rst
+++ b/docs/reference/composites.rst
@@ -128,6 +128,7 @@ Properties
    EmbeddingComposite.parameters
    EmbeddingComposite.properties
    EmbeddingComposite.return_embedding_default
+   EmbeddingComposite.warnings_default
 
 Methods
 ~~~~~~~

--- a/dwave/system/composites/embedding.py
+++ b/dwave/system/composites/embedding.py
@@ -246,6 +246,8 @@ class EmbeddingComposite(dimod.ComposedSampler):
 
         response = child.sample(bqm_embedded, **parameters)
 
+        warninghandler.chain_break(response, embedding)
+
         sampleset = unembed_sampleset(response, embedding, source_bqm=bqm,
                                       chain_break_method=chain_break_method,
                                       chain_break_fraction=chain_break_fraction,

--- a/dwave/system/composites/embedding.py
+++ b/dwave/system/composites/embedding.py
@@ -33,7 +33,7 @@ import minorminer
 
 from dwave.embedding import (target_to_source, unembed_sampleset, embed_bqm,
                              chain_to_quadratic)
-from dwave.system.warnings import WarningHandler
+from dwave.system.warnings import WarningHandler, WarningAction
 
 __all__ = ('EmbeddingComposite',
            'FixedEmbeddingComposite',
@@ -137,6 +137,10 @@ class EmbeddingComposite(dimod.ComposedSampler):
     kwarg.
     """
 
+    warnings_default = WarningAction.IGNORE
+    """Defines the default behabior for :meth:`.sample`'s `warnings` kwarg.
+    """
+
     def sample(self, bqm, chain_strength=1.0,
                chain_break_method=None,
                chain_break_fraction=True,
@@ -175,6 +179,12 @@ class EmbeddingComposite(dimod.ComposedSampler):
                 by :attr:`return_embedding_default`, which itself defaults to
                 False.
 
+            warnings (:class:`~dwave.system.warnings.WarningAction`, optional):
+                Defines what warning action to take, if any. See
+                :mod:`~dwave.system.warnings`. The default behaviour is defined
+                by :attr:`warnings_default`, which itself defaults to
+                :class:`~dwave.system.warnings.IGNORE`
+
             **parameters:
                 Parameters for the sampling method, specified by the child
                 sampler.
@@ -212,6 +222,9 @@ class EmbeddingComposite(dimod.ComposedSampler):
 
         embedding = self.find_embedding(source_edgelist, target_edgelist,
                                         **embedding_parameters)
+
+        if warnings is None:
+            warnings = self.warnings_default
 
         warninghandler = WarningHandler(warnings)
 

--- a/dwave/system/warnings.py
+++ b/dwave/system/warnings.py
@@ -13,12 +13,15 @@
 #    limitations under the License.
 #
 # =============================================================================
-from enum import Enum
+import enum
+import logging
 
 import six
 
+from dwave.embedding import broken_chains
 
-class WarningAction(Enum):
+
+class WarningAction(enum.Enum):
     IGNORE = 'ignore'
     SAVE = 'save'
 
@@ -31,6 +34,14 @@ IGNORE = WarningAction.IGNORE
 SAVE = WarningAction.SAVE
 # LOG = WarningAction.LOG
 # RAISE = WarningAction.RAISE
+
+
+class ChainBreakWarning(UserWarning):
+    pass
+
+
+class ChainLengthWarning(UserWarning):
+    pass
 
 
 class WarningHandler(object):
@@ -49,32 +60,91 @@ class WarningHandler(object):
         self.action = action
 
     # todo: let user override __init__ parameters with kwargs
-    def issue(self, msg, func=None):
+    def issue(self, msg, category=None, func=None, level=logging.WARNING,
+              data=None):
         """Issue a warning.
 
         Args:
-            msg (str): The warning message
+            msg (str):
+                The warning message
+
+            category (Warning):
+                The warning category class. Defaults to UserWarning.
+
+            level (int):
+                The level of warning severity. Uses the logging warning levels.
+
             func (function):
                 A function that is executed in the case that the warning level
-                is not IGNORE. The warning is issued only if the function
-                returns True. This is used to lazily execute expensive tests.
+                is not IGNORE. The function should return a 2-tuple containing
+                a bool specifying whether the warning should be saved/raised
+                and any relevent data associated with the warning as a
+                dictionary/None. This overrides anything provided in the `data`
+                kwarg.
+
+            data (dict):
+                Any data relevent to the warning.
 
         """
 
         if self.action is IGNORE:
             return
-        elif (func is not None and not func()):
-            # func condition was not met so do nothing
-            return
-        elif self.action is SAVE:
-            self.saved.append(msg)
+
+        if func is not None:
+            valid, data = func()
+            if not valid:
+                return
+
+        if category is None:
+            category = UserWarning
+
+        if data is None:
+            data = {}
+
+        if self.action is SAVE:
+            self.saved.append(dict(type=category,
+                                   message=msg,
+                                   level=level,
+                                   data=data))
         else:
             raise TypeError("unknown action")
 
-    # some hard-coded warnings for convenience
+    # some hard-coded warnings for convenience or for expensive operations
 
     def chain_length(self, embedding, length=7):
-        def func():
-            return any(len(chain) > length for chain in embedding.values())
+        if self.action is IGNORE:
+            return
 
-        self.issue('chain length greater than {}'.format(length), func)
+        for v, chain in embedding.items():
+            if len(chain) <= length:
+                continue
+
+            self.issue("chain length greater than {}".format(length),
+                       category=ChainLengthWarning,
+                       data=dict(target_variables=chain,
+                                 source_variables=[v]),
+                       )
+
+    def chain_break(self, sampleset, embedding):
+        if self.action is IGNORE:
+            return
+
+        ground = sampleset.lowest()
+        variables = list(embedding)
+        chains = [embedding[v] for v in variables]
+        broken = broken_chains(ground, chains)
+
+        if not (len(sampleset) and broken.any()):
+            return
+
+        for nc, chain in enumerate(chains):
+            for row in range(broken.shape[0]):
+                if not broken[row, nc]:
+                    continue
+
+                self.issue("a chain is broken in the lowest energy samples found",
+                           category=ChainBreakWarning,
+                           level=logging.ERROR,
+                           data=dict(target_variables=chain,
+                                     source_variables=[variables[nc]]),
+                           )

--- a/dwave/system/warnings.py
+++ b/dwave/system/warnings.py
@@ -1,0 +1,80 @@
+# Copyright 2019 D-Wave Systems Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+# =============================================================================
+from enum import Enum
+
+import six
+
+
+class WarningAction(Enum):
+    IGNORE = 'ignore'
+    SAVE = 'save'
+
+    # we may eventually want to support logging and raising python Warnings
+    # LOG = 'log'
+    # RAISE = 'raise'
+
+
+IGNORE = WarningAction.IGNORE
+SAVE = WarningAction.SAVE
+# LOG = WarningAction.LOG
+# RAISE = WarningAction.RAISE
+
+
+class WarningHandler(object):
+    def __init__(self, action=None):
+        self.saved = []
+
+        if action is None:
+            action = WarningAction.IGNORE
+        elif isinstance(action, WarningAction):
+            pass
+        elif isinstance(action, six.string_types):
+            action = WarningAction[action.upper()]
+        else:
+            raise TypeError('unknown warning action provided')
+
+        self.action = action
+
+    # todo: let user override __init__ parameters with kwargs
+    def issue(self, msg, func=None):
+        """Issue a warning.
+
+        Args:
+            msg (str): The warning message
+            func (function):
+                A function that is executed in the case that the warning level
+                is not IGNORE. The warning is issued only if the function
+                returns True. This is used to lazily execute expensive tests.
+
+        """
+
+        if self.action is IGNORE:
+            return
+        elif (func is not None and not func()):
+            # func condition was not met so do nothing
+            return
+        elif self.action is SAVE:
+            self.saved.append(msg)
+        else:
+            raise TypeError("unknown action")
+
+    # some hard-coded warnings for convenience
+
+    def chain_length(self, embedding, length=7):
+        def func():
+            return any(len(chain) > length for chain in embedding.values())
+
+        self.issue('chain length greater than {}'.format(length), func)

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,9 @@ install_requires = ['dimod>=0.8.13,<0.9.0',
                     'numpy>=1.14.0,<2.0.0',
                     ]
 
-extras_require = {'drivers': ['dwave-drivers>=0.4.0,<0.5.0']}
+extras_require = {'drivers': ['dwave-drivers>=0.4.0,<0.5.0'],
+                  ':python_version <= "3.3"': ['enum34>=1.1.6,<2.0.0'],
+                  }
 
 packages = ['dwave',
             'dwave.embedding',

--- a/tests/test_embedding_composite.py
+++ b/tests/test_embedding_composite.py
@@ -280,7 +280,7 @@ class TestEmbeddingComposite(unittest.TestCase):
         G = dnx.chimera_graph(12)
 
         sampler = EmbeddingComposite(
-            dimod.StructureComposite(dimod.NullSampler(), G.nodes, G.edges))
+            dimod.StructureComposite(dimod.RandomSampler(), G.nodes, G.edges))
 
         # this will need chains lengths > 7
         J = {uv: -1 for uv in itertools.combinations(range(40), 2)}
@@ -288,7 +288,6 @@ class TestEmbeddingComposite(unittest.TestCase):
         ss = sampler.sample_ising({}, J, warnings='SAVE')
 
         self.assertIn('warnings', ss.info)
-        self.assertIn('chain length greater than 7', ss.info['warnings'])
 
 
 class TestFixedEmbeddingComposite(unittest.TestCase):

--- a/tests/test_embedding_composite.py
+++ b/tests/test_embedding_composite.py
@@ -13,6 +13,7 @@
 #    limitations under the License.
 #
 # =============================================================================
+import itertools
 import unittest
 import warnings
 
@@ -274,6 +275,20 @@ class TestEmbeddingComposite(unittest.TestCase):
 
         # restore the default
         EmbeddingComposite.return_embedding_default = False
+
+    def test_warnings(self):
+        G = dnx.chimera_graph(12)
+
+        sampler = EmbeddingComposite(
+            dimod.StructureComposite(dimod.NullSampler(), G.nodes, G.edges))
+
+        # this will need chains lengths > 7
+        J = {uv: -1 for uv in itertools.combinations(range(40), 2)}
+
+        ss = sampler.sample_ising({}, J, warnings='SAVE')
+
+        self.assertIn('warnings', ss.info)
+        self.assertIn('chain length greater than 7', ss.info['warnings'])
 
 
 class TestFixedEmbeddingComposite(unittest.TestCase):

--- a/tests/test_embedding_composite.py
+++ b/tests/test_embedding_composite.py
@@ -289,6 +289,23 @@ class TestEmbeddingComposite(unittest.TestCase):
 
         self.assertIn('warnings', ss.info)
 
+    def test_warnings_as_class_variable(self):
+        G = dnx.chimera_graph(12)
+
+        sampler = EmbeddingComposite(
+            dimod.StructureComposite(dimod.RandomSampler(), G.nodes, G.edges))
+
+        # this will need chains lengths > 7
+        J = {uv: -1 for uv in itertools.combinations(range(40), 2)}
+
+        EmbeddingComposite.warnings_default = 'SAVE'
+
+        ss = sampler.sample_ising({}, J)
+
+        self.assertIn('warnings', ss.info)
+
+        EmbeddingComposite.warnings_default = 'IGNORE'  # restore default
+
 
 class TestFixedEmbeddingComposite(unittest.TestCase):
     def test_without_embedding_and_adjacency(self):


### PR DESCRIPTION
An extremely early prototype implementation of a way we might want to handle warning raising in dwave-system package.

This does not currently support:
* ~~warning types~~
* ~~a warning severity indicator~~
* ~~references to the relevant samples/chains~~