### PR TITLE
have to close client threads

### DIFF
--- a/dwave/system/samplers/dwave_sampler.py
+++ b/dwave/system/samplers/dwave_sampler.py
@@ -79,7 +79,7 @@ def _failover(f):
     return wrapper
 
 
-class DWaveSampler2(dimod.Sampler, dimod.Structured):
+class DWaveSampler(dimod.Sampler, dimod.Structured):
     """A class for using the D-Wave system as a sampler.
 
     Uses parameters set in a configuration file, as environment variables, or

--- a/dwave/system/samplers/dwave_sampler.py
+++ b/dwave/system/samplers/dwave_sampler.py
@@ -163,6 +163,8 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
 
         self.failover = failover
         self.retry_interval = retry_interval
+    def __del__(self):
+        self.client.close()
 
     @property
     def properties(self):

--- a/dwave/system/samplers/dwave_sampler.py
+++ b/dwave/system/samplers/dwave_sampler.py
@@ -79,7 +79,7 @@ def _failover(f):
     return wrapper
 
 
-class DWaveSampler(dimod.Sampler, dimod.Structured):
+class DWaveSampler2(dimod.Sampler, dimod.Structured):
     """A class for using the D-Wave system as a sampler.
 
     Uses parameters set in a configuration file, as environment variables, or


### PR DESCRIPTION
I faced a problem that 'You can't create a new thread'.
The library 'dwave-system' have client.close(), but DWaveSampler didn't close threads.
Sorry, but I think you may have to add this pull request.