### PR TITLE
Register non-OSS dependancy as a contrib package for `dwave install`

### DIFF
--- a/dwave/system/package_info.py
+++ b/dwave/system/package_info.py
@@ -19,3 +19,18 @@ __version__ = '0.8.1'
 __author__ = 'D-Wave Systems Inc.'
 __authoremail__ = 'acondello@dwavesys.com'
 __description__ = 'All things D-Wave System.'
+
+
+# register the non-open-source packages required for dwave-drivers to work
+contrib = [{
+    'name': 'drivers',
+    'title': 'D-Wave Drivers',
+    'description': 'These drivers enable some automated performance-tuning features.',
+    'license': {
+        'name': 'D-Wave EULA',
+        'url': 'https://docs.ocean.dwavesys.com/eula',
+    },
+    'requirements': [
+        'dwave-drivers>=0.4.4',
+    ]
+}]

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,11 @@ setup(
     url='https://github.com/dwavesystems/dwave-system',
     license='Apache 2.0',
     packages=packages,
+    entry_points={
+        'dwave_contrib': [
+            'dwave-system = dwave.system.package_info:contrib'
+        ]
+    },
     install_requires=install_requires,
     extras_require=extras_require,
     zip_safe=False

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,9 @@ install_requires = ['dimod>=0.8.20',
                     'numpy>=1.14.0,<2.0.0',
                     ]
 
+# NOTE: dwave-drivers can also be installed with `dwave install drivers`,
+# and the exact requirements for `drivers` contrib package are defined in
+# `dwave.system.package_info`, the `contrib` dict.
 extras_require = {'drivers': ['dwave-drivers>=0.4.0,<0.5.0'],
                   ':python_version <= "3.3"': ['enum34>=1.1.6,<2.0.0'],
                   }


### PR DESCRIPTION
For details on dwave contrib mechanism, check dwave-cloud-client#363.