### PR TITLE
(Requires SDK update) Mock calls to DWaveSampler to expand doctest coverage

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -97,8 +97,6 @@ from __future__ import print_function, division
 
 import dimod
 from dwave.embedding import *
-#from dwave.system import *
-
 
 from unittest.mock import Mock
 from dwave.system.testing import MockDWaveSampler

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -97,8 +97,15 @@ from __future__ import print_function, division
 
 import dimod
 from dwave.embedding import *
-from dwave.system import *
+#from dwave.system import *
 
+
+from unittest.mock import Mock
+from dwave.system.testing import MockDWaveSampler
+import dwave.system
+dwave.system.DWaveSampler = Mock()
+dwave.system.DWaveSampler.side_effect = MockDWaveSampler
+from dwave.system import *
 """
 
 

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -32,10 +32,9 @@ a mapping known as :term:`minor-embedding`.
 
 >>> import networkx as nx
 >>> import dwave_networkx as dnx
->>> from dwave.system.samplers import DWaveSampler
->>> from dwave.system.composites import EmbeddingComposite
+>>> from dwave.system import DWaveSampler, EmbeddingComposite
 ...
 >>> s5 = nx.star_graph(4)  # a star graph where node 0 is hub to four other nodes
 >>> sampler = EmbeddingComposite(DWaveSampler())
->>> print(dnx.min_vertex_cover(s5, sampler))
+>>> print(dnx.min_vertex_cover(s5, sampler))   
 [0]

--- a/dwave/embedding/chain_breaks.py
+++ b/dwave/embedding/chain_breaks.py
@@ -126,8 +126,8 @@ def discard(samples, chains):
         >>> unembedded, idx = dwave.embedding.discard(samples, chains)
         >>> unembedded
         array([[1, 0]], dtype=int8)
-        >>> idx
-        array([0])
+        >>> print(idx)
+        [0]
 
     """
     samples, labels = dimod.as_samples(samples)

--- a/dwave/embedding/chain_breaks.py
+++ b/dwave/embedding/chain_breaks.py
@@ -192,7 +192,7 @@ def majority_vote(samples, chains):
         [[1 0]
          [1 1]]
         >>> print(idx)
-        [0, 1]
+        [0 1]
 
     """
     samples, labels = dimod.as_samples(samples)

--- a/dwave/embedding/chain_breaks.py
+++ b/dwave/embedding/chain_breaks.py
@@ -188,11 +188,11 @@ def majority_vote(samples, chains):
         >>> chains = [(0, 1), (2, 3, 4)]
         >>> samples = np.array([[1, 1, 0, 0, 1], [1, 1, 1, 0, 1]], dtype=np.int8)
         >>> unembedded, idx = dwave.embedding.majority_vote(samples, chains)
-        >>> unembedded
-        array([[1, 0],
-               [1, 1]], dtype=int8)
-        >>> idx
-        array([0, 1])
+        >>> print(unembedded)
+        [[1 0]
+         [1 1]]
+        >>> print(idx)
+        [0, 1]
 
     """
     samples, labels = dimod.as_samples(samples)

--- a/dwave/embedding/diagnostic.py
+++ b/dwave/embedding/diagnostic.py
@@ -64,6 +64,7 @@ def diagnose_embedding(emb, source, target):
         to a square target graph. A valid embedding, such as
         `emb = {0: [1], 1: [0], 2: [2, 3]}`, yields no errors.
 
+         >>> from dwave.embedding import diagnose_embedding
          >>> import networkx as nx
          >>> source = nx.complete_graph(3)
          >>> target = nx.cycle_graph(4)

--- a/dwave/embedding/utils.py
+++ b/dwave/embedding/utils.py
@@ -50,7 +50,8 @@ def target_to_source(target_adjacency, embedding):
         >>> target_adjacency = {0: {1, 3}, 1: {0, 2}, 2: {1, 3}, 3: {0, 2}}  # a square graph
         >>> embedding = {'a': {0}, 'b': {1}, 'c': {2, 3}}
         >>> source_adjacency = dwave.embedding.target_to_source(target_adjacency, embedding)
-        >>> source_adjacency  # triangle
+        >>> # triangle graph:
+        >>> source_adjacency   # doctest: +SKIP
         {'a': {'b', 'c'}, 'b': {'a', 'c'}, 'c': {'a', 'b'}}
 
         This function also works with networkx graphs.
@@ -58,7 +59,8 @@ def target_to_source(target_adjacency, embedding):
         >>> import networkx as nx
         >>> target_graph = nx.complete_graph(5)
         >>> embedding = {'a': {0, 1, 2}, 'b': {3, 4}}
-        >>> dwave.embedding.target_to_source(target_graph, embedding)
+        >>> dwave.embedding.target_to_source(target_graph, embedding)   # doctest: +SKIP
+        {'a': {'b'}, 'b': {'a'}}
 
     """
     # the nodes in the source adjacency are just the keys of the embedding

--- a/dwave/system/composites/cutoffcomposite.py
+++ b/dwave/system/composites/cutoffcomposite.py
@@ -64,13 +64,13 @@ class CutOffComposite(dimod.ComposedSampler):
 
         >>> import dimod
         >>> sampler = DWaveSampler(solver={'qpu': True})
-        >>> bqm = dimod.BinaryQuadraticModel({'a': -1, 'b': 1, 'c': 1},    # doctest: +SKIP
+        >>> bqm = dimod.BinaryQuadraticModel({'a': -1, 'b': 1, 'c': 1},
         ...                            {'ab': -0.8, 'ac': -0.7, 'bc': -1},
         ...                            0,
         ...                            dimod.SPIN)
         >>> CutOffComposite(AutoEmbeddingComposite(sampler), 0.75).sample(bqm,
-        ...                 num_reads=1000).first.sample # doctest: +SKIP
-        {'a': -1, 'b': -1, 'c': -1}
+        ...                 num_reads=1000).first.energy
+        -3.5
 
     """
 

--- a/dwave/system/composites/embedding.py
+++ b/dwave/system/composites/embedding.py
@@ -80,7 +80,10 @@ class EmbeddingComposite(dimod.ComposedSampler):
        >>> sampler = EmbeddingComposite(DWaveSampler())
        >>> h = {'a': -1., 'b': 2}
        >>> J = {('a', 'b'): 1.5}
-       >>> sampleset = sampler.sample_ising(h, J)
+       >>> sampleset = sampler.sample_ising(h, J, num_reads=100)
+       >>> sampleset.first.energy
+       -4.5
+
 
     """
     def __init__(self, child_sampler,
@@ -498,8 +501,7 @@ class FixedEmbeddingComposite(LazyFixedEmbeddingComposite):
 
     Examples:
 
-        >>> from dwave.system.samplers import DWaveSampler
-        >>> from dwave.system.composites import FixedEmbeddingComposite
+        >>> from dwave.system import DWaveSampler, FixedEmbeddingComposite
         ...
         >>> embedding = {'a': [0, 4], 'b': [1, 5], 'c': [2, 6]}
         >>> sampler = FixedEmbeddingComposite(DWaveSampler(), embedding)
@@ -507,7 +509,10 @@ class FixedEmbeddingComposite(LazyFixedEmbeddingComposite):
         ['a', 'b', 'c']
         >>> sampler.edgelist
         [('a', 'b'), ('a', 'c'), ('b', 'c')]
-        >>> sampleset = sampler.sample_ising({'a': .5, 'c': 0}, {('a', 'c'): -1})
+        >>> sampleset = sampler.sample_ising({'a': .5, 'c': 0}, {('a', 'c'): -1}, num_reads=500)
+        >>> sampleset.first.energy
+        -1.5
+
 
     """
     def __init__(self, child_sampler, embedding=None, source_adjacency=None,

--- a/dwave/system/composites/tiling.py
+++ b/dwave/system/composites/tiling.py
@@ -68,15 +68,14 @@ class TilingComposite(dimod.Sampler, dimod.Composite, dimod.Structured):
        Composite :class:`.TilingComposite` tiles it multiple times for parallel solution:
        the two nodes should typically have opposite values.
 
-       >>> from dwave.system.samplers import DWaveSampler
-       >>> from dwave.system.composites import EmbeddingComposite
-       >>> from dwave.system.composites import TilingComposite
+       >>> from dwave.system import DWaveSampler, EmbeddingComposite
+       >>> from dwave.system import TilingComposite
        ...
        >>> sampler = EmbeddingComposite(TilingComposite(DWaveSampler(), 1, 1, 4))
        >>> Q = {(1, 1): -1, (1, 2): 2, (2, 1): 0, (2, 2): -1}
-       >>> response = sampler.sample_qubo(Q)
-       >>> response.first    # doctest: +SKIP
-       Sample(sample={1: 0, 2: 1}, energy=-1.0, num_occurrences=1, chain_break_fraction=0.0)
+       >>> sampleset = sampler.sample_qubo(Q)
+       >>> len(sampleset)> 1
+       True
 
     See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/latest/glossary.html>`_
     for explanations of technical terms in descriptions of Ocean tools.

--- a/dwave/system/composites/tiling.py
+++ b/dwave/system/composites/tiling.py
@@ -192,9 +192,8 @@ class TilingComposite(dimod.Sampler, dimod.Composite, dimod.Structured):
             across the solver's entire Chimera graph, resulting in multiple samples
             (the exact number depends on the working Chimera graph of the D-Wave system).
 
-            >>> from dwave.system.samplers import DWaveSampler
-            >>> from dwave.system.composites import EmbeddingComposite
-            >>> from dwave.system.composites import EmbeddingComposite, TilingComposite
+            >>> from dwave.system import DWaveSampler, EmbeddingComposite
+            >>> from dwave.system import TilingComposite
             ...
             >>> sampler = EmbeddingComposite(TilingComposite(DWaveSampler(), 1, 1, 4))
             >>> response = sampler.sample_ising({},{('a', 'b'): 1})

--- a/dwave/system/composites/virtual_graph.py
+++ b/dwave/system/composites/virtual_graph.py
@@ -95,24 +95,18 @@ class VirtualGraphComposite(FixedEmbeddingComposite):
 
        >>> from dwave.system import DWaveSampler, VirtualGraphComposite
        >>> embedding = {'x': {1}, 'y': {5}, 'z': {0, 4}}
-       >>> DWaveSampler().properties['extended_j_range']   # doctest: +SKIP
+       >>> DWaveSampler().properties['extended_j_range']
        [-2.0, 1.0]
        >>> sampler = VirtualGraphComposite(DWaveSampler(), embedding, chain_strength=2) # doctest: +SKIP
        >>> Q = {('x', 'y'): 1, ('x', 'z'): -2, ('y', 'z'): -2, ('z', 'z'): 3}
        >>> sampleset = sampler.sample_qubo(Q, num_reads=10) # doctest: +SKIP
-       >>> for sample in sampleset.samples():    # doctest: +SKIP
-       ...     print(sample)
-       ...
-       {'y': 0, 'x': 1, 'z': 0}
-       {'y': 1, 'x': 0, 'z': 0}
-       {'y': 1, 'x': 0, 'z': 0}
-       {'y': 1, 'x': 1, 'z': 1}
-       {'y': 0, 'x': 1, 'z': 0}
-       {'y': 1, 'x': 0, 'z': 0}
-       {'y': 0, 'x': 1, 'z': 0}
-       {'y': 0, 'x': 1, 'z': 0}
-       {'y': 0, 'x': 0, 'z': 0}
-       {'y': 1, 'x': 0, 'z': 0}
+       >>> print(sampleset)    # doctest: +SKIP
+          x  y  z energy num_oc. chain_.
+       0  1  0  0    0.0       2     0.0
+       1  0  1  0    0.0       3     0.0
+       2  1  1  1    0.0       3     0.0
+       3  0  0  0    0.0       2     0.0
+       ['BINARY', 4 rows, 10 samples, 3 variables]
 
     See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/latest/glossary.html>`_
     for explanations of technical terms in descriptions of Ocean tools.
@@ -183,25 +177,17 @@ class VirtualGraphComposite(FixedEmbeddingComposite):
 
            >>> from dwave.system import DWaveSampler, VirtualGraphComposite
            >>> embedding = {'x': {0, 4, 1, 5}, 'y': {2, 6, 3, 7}}
-           >>> DWaveSampler().properties['extended_j_range']   # doctest: +SKIP
+           >>> DWaveSampler().properties['extended_j_range']
            [-2.0, 1.0]
            >>> sampler = VirtualGraphComposite(DWaveSampler(), embedding, chain_strength=1) # doctest: +SKIP
            >>> h = {}
            >>> J = {('x', 'y'): 1}
            >>> sampleset = sampler.sample_ising(h, J, num_reads=10) # doctest: +SKIP
-           >>> for sample in sampleset.samples():    # doctest: +SKIP
-           ...     print(sample)
-           ...
-           {'y': -1, 'x': 1}
-           {'y': 1, 'x': -1}
-           {'y': -1, 'x': 1}
-           {'y': -1, 'x': 1}
-           {'y': -1, 'x': 1}
-           {'y': 1, 'x': -1}
-           {'y': 1, 'x': -1}
-           {'y': 1, 'x': -1}
-           {'y': -1, 'x': 1}
-           {'y': 1, 'x': -1}
+           >>> print(sampleset)    # doctest: +SKIP
+              x  y energy num_oc. chain_.
+           0 -1 +1   -1.0       6     0.0
+           1 +1 -1   -1.0       4     0.0
+           ['SPIN', 2 rows, 10 samples, 2 variables]
 
         See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/latest/glossary.html>`_
         for explanations of technical terms in descriptions of Ocean tools.

--- a/dwave/system/composites/virtual_graph.py
+++ b/dwave/system/composites/virtual_graph.py
@@ -181,8 +181,7 @@ class VirtualGraphComposite(FixedEmbeddingComposite):
            J range. In this example, the ten returned samples all represent valid states of
            the NOT gate.
 
-           >>> from dwave.system.samplers import DWaveSampler
-           >>> from dwave.system.composites import VirtualGraphComposite
+           >>> from dwave.system import DWaveSampler, VirtualGraphComposite
            >>> embedding = {'x': {0, 4, 1, 5}, 'y': {2, 6, 3, 7}}
            >>> DWaveSampler().properties['extended_j_range']   # doctest: +SKIP
            [-2.0, 1.0]

--- a/dwave/system/composites/virtual_graph.py
+++ b/dwave/system/composites/virtual_graph.py
@@ -93,15 +93,14 @@ class VirtualGraphComposite(FixedEmbeddingComposite):
        J range. In this example, the ten returned samples all represent valid states of
        the AND gate.
 
-       >>> from dwave.system.samplers import DWaveSampler
-       >>> from dwave.system.composites import VirtualGraphComposite
+       >>> from dwave.system import DWaveSampler, VirtualGraphComposite
        >>> embedding = {'x': {1}, 'y': {5}, 'z': {0, 4}}
        >>> DWaveSampler().properties['extended_j_range']   # doctest: +SKIP
        [-2.0, 1.0]
        >>> sampler = VirtualGraphComposite(DWaveSampler(), embedding, chain_strength=2) # doctest: +SKIP
        >>> Q = {('x', 'y'): 1, ('x', 'z'): -2, ('y', 'z'): -2, ('z', 'z'): 3}
-       >>> response = sampler.sample_qubo(Q, num_reads=10) # doctest: +SKIP
-       >>> for sample in response.samples():    # doctest: +SKIP
+       >>> sampleset = sampler.sample_qubo(Q, num_reads=10) # doctest: +SKIP
+       >>> for sample in sampleset.samples():    # doctest: +SKIP
        ...     print(sample)
        ...
        {'y': 0, 'x': 1, 'z': 0}
@@ -190,8 +189,8 @@ class VirtualGraphComposite(FixedEmbeddingComposite):
            >>> sampler = VirtualGraphComposite(DWaveSampler(), embedding, chain_strength=1) # doctest: +SKIP
            >>> h = {}
            >>> J = {('x', 'y'): 1}
-           >>> response = sampler.sample_ising(h, J, num_reads=10) # doctest: +SKIP
-           >>> for sample in response.samples():    # doctest: +SKIP
+           >>> sampleset = sampler.sample_ising(h, J, num_reads=10) # doctest: +SKIP
+           >>> for sample in sampleset.samples():    # doctest: +SKIP
            ...     print(sample)
            ...
            {'y': -1, 'x': 1}

--- a/dwave/system/samplers/dwave_sampler.py
+++ b/dwave/system/samplers/dwave_sampler.py
@@ -137,14 +137,15 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
         as its URL and an autentication token, are implicitly set in a configuration file
         or as environment variables, as described in
         `Configuring a D-Wave System <https://docs.ocean.dwavesys.com/en/latest/overview/dwavesys.html>`_.
+        Given sufficient reads (here 100), the quantum
+        computer should return the best solution, :math:`{1, -1}` on qubits 0 and 1,
+        respectively, as its first sample (samples are ordered from lowest energy).
 
         >>> from dwave.system import DWaveSampler
         >>> sampler = DWaveSampler(solver={'qubits__issuperset': {0, 1}})
-        >>> sampleset = sampler.sample_ising({0: -1, 1: 1}, {})
-        >>> for sample in sampleset.samples():  # doctest: +SKIP
-        ...    print(sample)
-        ...
-        {0: 1, 1: -1}
+        >>> sampleset = sampler.sample_ising({0: -1, 1: 1}, {}, num_reads=100)
+        >>> sampleset.first.sample[0] == 1 and sampleset.first.sample[1] == -1
+        True
 
     See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/latest/glossary.html>`_
     for explanations of technical terms in descriptions of Ocean tools.
@@ -241,17 +242,12 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
         """list: List of active couplers for the D-Wave solver.
 
         Examples:
+            Coupler list for one D-Wave 2000Q system (output snipped for brevity).
 
             >>> from dwave.system import DWaveSampler
             >>> sampler = DWaveSampler()
-            >>> sampler.edgelist    # doctest: +SKIP
-            [(0, 4),
-             (0, 5),
-             (0, 6),
-             (0, 7),
-             (0, 128),
-             (1, 4),
-            # Snipped above response for brevity
+            >>> sampler.edgelist
+            [(0, 4), (0, 5), (0, 6), (0, 7), ...
 
         See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/latest/glossary.html>`_
         for explanations of technical terms in descriptions of Ocean tools.
@@ -270,14 +266,12 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
         """list: List of active qubits for the D-Wave solver.
 
         Examples:
+            Node list for one D-Wave 2000Q system (output snipped for brevity).
 
             >>> from dwave.system import DWaveSampler
             >>> sampler = DWaveSampler()
-            >>> sampler.nodelist    # doctest: +SKIP
-            [0,
-             1,
-             2,
-            # Snipped above response for brevity
+            >>> sampler.nodelist
+            [0, 1, 2, ...
 
         See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/latest/glossary.html>`_
         for explanations of technical terms in descriptions of Ocean tools.
@@ -327,15 +321,15 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
 
         Examples:
             This example submits a two-variable Ising problem mapped directly to qubits
-            0 and 1 on a D-Wave system.
+            0 and 1 on a D-Wave system. Given sufficient reads (here 100), the quantum
+            computer should return the best solution, :math:`{1, -1}` on qubits 0 and 1,
+            respectively, as its first sample (samples are ordered from lowest energy).
 
             >>> from dwave.system import DWaveSampler
-            >>> sampler = DWaveSampler()
-            >>> sampleset = sampler.sample_ising({0: -1, 1: 1}, {})
-            >>> for sample in sampleset.samples():    # doctest: +SKIP
-            ...    print(sample)
-            ...
-            {0: 1, 1: -1}
+            >>> sampler = DWaveSampler(solver={'qubits__issuperset': {0, 1}})
+            >>> sampleset = sampler.sample_ising({0: -1, 1: 1}, {}, num_reads=100)
+            >>> sampleset.first.sample[0] == 1 and sampleset.first.sample[1] == -1
+            True
 
         See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/latest/glossary.html>`_
         for explanations of technical terms in descriptions of Ocean tools.
@@ -399,16 +393,17 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
 
         Examples:
             This example submits a two-variable QUBO mapped directly to qubits
-            0 and 4 on a D-Wave system.
+            0 and 4 on a D-Wave system. Given sufficient reads (here 100), the quantum
+            computer should return the best solutions, :math:`{0, 1}` or
+            :math:`{1, 0}` on qubits 0 and 4, respectively, as its first sample
+            (samples are ordered from lowest energy).
 
             >>> from dwave.system import DWaveSampler
             >>> sampler = DWaveSampler()
             >>> Q = {(0, 0): -1, (4, 4): -1, (0, 4): 2}
-            >>> sampleset = sampler.sample_qubo(Q)
-            >>> for sample in sampleset.samples():    # doctest: +SKIP
-            ...    print(sample)
-            ...
-            {0: 0, 4: 1}
+            >>> sampleset = sampler.sample_qubo(Q, num_reads=100)
+            >>> sampleset.first.sample[0] != sampleset.first.sample[4]
+            True
 
         See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/latest/glossary.html>`_
         for explanations of technical terms in descriptions of Ocean tools.

--- a/dwave/system/samplers/dwave_sampler.py
+++ b/dwave/system/samplers/dwave_sampler.py
@@ -138,7 +138,7 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
         or as environment variables, as described in
         `Configuring a D-Wave System <https://docs.ocean.dwavesys.com/en/latest/overview/dwavesys.html>`_.
 
-        >>> from dwave.system.samplers import DWaveSampler
+        >>> from dwave.system import DWaveSampler
         >>> sampler = DWaveSampler(solver={'qubits__issuperset': {0, 1}})
         >>> sampleset = sampler.sample_ising({0: -1, 1: 1}, {})
         >>> for sample in sampleset.samples():  # doctest: +SKIP
@@ -182,7 +182,7 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
 
         Examples:
 
-            >>> from dwave.system.samplers import DWaveSampler
+            >>> from dwave.system import DWaveSampler
             >>> sampler = DWaveSampler()
             >>> sampler.properties    # doctest: +SKIP
             {u'anneal_offset_ranges': [[-0.2197463755538704, 0.03821687759418928],
@@ -213,7 +213,7 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
 
         Examples:
 
-            >>> from dwave.system.samplers import DWaveSampler
+            >>> from dwave.system import DWaveSampler
             >>> sampler = DWaveSampler()
             >>> sampler.parameters    # doctest: +SKIP
             {u'anneal_offsets': ['parameters'],
@@ -242,7 +242,7 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
 
         Examples:
 
-            >>> from dwave.system.samplers import DWaveSampler
+            >>> from dwave.system import DWaveSampler
             >>> sampler = DWaveSampler()
             >>> sampler.edgelist    # doctest: +SKIP
             [(0, 4),
@@ -271,7 +271,7 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
 
         Examples:
 
-            >>> from dwave.system.samplers import DWaveSampler
+            >>> from dwave.system import DWaveSampler
             >>> sampler = DWaveSampler()
             >>> sampler.nodelist    # doctest: +SKIP
             [0,
@@ -329,7 +329,7 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
             This example submits a two-variable Ising problem mapped directly to qubits
             0 and 1 on a D-Wave system.
 
-            >>> from dwave.system.samplers import DWaveSampler
+            >>> from dwave.system import DWaveSampler
             >>> sampler = DWaveSampler()
             >>> sampleset = sampler.sample_ising({0: -1, 1: 1}, {})
             >>> for sample in sampleset.samples():    # doctest: +SKIP
@@ -401,7 +401,7 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
             This example submits a two-variable QUBO mapped directly to qubits
             0 and 4 on a D-Wave system.
 
-            >>> from dwave.system.samplers import DWaveSampler
+            >>> from dwave.system import DWaveSampler
             >>> sampler = DWaveSampler()
             >>> Q = {(0, 0): -1, (4, 4): -1, (0, 4): 2}
             >>> sampleset = sampler.sample_qubo(Q)
@@ -475,7 +475,7 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
         Examples:
             This example sets a quench schedule on a D-Wave system.
 
-            >>> from dwave.system.samplers import DWaveSampler
+            >>> from dwave.system import DWaveSampler
             >>> sampler = DWaveSampler()
             >>> quench_schedule=[[0.0, 0.0], [12.0, 0.6], [12.8, 1.0]]
             >>> DWaveSampler().validate_anneal_schedule(quench_schedule)    # doctest: +SKIP

--- a/dwave/system/schedules.py
+++ b/dwave/system/schedules.py
@@ -35,9 +35,8 @@ def ramp(s, width, annealing_time):
         a ramp.
 
     Examples:
-
-        In this example we get a QPU, use it to construct a schedule and then
-        use that schdule for the `h_gain_schedule` parameter.
+        This example constructs a schedule for a QPU that supports
+        configuring an `h_gain_schedule`.
 
         >>> sampler = DWaveSampler(solver=dict(annealing_time=True,
                                                h_gain_schedule=True))

--- a/dwave/system/schedules.py
+++ b/dwave/system/schedules.py
@@ -29,17 +29,17 @@ def ramp(s, width, annealing_time):
 
         annealing_time (float):
             The total annealing time, in microseconds.
-    
+
     Returns:
         list[2-tuple]: The points defining in a piece-wise curve in the shape of
         a ramp.
 
     Examples:
-        
+
         In this example we get a QPU, use it to construct a schedule and then
         use that schdule for the `h_gain_schedule` parameter.
 
-        >>> sampler = DWaveSampler(solver=dict(default_annealing_time=True,
+        >>> sampler = DWaveSampler(solver=dict(annealing_time=True,
                                                h_gain_schedule=True))
         >>> h = {v: -1 for v in sampler.nodelist}
         >>> schedule = ramp(.5, .2, sampler.properties['default_annealing_time'])
@@ -50,7 +50,7 @@ def ramp(s, width, annealing_time):
         raise ValueError("s should be in interval (0, 1)")
     if width >= min(s, 1 - s) / 2:
         raise ValueError("given width takes curve outside of [0, 1] interval")
-    
+
     return [(0, 0),
             (annealing_time * (s - width / 2), 0),
             (annealing_time * (s + width / 2), 1),

--- a/dwave/system/testing.py
+++ b/dwave/system/testing.py
@@ -68,7 +68,7 @@ class MockDWaveSampler(dimod.Sampler, dimod.Structured):
         properties['chip_id'] = 'MockDWaveSampler'
         properties['annealing_time_range'] = [1, 2000]
         properties['num_qubits'] = len(self.nodelist)
-
+        properties['extended_j_range'] = [-2.0, 1.0]
 
     @dimod.bqm_structured
     def sample(self, bqm, num_reads=10, flux_biases=[]):

--- a/dwave/system/testing.py
+++ b/dwave/system/testing.py
@@ -45,10 +45,10 @@ class MockDWaveSampler(dimod.Sampler, dimod.Structured):
     def __init__(self, broken_nodes=None, **config):
         if broken_nodes is None:
             self.nodelist = sorted(C4.nodes)
-            self.edgelist = sorted(sorted(edge) for edge in C4.edges)
+            self.edgelist = sorted(tuple(sorted(edge)) for edge in C4.edges)
         else:
             self.nodelist = sorted(v for v in C4.nodes if v not in broken_nodes)
-            self.edgelist = sorted(sorted((u, v)) for u, v in C4.edges
+            self.edgelist = sorted(tuple(sorted((u, v))) for u, v in C4.edges
                                    if u not in broken_nodes and v not in broken_nodes)
 
         # mark the sample kwargs

--- a/dwave/system/testing.py
+++ b/dwave/system/testing.py
@@ -42,7 +42,7 @@ class MockDWaveSampler(dimod.Sampler, dimod.Structured):
     properties = None
     parameters = None
 
-    def __init__(self, broken_nodes=None):
+    def __init__(self, broken_nodes=None, **config):
         if broken_nodes is None:
             self.nodelist = sorted(C4.nodes)
             self.edgelist = sorted(sorted(edge) for edge in C4.edges)
@@ -62,6 +62,13 @@ class MockDWaveSampler(dimod.Sampler, dimod.Structured):
         properties['h_range'] = [-2.0, 2.0]
         properties['num_reads_range'] = [1, 10000]
         properties['num_qubits'] = len(C4)
+        properties['category'] = 'qpu'
+        properties['quota_conversion_rate'] = 1
+        properties['topology'] = {'type': 'chimera', 'shape': [16, 16, 4]}
+        properties['chip_id'] = 'MockDWaveSampler'
+        properties['annealing_time_range'] = [1, 2000]
+        properties['num_qubits'] = len(self.nodelist)
+
 
     @dimod.bqm_structured
     def sample(self, bqm, num_reads=10, flux_biases=[]):

--- a/dwave/system/utilities.py
+++ b/dwave/system/utilities.py
@@ -47,9 +47,9 @@ def common_working_graph(graph0, graph1):
         >>> import dwave_networkx as dnx
         >>> from dwave.system import DWaveSampler, common_working_graph
         ...
-        >>> sampler = DWaveSampler(solver={'qpu': True}) # doctest: +SKIP
+        >>> sampler = DWaveSampler(solver={'qpu': True})
         >>> C4 = dnx.chimera_graph(4)  # a 4x4 lattice of Chimera tiles
-        >>> c4_working_graph = common_working_graph(C4, sampler.adjacency)   # doctest: +SKIP
+        >>> c4_working_graph = common_working_graph(C4, sampler.adjacency)   
 
     """
 

--- a/tests/test_leaphybridsolver.py
+++ b/tests/test_leaphybridsolver.py
@@ -14,14 +14,9 @@
 #
 # =============================================================================
 import unittest
-from concurrent.futures import Future
 import numpy as np
 
 import dimod
-from tabu import TabuSampler
-from dwave.system.samplers import LeapHybridSampler
-
-from dwave.cloud.computation import Future as cloud_future
 from dwave.cloud import Client
 
 try:
@@ -31,31 +26,8 @@ except ImportError:
     # py2
     import mock
 
-class MockLeapHybridSolver:
-
-    properties = {'supported_problem_types': ['bqm'],
-                  'minimum_time_limit': [[1, 1.0], [1024, 1.0],
-                                         [4096, 10.0], [10000, 40.0]],
-                  'parameters': {'time_limit': None},
-                  'category': 'hybrid',
-                  'quota_conversion_rate': 1}
-
-    def upload_bqm(self, bqm, **parameters):
-        bqm_adjarray = dimod.serialization.fileview.load(bqm)
-        future = Future()
-        future.set_result(bqm_adjarray)
-        return future
-
-    def sample_bqm(self, sapi_problem_id, time_limit):
-        #Workaround until TabuSampler supports C BQMs
-        bqm = dimod.BQM(sapi_problem_id.linear,
-                                    sapi_problem_id.quadratic,
-                                    sapi_problem_id.offset,
-                                    sapi_problem_id.vartype)
-        result = TabuSampler().sample(bqm, timeout=1000*int(time_limit))
-        future = cloud_future('fake_solver', None)
-        future._result = {'sampleset': result, 'problem_type': 'bqm'}
-        return future
+from dwave.system.samplers import LeapHybridSampler
+from dwave.system.testing import MockLeapHybridSolver
 
 # Called only for named solver
 class MockBadLeapHybridSolver:


### PR DESCRIPTION
This PR mocks all `dwave.system` calls to DWaveSampler(), removes doctest skipping, and updates examples for expanded doctest coverage. It needs an update to dwave-ocean-sdk, which I'll make soon, before being merged.
If I have time I'll update MockLeapHybridSolver to work this way too.

```
Doctest summary
===============
  174 tests
    0 failures in tests
    0 failures in setup code
    0 failures in cleanup code
build succeeded.
```