### PR TITLE
Naive fix of floating point error in validate anneal. Added test.

### DIFF
--- a/dwave/system/samplers/dwave_sampler.py
+++ b/dwave/system/samplers/dwave_sampler.py
@@ -533,11 +533,7 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
         # finally check the slope abs(slope) < 1/min_anneal_time
         max_slope = 1.0 / min_anneal_time
         for (t0, s0), (t1, s1) in zip(anneal_schedule, anneal_schedule[1:]):
-            pct0 = int(s0*100)
-            pct1 = int(s1*100)
-            t0_ns = int(t0*100)
-            t1_ns = int(t1*100)
-            if abs((pct0 - pct1) / (t0_ns - t1_ns)) > max_slope:
+            if round(abs((s0 - s1) / (t0 - t1)),10) > max_slope:
                 raise ValueError("the maximum slope cannot exceed {}".format(max_slope))
 
 

--- a/dwave/system/samplers/dwave_sampler.py
+++ b/dwave/system/samplers/dwave_sampler.py
@@ -533,7 +533,11 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
         # finally check the slope abs(slope) < 1/min_anneal_time
         max_slope = 1.0 / min_anneal_time
         for (t0, s0), (t1, s1) in zip(anneal_schedule, anneal_schedule[1:]):
-            if abs((s0 - s1) / (t0 - t1)) > max_slope:
+            pct0 = int(s0*100)
+            pct1 = int(s1*100)
+            t0_ns = int(t0*100)
+            t1_ns = int(t1*100)
+            if abs((pct0 - pct1) / (t0_ns - t1_ns)) > max_slope:
                 raise ValueError("the maximum slope cannot exceed {}".format(max_slope))
 
 

--- a/tests/test_dwavesampler.py
+++ b/tests/test_dwavesampler.py
@@ -312,4 +312,5 @@ class TestDWaveSamplerAnnealSchedule(unittest.TestCase):
             def __init__(self):
                 pass
 
+        DWaveSampler.validate_anneal_schedule(MockScheduleSampler(), [[0.0, 0.0], [0.2, 0.2], [5.2, 0.2], [6.0, 1.0]])
         DWaveSampler.validate_anneal_schedule(MockScheduleSampler(), [(0, 1), (55.0, 0.45), (155.0, 0.45), (210.0, 1)])


### PR DESCRIPTION
Naive solution for #273 

Using round() or any rounding method with some tolerance although it requires setting a fixed precision. I used 10 arbitrarily.

Not sure how, but this seems to be managed successfully once the problem is submitted to the machine, maybe the method used there is more appropriate. 