### PR TITLE
Add direct Chimera unit-cell embedding composite

### DIFF
--- a/dwave/system/composites/__init__.py
+++ b/dwave/system/composites/__init__.py
@@ -18,3 +18,4 @@ from dwave.system.composites.embedding import *
 from dwave.system.composites.tiling import *
 from dwave.system.composites.virtual_graph import *
 from dwave.system.composites.reversecomposite import *
+from dwave.system.composites.directembedding import *

--- a/dwave/system/composites/directembedding.py
+++ b/dwave/system/composites/directembedding.py
@@ -208,8 +208,12 @@ class DirectChimeraTilesEmbeddingComposite(dimod.ComposedSampler):
                                             for v, h in self.edges_vh[i]})
                            embedding.update({h + 8*i + 4: [h + q0 + 8*i + 4]
                                             for v, h in self.edges_vh[i]})
-                           embedding.update({h + 8*i + 4: [h + q0 + 8*i + 4]
-                                            for v, h in self.edges_hh[i]})
+                           embedding.update({h0 + 8*i + 4: [h0 + q0 + 8*i + 4]
+                                            for h0, h1 in self.edges_hh[i]})
+                           # Exploit empty self.edges_hh set for i = self.num_cells
+                           embedding.update({h1 + 8*(i + 1) + 4:
+                                            [h1 + q0 + 8*(i+1) + 4] for h0, h1
+                                            in self.edges_hh[i]})
 
                        return (embedding)
 

--- a/dwave/system/composites/directembedding.py
+++ b/dwave/system/composites/directembedding.py
@@ -177,7 +177,8 @@ class DirectChimeraTilesEmbeddingComposite(dimod.ComposedSampler):
                 self.couplers = G_ideal.edges
                 embedding = embed()
             except EmbeddingError:
-                msg = "Graph must be horizontally adjacent Chimera unit cells"
+                msg = "Graph must be up to {} horizontally adjacent \
+                       Chimera unit cells".format(self.tiles)
                 raise BinaryQuadraticModelStructureError(msg)
 
         return FixedEmbeddingComposite(self.child, embedding=embedding).sample_qubo(

--- a/dwave/system/composites/directembedding.py
+++ b/dwave/system/composites/directembedding.py
@@ -69,16 +69,17 @@ class DirectChimeraTilesEmbeddingComposite(dimod.ComposedSampler):
        {0: [20], 1: [25], 4: [440], 6: [450], 11: [95], 14: [451], 15: [456]}
 
     Note:
-       For a Chimera QPU especially, direct embedding is often simply done by
-       setting the desired node biases in the submission of a
+       direct embedding is useful when it's important that each node be represented
+       by a single qubit. For a Chimera QPU especially, direct embedding is often
+       simply done by setting the desired node biases in the submission of a
        :class:`~dwave.system.samplers.DWaveSampler()` for example,
 
        >>> samplset = DWaveSampler().sample_ising({}, {(0, 4): 1})  # doctest: +SKIP
 
-       You can shift embedding to another unit cell, :math: `n`, just by adding an offset of
-       :math:`8*n` to the zero node. But if you want the emebdding to be agnostic
-       to the selected QPU's working graph and topology, this composite can be
-       useful.
+       You can shift embedding to another unit cell, :math: `n`, just by adding
+       an offset of :math:`8*n` to the zero node. But if you want the emebdding
+       to be agnostic to the selected QPU's working graph and topology, this
+       composite can be useful.
     """
     def __init__(self, child_sampler):
 
@@ -132,126 +133,103 @@ class DirectChimeraTilesEmbeddingComposite(dimod.ComposedSampler):
         """
 
         if self.topology_type == "pegasus":
-            G_ideal = pegasus_graph(self.tiles)
-            G_working = dnx.pegasus_graph(self.tiles,
+            self.couplers = dnx.pegasus_graph(self.tiles,
                          node_list=self.child.nodelist,
-                         edge_list=self.child.edgelist)
-            self.couplers = G_working.edges
+                         edge_list=self.child.edgelist).edges
             embed = self._pegasus_embedding
         else:
-            G_ideal = chimera_graph(self.tiles, 1)
             self.couplers = self.child.edgelist
             embed = self._chimera_embedding
 
         max_nodes = 8*self.tiles if self.topology_type == "chimera" else \
-                    3*8*self.tiles
-        if not set(val for tup in Q.keys() for val in tup).issubset(set
-           (range(max_nodes))):
+                    3*8*self.tiles  #Rough (and extreme) limit on size
+        if not set(val for tup in Q.keys() for val in tup).issubset(
+               set(range(max_nodes))):
            msg = "Composite supports only indexed nodes"
            raise BinaryQuadraticModelStructureError(msg)
 
         uncoupled = (set(val for tup in Q.keys() for val in tup if tup[0] == tup[1]) -
-            set(val for tup in Q.keys() for val in tup if tup[0] != tup[1]))
+                     set(val for tup in Q.keys() for val in tup if tup[0] != tup[1]))
         if uncoupled:
            msg = "Composite does not support singleton nodes: {}".format(uncoupled)
            raise BinaryQuadraticModelStructureError(msg)
 
         self.num_cells = max([max(u, v) for u,v in Q.keys()]) //8 + 1
 
-        # Map chimera-indexed edges to relative vertical/horizontal positions
+        # Map to intra-cell and inter-cell couplers per unit cell
         self.edges_vh = list()
         self.edges_hh = list()
         for i in range(self.num_cells):
-            self.edges_vh.append([(min(edge) % 4, max(edge) % 4)
+            self.edges_vh.append([(min(edge), max(edge))
                  for edge in Q.keys() if min(edge) != max(edge) and
                                          min(edge) >= 8 * i and
                                          max(edge) < 8 * (i + 1)])
-            self.edges_hh.append([(edge[0] % 4, edge[1] % 4)
+            self.edges_hh.append([(edge[0], edge[1])
                  for edge in Q.keys() if min(edge) in range(8 * i, 8 * (i + 1)) and
                                          max(edge) in range(8 * (i + 1), 8 * (i + 2))])
 
-        try:
-            embedding = embed()
-        except EmbeddingError:
-            try:
-                self.couplers = G_ideal.edges
-                embedding = embed()
-            except EmbeddingError:
-                msg = "Graph must be up to {} horizontally adjacent \
-                       Chimera unit cells".format(self.tiles)
-                raise BinaryQuadraticModelStructureError(msg)
+        embedding = embed()
 
         return FixedEmbeddingComposite(self.child, embedding=embedding).sample_qubo(
-                                       Q, **parameters)
+                                           Q, **parameters)
 
     def _chimera_embedding(self):
-        """
-        Map the problem's logical edges to edges of one or more unit cells in a
-        row of a Chimera QPU's working graph.
-        """
+        """Map problem's edges to qubits in row of unit cells in a Chimera QPU."""
 
         for row in range(self.tiles):
             for column in range(self.tiles - self.num_cells):
 
                 q0 = 8*self.tiles*row + 8*column
 
-                if all((set((v + q0 + 8*i, h + q0 + 8*i + 4) for
+                if all((set((v + q0, h + q0) for
                             v, h in self.edges_vh[i])
                        |  # Exploit empty self.edges_hh set for i = self.num_cells
-                        set((v + q0 + 8*i + 4, h + q0 + 8*(i + 1) + 4) for
+                        set((v + q0, h + q0) for
                             v, h in self.edges_hh[i])
                        ).issubset(self.couplers) for i in range(self.num_cells)):
 
                        embedding = dict()
                        for i in range(self.num_cells):
-                           embedding.update({v + 8*i: [v + q0 + 8*i]
+                           embedding.update({v: [v + q0]
                                             for v, h in self.edges_vh[i]})
-                           embedding.update({h + 8*i + 4: [h + q0 + 8*i + 4]
+                           embedding.update({h: [h + q0]
                                             for v, h in self.edges_vh[i]})
-                           embedding.update({h0 + 8*i + 4: [h0 + q0 + 8*i + 4]
+                           embedding.update({h0: [h0 + q0]
                                             for h0, h1 in self.edges_hh[i]})
                            # Exploit empty self.edges_hh set for i = self.num_cells
-                           embedding.update({h1 + 8*(i + 1) + 4:
-                                            [h1 + q0 + 8*(i+1) + 4] for h0, h1
-                                            in self.edges_hh[i]})
+                           embedding.update({h1: [h1 + q0]
+                                            for h0, h1 in self.edges_hh[i]})
 
                        return (embedding)
 
         raise EmbeddingError("No embedding found")
 
     def _pegasus_embedding(self):
-        """
-        Map the problem's logical edges to indexed edges of one or more :math:`K_{4,4}`
-        unit cells in a row of a Pegaus QPU's working graph.
-        """
+        """Map problem's edges to row of :math:`K_{4,4}` cells in a Pegaus QPU."""
 
         w, z, k_44 = self._scan_cells()
 
         embedding = dict()
         for i in range(self.num_cells):
 
-            embedding.update({k + 8*i: [dnx.pegasus_coordinates(self.tiles).pegasus_to_linear(
-                       (0, w + i, k + 4*k_44, z))] for k, h in self.edges_vh[i]})
-
             nodes_h = list(dnx.pegasus_coordinates(self.tiles).iter_pegasus_to_linear(
                            self._h_pair(w + i, z, k_44)))
-            embedding.update({k + 8*i + 4: [nodes_h[k]] for v, k
-                              in self.edges_vh[i]})
-            embedding.update({h0 + 8*i + 4: [nodes_h[h0]] for
-                              h0, h1 in self.edges_hh[i]})
-            # Exploit empty self.edges_hh set for i = self.num_cells
             nodes_h1 = list(dnx.pegasus_coordinates(self.tiles).iter_pegasus_to_linear(
                             self._h_pair(w + i + 1, z, k_44)))
-            embedding.update({h1 + 8*(i + 1) + 4: [nodes_h1[h1]] for
+
+            embedding.update({v: [dnx.pegasus_coordinates(self.tiles).pegasus_to_linear(
+                       (0, w + i, v - 8*i + 4*k_44, z))] for v, h in self.edges_vh[i]})
+            embedding.update({h: [nodes_h[h - 8*i - 4]] for v, h in self.edges_vh[i]})
+            embedding.update({h0: [nodes_h[h0 - 8*i - 4]] for
+                              h0, h1 in self.edges_hh[i]})
+            # Exploit empty self.edges_hh set for i = self.num_cells
+            embedding.update({h1: [nodes_h1[h1 - 8*(i + 1) - 4]] for
                               h0, h1 in self.edges_hh[i]})
 
         return(embedding)
 
     def _scan_cells(self):
-        """
-        Find horizontally adjacent :math:`K_{4,4}` unit cells with all the required
-        internal and external couplers.
-        """
+        """Find horizontally adjacent :math:`K_{4,4}` cells with needed couplers."""
 
         for z in range(self.tiles):
             for w in range(self.tiles - self.num_cells):
@@ -259,39 +237,35 @@ class DirectChimeraTilesEmbeddingComposite(dimod.ComposedSampler):
 
                     if all(self._couplers_vh(w, z, k_44, i) and
                            self._couplers_hh(w, z, k_44, i)
-                           for i in range(self.num_cells)):
-
+                              for i in range(self.num_cells)):
                         return (w, z, k_44)
 
         raise EmbeddingError("No embedding found")
 
     def _couplers_vh(self, w, z, k_44, cell):
-        """
-        Check edges between left/vertical and right/horizontal nodes of a
-        :math:`K_{4,4}` unit cell.
-        """
+        """Check internal couplers in a :math:`K_{4,4}` unit cell."""
 
         nodes_v = list(dnx.pegasus_coordinates(self.tiles).iter_pegasus_to_linear(
                        [(0, w + cell, k, z) for k in range(4*k_44, 4*k_44 + 4)]))
         nodes_h = list(dnx.pegasus_coordinates(self.tiles).iter_pegasus_to_linear(
                        self._h_pair(w + cell, z, k_44)))
 
-        couplers_vh = [(nodes_v[v], nodes_h[h]) for v, h in self.edges_vh[cell]]
+        couplers_vh = [(nodes_v[v - 8*cell], nodes_h[h - 8*cell - 4]) for
+                       v, h in self.edges_vh[cell]]
 
         return all(edge in self.couplers for edge in couplers_vh)
 
     def _couplers_hh(self, w, z, k_44, cell):
-        """
-        Check edges between horizontal shores of two adjacent :math:`K_{4,4}` unit
-        cells.
-        """
+        """Check external couplers between horizontal shores of unit cells."""
 
         left = list(dnx.pegasus_coordinates(self.tiles).iter_pegasus_to_linear(
-               self._h_pair(w + cell, z, k_44)))
+                    self._h_pair(w + cell, z, k_44)))
         right = list(dnx.pegasus_coordinates(self.tiles).iter_pegasus_to_linear(
-               self._h_pair(w + cell + 1, z, k_44)))
+                     self._h_pair(w + cell + 1, z, k_44)))
 
-        couplers_hh = [(left[v], right[h]) for v, h in self.edges_hh[cell]]
+        couplers_hh = [(left[h0 - 8*cell - 4], right[h1 - 8*(cell + 1) - 4])
+                       for h0, h1 in self.edges_hh[cell]]
+
         return all(edge in self.couplers for edge in couplers_hh)
 
     def _h_pair(self, w, z, k_44):
@@ -299,4 +273,5 @@ class DirectChimeraTilesEmbeddingComposite(dimod.ComposedSampler):
 
         ww = z + 1 if k_44 > 0 else z
         zz = w - 1 if k_44 == 0 else w
+
         return [(1, ww, j, zz) for j in range(8 - 4*k_44, 12 - 4*k_44)]

--- a/dwave/system/composites/directembedding.py
+++ b/dwave/system/composites/directembedding.py
@@ -1,0 +1,282 @@
+# coding: utf-8
+# Copyright 2020 D-Wave Systems Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+# =============================================================================
+"""Composites that directly embed small problems defined on qubit indices onto
+a QPU's working graph.
+"""
+import dwave_networkx as dnx
+import dimod
+from dimod.exceptions import BinaryQuadraticModelStructureError
+from dwave_networkx import chimera_graph, pegasus_graph
+from dwave.system import FixedEmbeddingComposite
+from dwave.embedding.exceptions import EmbeddingError
+
+__all__ = ('DirectChimeraTilesEmbeddingComposite',
+          )
+
+class DirectChimeraTilesEmbeddingComposite(dimod.ComposedSampler):
+    """
+    Directly embeds small problems to horizontally adjacent Chimera unit cell(s).
+
+    Maps small problem graphs, defined on the indexed couplers of a logical
+    Chimera unit cell, or several in a row, to physical :math:`K_{4,4}` unit cells
+    of a Pegasus or Chimera QPU.
+
+    Nodes of a Chimera unit cell are indexed :math:`0` to :math:'7', with
+    :math:`0-3` representing one shore, implemented on the QPU by vertically
+    oriented qubits, and :math:`4-7` the second shore, of horizontally oriented
+    qubits. Rows of Chimera unit cells are linked by couplers between the
+    horizontal qubits; for example, couplers :math:`(4, 12), (5, 13)...` between
+    the leftmost two unit cells.
+
+    Args:
+        child_sampler (:class:`dimod.Sampler`):
+            A dimod sampler, such as a :obj:`.DWaveSampler`, that accepts
+            only binary quadratic models of a particular structure: Chimera or
+            Pegasus topology.
+
+    Returns:
+        :obj:`dimod.SampleSet`
+
+    Examples:
+       This example embeds an Ising model with a graph defined on two Chimera
+       unit cells to a QPU. In this case, an Advantage system with
+       Pegasus toplogy is selected.
+
+       >>> from dwave.system import DWaveSampler, DirectChimeraTilesEmbeddingComposite
+       ...
+       >>> qpu = DWaveSampler(solver={'QPU': True})
+       >>> qpu.solver.properties["topology"]["type"] # doctest: +SKIP
+       'pegasus'
+       >>> sampler = DirectChimeraTilesEmbeddingComposite(qpu)
+       >>> h = {}
+       >>> J = {(0, 4): 1, (1, 4): 1, (1, 6): 1, (6, 14): -1, (14, 11): 1, (11, 15): 1}
+       >>> sampleset = sampler.sample_ising(h, J, num_reads=100)
+       >>> sampleset.info["embedding_context"]["embedding"]   # doctest: +SKIP
+       {0: [20], 1: [25], 4: [440], 6: [450], 11: [95], 14: [451], 15: [456]}
+
+    Note:
+       For a Chimera QPU especially, direct embedding is often simply done by
+       setting the desired node biases in the submission of a
+       :class:`~dwave.system.samplers.DWaveSampler()` for example,
+
+       >>> samplset = DWaveSampler().sample_ising({}, {(0, 4): 1})  # doctest: +SKIP
+
+       You can shift embedding to another unit cell, :math: `n`, just by adding an offset of
+       :math:`8*n` to the zero node. But if you want the emebdding to be agnostic
+       to the selected QPU's working graph and topology, this composite can be
+       useful.
+    """
+    def __init__(self, child_sampler):
+
+        self.children = [child_sampler]
+
+        # set the parameters
+        self.parameters = parameters = child_sampler.parameters.copy()
+
+        # set the properties
+        self.properties = dict(child_properties=child_sampler.properties.copy())
+
+        if self.properties["child_properties"]["category"] != "qpu":
+            raise TypeError("Child sampler must be a QPU solver.")
+
+        self.tiles = self.properties["child_properties"]["topology"]["shape"][0]
+        self.topology_type = self.properties["child_properties"]["topology"]["type"]
+
+    parameters = None  # overwritten by init
+    children = None  # overwritten by init
+    properties = None  # overwritten by init
+
+    def sample_qubo(self, Q, **parameters):
+        """
+        Sample the binary quadratic model.
+
+        Args:
+            bqm (:obj:`dimod.BinaryQuadraticModel`):
+                Binary quadratic model to be sampled from.
+
+        Returns:
+            :obj:`dimod.SampleSet`
+
+        Examples:
+           This example embeds a QUBO with a graph defined on two Chimera
+           unit cells to a QPU. In this case, an Advantage system with
+           Pegasus toplogy is selected.
+
+           >>> from dwave.system import DWaveSampler, DirectChimeraTilesEmbeddingComposite
+           ...
+           >>> qpu = DWaveSampler(solver={'QPU': True})
+           >>> qpu.solver.properties["topology"]["type"] # doctest: +SKIP
+           'pegasus'
+           >>> sampler = DirectChimeraTilesEmbeddingComposite(qpu)
+           >>> Q = {(0, 0): -2.0, (1, 1): -4.0, (4, 4): -4.0, (6, 6): 0.0, (11, 11): -4.0,
+           ...      (14, 14): 0.0, (15, 15): -2.0, (0, 4): 4.0, (1, 4): 4.0,
+           ...      (1, 6): 4.0, (6, 14): -4.0, (14, 11): 4.0, (11, 15): 4.0}
+           >>> sampleset = sampler.sample_qubo(Q, num_reads=100)
+           >>> sampleset.info["embedding_context"]["embedding"]   # doctest: +SKIP
+           {0: [20], 1: [25], 4: [440], 6: [450], 11: [95], 14: [451], 15: [456]}
+
+        """
+
+        if self.topology_type == "pegasus":
+            G_ideal = pegasus_graph(self.tiles)
+            G_working = dnx.pegasus_graph(self.tiles,
+                         node_list=self.child.nodelist,
+                         edge_list=self.child.edgelist)
+            self.couplers = G_working.edges
+            embed = self._pegasus_embedding
+        else:
+            G_ideal = chimera_graph(self.tiles, 1)
+            self.couplers = self.child.edgelist
+            embed = self._chimera_embedding
+
+        if (set(val for tup in Q.keys() for val in tup if tup[0] == tup[1]) -
+            set(val for tup in Q.keys() for val in tup if tup[0] != tup[1])):
+           msg = "Composite does not support singleton nodes: {}".format(uncoupled)
+           raise BinaryQuadraticModelStructureError(msg)
+
+        self.num_cells = max([max(u, v) for u,v in Q.keys()]) //8 + 1
+
+        # Map chimera-indexed edges to relative vertical/horizontal positions
+        self.edges_vh = list()
+        self.edges_hh = list()
+        for i in range(self.num_cells):
+            self.edges_vh.append([(min(edge) % 4, max(edge) % 4)
+                 for edge in Q.keys() if min(edge) != max(edge) and
+                                         min(edge) >= 8 * i and
+                                         max(edge) < 8 * (i + 1)])
+            self.edges_hh.append([(edge[0] % 4, edge[1] % 4)
+                 for edge in Q.keys() if min(edge) in range(8 * i, 8 * (i + 1)) and
+                                         max(edge) in range(8 * (i + 1), 8 * (i + 2))])
+
+        try:
+            embedding = embed()
+        except EmbeddingError:
+            try:
+                self.couplers = G_ideal.edges
+                embedding = embed()
+            except EmbeddingError:
+                msg = "Graph must be horizontally adjacent Chimera unit cells"
+                raise BinaryQuadraticModelStructureError(msg)
+
+        return FixedEmbeddingComposite(self.child, embedding=embedding).sample_qubo(
+                                       Q, **parameters)
+
+    def _chimera_embedding(self):
+        """
+        Map the problem's logical edges to edges of one or more unit cells in a
+        row of a Chimera QPU's working graph.
+        """
+
+        for row in range(self.tiles):
+            for column in range(self.tiles - self.num_cells):
+
+                q0 = 8*self.tiles*row + 8*column
+
+                if all((set((v + q0 + 8*i, h + q0 + 8*i + 4) for
+                            v, h in self.edges_vh[i])
+                       |  # Exploit empty self.edges_hh set for i = self.num_cells
+                        set((v + q0 + 8*i + 4, h + q0 + 8*(i + 1) + 4) for
+                            v, h in self.edges_hh[i])
+                       ).issubset(self.couplers) for i in range(self.num_cells)):
+
+                       embedding = dict()
+                       for i in range(self.num_cells):
+                           embedding.update({v + 8*i: [v + q0 + 8*i]
+                                            for v, h in self.edges_vh[i]})
+                           embedding.update({h + 8*i + 4: [h + q0 + 8*i + 4]
+                                            for v, h in self.edges_vh[i]})
+                           embedding.update({h + 8*i + 4: [h + q0 + 8*i + 4]
+                                            for v, h in self.edges_hh[i]})
+
+                       return (embedding)
+
+        raise EmbeddingError("No embedding found")
+
+    def _pegasus_embedding(self):
+        """
+        Map the problem's logical edges to indexed edges of one or more :math:`K_{4,4}`
+        unit cells in a row of a Pegaus QPU's working graph.
+        """
+
+        w, z, k_44 = self._scan_cells()
+
+        embedding = dict()
+        for i in range(self.num_cells):
+
+            embedding.update({k + 8*i: [dnx.pegasus_coordinates(self.tiles).pegasus_to_linear(
+                       (0, w + i, k + 4*k_44, z))] for k, h in self.edges_vh[i]})
+
+            nodes_h = list(dnx.pegasus_coordinates(self.tiles).iter_pegasus_to_linear(
+                           self._h_pair(w + i, z, k_44)))
+            embedding.update({k + 8*i + 4: [nodes_h[k]] for v, k in self.edges_vh[i]})
+            embedding.update({k + 8*i + 4: [nodes_h[k]] for v, k in self.edges_hh[i]})
+
+        return(embedding)
+
+    def _scan_cells(self):
+        """
+        Find horizontally adjacent :math:`K_{4,4}` unit cells with all the required
+        internal and external couplers.
+        """
+
+        for z in range(self.tiles):
+            for w in range(self.tiles - self.num_cells):
+                for k_44 in range(3):
+
+                    if all(self._couplers_vh(w, z, k_44, i) and
+                           self._couplers_hh(w, z, k_44, i)
+                           for i in range(self.num_cells)):
+
+                        return (w, z, k_44)
+
+        raise EmbeddingError("No embedding found")
+
+    def _couplers_vh(self, w, z, k_44, cell):
+        """
+        Check edges between left/vertical and right/horizontal nodes of a
+        :math:`K_{4,4}` unit cell.
+        """
+
+        nodes_v = list(dnx.pegasus_coordinates(self.tiles).iter_pegasus_to_linear(
+                       [(0, w + cell, k, z) for k in range(4*k_44, 4*k_44 + 4)]))
+        nodes_h = list(dnx.pegasus_coordinates(self.tiles).iter_pegasus_to_linear(
+                       self._h_pair(w + cell, z, k_44)))
+
+        couplers_vh = [(nodes_v[v], nodes_h[h]) for v, h in self.edges_vh[cell]]
+
+        return all(edge in self.couplers for edge in couplers_vh)
+
+    def _couplers_hh(self, w, z, k_44, cell):
+        """
+        Check edges between horizontal shores of two adjacent :math:`K_{4,4}` unit
+        cells.
+        """
+
+        left = list(dnx.pegasus_coordinates(self.tiles).iter_pegasus_to_linear(
+               self._h_pair(w + cell, z, k_44)))
+        right = list(dnx.pegasus_coordinates(self.tiles).iter_pegasus_to_linear(
+               self._h_pair(w + cell + 1, z, k_44)))
+
+        couplers_hh = [(left[v], right[h]) for v, h in self.edges_hh[cell]]
+        return all(edge in self.couplers for edge in couplers_hh)
+
+    def _h_pair(self, w, z, k_44):
+        """Get horizontal shore of a :math:`K_{4,4}` unit cell."""
+
+        ww = z + 1 if k_44 > 0 else z
+        zz = w - 1 if k_44 == 0 else w
+        return [(1, ww, j, zz) for j in range(8 - 4*k_44, 12 - 4*k_44)]

--- a/dwave/system/composites/directembedding.py
+++ b/dwave/system/composites/directembedding.py
@@ -144,7 +144,7 @@ class DirectChimeraTilesEmbeddingComposite(dimod.ComposedSampler):
             embed = self._chimera_embedding
 
         max_nodes = 8*self.tiles if self.topology_type == "chimera" else \
-                    3*15*self.tiles
+                    3*8*self.tiles
         if not set(val for tup in Q.keys() for val in tup).issubset(set
            (range(max_nodes))):
            msg = "Composite supports only indexed nodes"

--- a/dwave/system/composites/directembedding.py
+++ b/dwave/system/composites/directembedding.py
@@ -235,8 +235,15 @@ class DirectChimeraTilesEmbeddingComposite(dimod.ComposedSampler):
 
             nodes_h = list(dnx.pegasus_coordinates(self.tiles).iter_pegasus_to_linear(
                            self._h_pair(w + i, z, k_44)))
-            embedding.update({k + 8*i + 4: [nodes_h[k]] for v, k in self.edges_vh[i]})
-            embedding.update({k + 8*i + 4: [nodes_h[k]] for v, k in self.edges_hh[i]})
+            embedding.update({k + 8*i + 4: [nodes_h[k]] for v, k
+                              in self.edges_vh[i]})
+            embedding.update({h0 + 8*i + 4: [nodes_h[h0]] for
+                              h0, h1 in self.edges_hh[i]})
+            # Exploit empty self.edges_hh set for i = self.num_cells
+            nodes_h1 = list(dnx.pegasus_coordinates(self.tiles).iter_pegasus_to_linear(
+                            self._h_pair(w + i + 1, z, k_44)))
+            embedding.update({h1 + 8*(i + 1) + 4: [nodes_h1[h1]] for
+                              h0, h1 in self.edges_hh[i]})
 
         return(embedding)
 

--- a/dwave/system/composites/directembedding.py
+++ b/dwave/system/composites/directembedding.py
@@ -164,7 +164,7 @@ class DirectChimeraTilesEmbeddingComposite(dimod.ComposedSampler):
                  for edge in Q.keys() if min(edge) != max(edge) and
                                          min(edge) >= 8 * i and
                                          max(edge) < 8 * (i + 1)])
-            self.edges_hh.append([(edge[0], edge[1])
+            self.edges_hh.append([(min(edge), max(edge))
                  for edge in Q.keys() if min(edge) in range(8 * i, 8 * (i + 1)) and
                                          max(edge) in range(8 * (i + 1), 8 * (i + 2))])
 

--- a/dwave/system/composites/directembedding.py
+++ b/dwave/system/composites/directembedding.py
@@ -21,7 +21,7 @@ import dwave_networkx as dnx
 import dimod
 from dimod.exceptions import BinaryQuadraticModelStructureError
 from dwave_networkx import chimera_graph, pegasus_graph
-from dwave.system import FixedEmbeddingComposite
+from dwave.system.composites.embedding import FixedEmbeddingComposite
 from dwave.embedding.exceptions import EmbeddingError
 
 __all__ = ('DirectChimeraTilesEmbeddingComposite',
@@ -143,8 +143,16 @@ class DirectChimeraTilesEmbeddingComposite(dimod.ComposedSampler):
             self.couplers = self.child.edgelist
             embed = self._chimera_embedding
 
-        if (set(val for tup in Q.keys() for val in tup if tup[0] == tup[1]) -
-            set(val for tup in Q.keys() for val in tup if tup[0] != tup[1])):
+        max_nodes = 8*self.tiles if self.topology_type == "chimera" else \
+                    3*15*self.tiles
+        if not set(val for tup in Q.keys() for val in tup).issubset(set
+           (range(max_nodes))):
+           msg = "Composite supports only indexed nodes"
+           raise BinaryQuadraticModelStructureError(msg)
+
+        uncoupled = (set(val for tup in Q.keys() for val in tup if tup[0] == tup[1]) -
+            set(val for tup in Q.keys() for val in tup if tup[0] != tup[1]))
+        if uncoupled:
            msg = "Composite does not support singleton nodes: {}".format(uncoupled)
            raise BinaryQuadraticModelStructureError(msg)
 

--- a/dwave/system/testing.py
+++ b/dwave/system/testing.py
@@ -36,6 +36,7 @@ except ImportError:
     import mock
 
 C4 = dnx.chimera_graph(4, 4, 4)
+P6 = dnx.pegasus_graph(6)
 
 
 class MockDWaveSampler(dimod.Sampler, dimod.Structured):
@@ -46,13 +47,16 @@ class MockDWaveSampler(dimod.Sampler, dimod.Structured):
     properties = None
     parameters = None
 
-    def __init__(self, broken_nodes=None, **config):
+    def __init__(self, broken_nodes=None, topology="chimera", **config):
+
+        G = C4 if topology == "chimera" else P6
+
         if broken_nodes is None:
-            self.nodelist = sorted(C4.nodes)
-            self.edgelist = sorted(tuple(sorted(edge)) for edge in C4.edges)
+            self.nodelist = sorted(G.nodes)
+            self.edgelist = sorted(tuple(sorted(edge)) for edge in G.edges)
         else:
-            self.nodelist = sorted(v for v in C4.nodes if v not in broken_nodes)
-            self.edgelist = sorted(tuple(sorted((u, v))) for u, v in C4.edges
+            self.nodelist = sorted(v for v in G.nodes if v not in broken_nodes)
+            self.edgelist = sorted(tuple(sorted((u, v))) for u, v in G.edges
                                    if u not in broken_nodes and v not in broken_nodes)
 
         # mark the sample kwargs
@@ -65,10 +69,11 @@ class MockDWaveSampler(dimod.Sampler, dimod.Structured):
         properties['j_range'] = [-2.0, 1.0]
         properties['h_range'] = [-2.0, 2.0]
         properties['num_reads_range'] = [1, 10000]
-        properties['num_qubits'] = len(C4)
+        properties['num_qubits'] = len(G)
         properties['category'] = 'qpu'
         properties['quota_conversion_rate'] = 1
-        properties['topology'] = {'type': 'chimera', 'shape': [16, 16, 4]}
+        properties['topology'] = {'type': 'chimera', 'shape': [16, 16, 4]} if \
+           topology == "chimera" else {'type': 'pegasus', 'shape': [6, 6, 12]}
         properties['chip_id'] = 'MockDWaveSampler'
         properties['annealing_time_range'] = [1, 2000]
         properties['num_qubits'] = len(self.nodelist)

--- a/tests/test_direct_embedding_composite.py
+++ b/tests/test_direct_embedding_composite.py
@@ -1,0 +1,119 @@
+# Copyright 2020 D-Wave Systems Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+# ================================================================================================
+import unittest
+from collections import Mapping
+
+import dimod
+import dimod.testing as dtest
+import dwave_networkx as dnx
+from dimod.exceptions import BinaryQuadraticModelStructureError
+
+from dwave.system.testing import MockDWaveSampler
+from dwave.system.composites import DirectChimeraTilesEmbeddingComposite
+
+
+class TestDirect(unittest.TestCase):
+
+    def test_instantiation_smoketest(self):
+        sampler = DirectChimeraTilesEmbeddingComposite(MockDWaveSampler())
+
+        dtest.assert_sampler_api(sampler)
+
+    def test_sample_ising(self):
+        mock_sampler_chimera = MockDWaveSampler()  # C4 structured sampler
+
+        sampler = DirectChimeraTilesEmbeddingComposite(mock_sampler_chimera)
+
+        h = {0: 1.0, 1: -1.0, 2: -1.0, 3: 1.0, 4: 1.0, 5: -1.0, 6: 0.0, 7: 1.0,
+             8: 1.0, 9: -1.0, 10: -1.0, 11: 1.0, 12: 1.0, 13: 0.0, 14: -1.0,
+             15: 1.0}
+        J = {(9, 13): -1, (2, 6): -1, (8, 13): -1, (9, 14): -1, (9, 15): -1,
+             (10, 13): -1, (5, 13): -1, (10, 12): -1, (1, 5): -1, (10, 14): -1,
+             (0, 5): -1, (1, 6): -1, (3, 6): -1, (1, 7): -1, (11, 14): -1,
+             (2, 5): -1, (2, 4): -1, (6, 14): -1}
+
+        sampleset = sampler.sample_ising(h, J)
+
+        self.assertGreaterEqual(len(sampleset), 1)
+
+        for sample in sampleset.samples():
+            self.assertIsInstance(sample, Mapping)
+            self.assertEqual(set(sample), set(h))
+
+        for sample, energy in sampleset.data(['sample', 'energy']):
+            self.assertIsInstance(sample, Mapping)
+            self.assertEqual(set(sample), set(h))
+            self.assertAlmostEqual(dimod.ising_energy(sample, h, J),
+                                   energy)
+
+    def test_sample_ising_not_index_inputs(self):
+        sampler = DirectChimeraTilesEmbeddingComposite(MockDWaveSampler())
+
+        h = {'a': -1., 'b': 2}
+        J = {('a', 'b'): 1.5}
+
+        with self.assertRaises(BinaryQuadraticModelStructureError):
+            sampler.sample_ising(h, J)
+
+    def test_sample_qubo(self):
+        sampler = DirectChimeraTilesEmbeddingComposite(MockDWaveSampler())
+
+        Q = {(0, 0): .1, (0, 4): -.8, (4, 4): 1}
+
+        sampleset = sampler.sample_qubo(Q)
+
+        self.assertGreaterEqual(len(sampleset), 1)
+
+        for sample in sampleset.samples():
+            for u, v in Q:
+                self.assertIn(v, sample)
+                self.assertIn(u, sample)
+
+        for sample, energy in sampleset.data(['sample', 'energy']):
+            self.assertAlmostEqual(dimod.qubo_energy(sample, Q),
+                                   energy)
+
+    def test_singleton_variables(self):
+        sampler = DirectChimeraTilesEmbeddingComposite(MockDWaveSampler())
+
+        h = {0: -1., 4: 2}
+        J = {}
+
+        with self.assertRaises(BinaryQuadraticModelStructureError):
+            sampleset = sampler.sample_ising(h, J)
+
+    def test_embedding_chiera_first_cell(self):
+        sampler = DirectChimeraTilesEmbeddingComposite(MockDWaveSampler())
+
+        h = {}
+        J = {(0, 4): 1, (4, 1): 1, (1, 6): 1}
+
+        sampleset = sampler.sample_ising(h, J, return_embedding=True)
+
+        self.assertEqual(sampleset.info["embedding_context"]["embedding"],
+             {0: [0], 1: [1], 4: [4], 6: [6]})
+
+    def test_embedding_chiera_first_two_cells(self):
+        sampler = DirectChimeraTilesEmbeddingComposite(MockDWaveSampler())
+
+        h = {}
+        J = {(0, 4): 1, (4, 1): 1, (1, 6): 1, (6, 14): -1, (14, 11): 1,
+             (11, 15): 1}
+
+        sampleset = sampler.sample_ising(h, J, return_embedding=True)
+
+        self.assertEqual(sampleset.info["embedding_context"]["embedding"],
+             {0: [0], 1: [1], 4: [4], 6: [6], 11: [11], 14: [14], 15: [15]})

--- a/tests/test_direct_embedding_composite.py
+++ b/tests/test_direct_embedding_composite.py
@@ -94,15 +94,6 @@ class TestDirect(unittest.TestCase):
         with self.assertRaises(BinaryQuadraticModelStructureError):
             sampleset = sampler.sample_ising(h, J)
 
-        sampler = DirectChimeraTilesEmbeddingComposite(MockDWaveSampler(
-                  topology="pegasus"))
-
-        h = {0: -1., 4: 2}
-        J = {}
-
-        with self.assertRaises(BinaryQuadraticModelStructureError):
-            sampleset = sampler.sample_ising(h, J)
-
     def test_embedding_chimera_first_cell(self):
         sampler = DirectChimeraTilesEmbeddingComposite(MockDWaveSampler())
 
@@ -164,18 +155,17 @@ class TestDirect(unittest.TestCase):
         self.assertEqual(sampleset.info["embedding_context"]["embedding"],
              {0: [32], 1: [33], 4: [36], 6: [38], 11: [43], 14: [46], 15: [47]})
 
-    # def test_embedding_pegasus_first_cell(self):
-    #     sampler = DirectChimeraTilesEmbeddingComposite(MockDWaveSampler(
-    #               topology="pegasus"))
-    #
-    #
-    #     h = {}
-    #     J = {(0, 4): 1, (4, 1): 1, (1, 6): 1}
-    #
-    #     sampleset = sampler.sample_ising(h, J, return_embedding=True)
-    #
-    #     self.assertEqual(sampleset.info["embedding_context"]["embedding"],
-    #          {0: [0], 1: [1], 4: [4], 6: [6]})
+    def test_embedding_pegasus_first_cell(self):
+        sampler = DirectChimeraTilesEmbeddingComposite(MockDWaveSampler(
+                  topology="pegasus"))
+
+        h = {}
+        J = {(0, 4): 1, (4, 1): 1, (1, 6): 1}
+
+        sampleset = sampler.sample_ising(h, J, return_embedding=True)
+
+        self.assertEqual(sampleset.info["embedding_context"]["embedding"],
+             {0: [20], 1: [25], 4: [440], 6: [450]})
 
     def test_embedding_pegasus_two_cell(self):
         sampler = DirectChimeraTilesEmbeddingComposite(MockDWaveSampler(
@@ -193,52 +183,56 @@ class TestDirect(unittest.TestCase):
 
         sampleset = sampler.sample_qubo(Q, return_embedding=True)
 
-    # def test_embedding_chimera_first_two_cells(self):
-    #     sampler = DirectChimeraTilesEmbeddingComposite(MockDWaveSampler())
-    #
-    #     h = {}
-    #     J = {(0, 4): 1, (4, 1): 1, (1, 6): 1, (6, 14): -1, (14, 11): 1,
-    #          (11, 15): 1}
-    #
-    #     sampleset = sampler.sample_ising(h, J, return_embedding=True)
-    #
-    #     self.assertEqual(sampleset.info["embedding_context"]["embedding"],
-    #          {0: [0], 1: [1], 4: [4], 6: [6], 11: [11], 14: [14], 15: [15]})
-    #
-    # def test_embedding_chimera_first_cell_broken(self):
-    #     sampler = DirectChimeraTilesEmbeddingComposite(MockDWaveSampler(
-    #               broken_nodes=[1]))
-    #
-    #     h = {}
-    #     J = {(0, 4): 1, (4, 1): 1, (1, 6): 1}
-    #
-    #     sampleset = sampler.sample_ising(h, J, return_embedding=True)
-    #
-    #     self.assertEqual(sampleset.info["embedding_context"]["embedding"],
-    #          {0: [8], 1: [9], 4: [12], 6: [14]})
-    #
-    # def test_embedding_chimera_two_cells_second_broken(self):
-    #     sampler = DirectChimeraTilesEmbeddingComposite(MockDWaveSampler(
-    #               broken_nodes=[14]))
-    #
-    #     h = {}
-    #     J = {(0, 4): 1, (4, 1): 1, (1, 6): 1, (6, 14): -1, (14, 11): 1,
-    #          (11, 15): 1}
-    #
-    #     sampleset = sampler.sample_ising(h, J, return_embedding=True)
-    #
-    #     self.assertEqual(sampleset.info["embedding_context"]["embedding"],
-    #          {0: [16], 1: [17], 4: [20], 6: [22], 11: [27], 14: [30], 15: [31]})
-    #
-    # def test_embedding_chimera_two_cells_broken_row(self):
-    #     sampler = DirectChimeraTilesEmbeddingComposite(MockDWaveSampler(
-    #               broken_nodes=[x for x in range(0, 4*8, 8)]))  # C4 tester
-    #
-    #     h = {}
-    #     J = {(0, 4): 1, (4, 1): 1, (1, 6): 1, (6, 14): -1, (14, 11): 1,
-    #          (11, 15): 1}
-    #
-    #     sampleset = sampler.sample_ising(h, J, return_embedding=True)
-    #
-    #     self.assertEqual(sampleset.info["embedding_context"]["embedding"],
-    #          {0: [32], 1: [33], 4: [36], 6: [38], 11: [43], 14: [46], 15: [47]})
+        self.assertEqual(sampleset.info["embedding_context"]["embedding"],
+             {2: [30], 1: [25], 0: [20], 3: [35], 6: [450], 5: [445], 7: [455],
+              4: [440], 9: [85], 8: [80], 10: [90], 11: [95], 13: [446],
+              14: [451], 15: [456], 12: [441]})
+
+        h = {0: 1.0, 1: -1.0, 2: -1.0, 3: 1.0, 4: 1.0, 5: -1.0, 6: 0.0, 7: 1.0,
+             8: 1.0, 9: -1.0, 10: -1.0, 11: 1.0, 12: 1.0, 13: 0.0, 14: -1.0,
+             15: 1.0}
+        J = {(9, 13): -1, (2, 6): -1, (8, 13): -1, (9, 14): -1, (9, 15): -1,
+             (10, 13): -1, (5, 13): -1, (10, 12): -1, (1, 5): -1, (10, 14): -1,
+             (0, 5): -1, (1, 6): -1, (3, 6): -1, (1, 7): -1, (11, 14): -1,
+             (2, 5): -1, (2, 4): -1, (6, 14): -1}
+
+    def test_embedding_pegasus_first_cell_broken(self):
+        sampler = DirectChimeraTilesEmbeddingComposite(MockDWaveSampler(
+                  topology="pegasus", broken_nodes=[20]))
+
+        h = {}
+        J = {(0, 4): 1, (4, 1): 1, (1, 6): 1}
+
+        sampleset = sampler.sample_ising(h, J, return_embedding=True)
+
+        self.assertEqual(sampleset.info["embedding_context"]["embedding"],
+             {0: [40], 1: [45], 4: [420], 6: [430]})
+
+    def test_embedding_pegasus_two_cells_second_broken(self):
+        sampler = DirectChimeraTilesEmbeddingComposite(MockDWaveSampler(
+                  topology="pegasus", broken_nodes=[451]))
+
+        h = {}
+        J = {(0, 4): 1, (4, 1): 1, (1, 6): 1, (6, 14): -1, (14, 11): 1,
+             (11, 15): 1}
+
+        sampleset = sampler.sample_ising(h, J, return_embedding=True)
+
+        self.assertEqual(sampleset.info["embedding_context"]["embedding"],
+             {0: [40], 1: [45], 4: [420], 6: [430], 11: [115], 14: [431],
+              15: [436]})
+
+    def test_embedding_pegasus_two_cells_broken_row(self):
+        sampler = DirectChimeraTilesEmbeddingComposite(MockDWaveSampler(
+                  topology="pegasus",
+                  broken_nodes=[x for x in range(0, 6*12, 4)]))  # P6 tester
+
+        h = {}
+        J = {(0, 4): 1, (4, 1): 1, (1, 6): 1, (6, 14): -1, (14, 11): 1,
+             (11, 15): 1}
+
+        sampleset = sampler.sample_ising(h, J, return_embedding=True)
+
+        self.assertEqual(sampleset.info["embedding_context"]["embedding"],
+             {0: [80], 1: [85], 4: [441], 6: [451], 11: [155], 14: [452],
+              15: [457]})


### PR DESCRIPTION
For several Leap JNs I wrote a function in the past that finds the first available Chimera unit cells to "directly" embed (map each node of a Chimera-indexed graph to one qubit) small problems. The typical use case is placing the problem below without worrying about the working graph of a particular QPU:

![image](https://user-images.githubusercontent.com/34041130/81336241-cdf58780-905d-11ea-9535-793ede9d957c.png)

I'm now updating the Leap JNs for Pegasus, and went overboard on generalizing that code. I've often found this functionality useful and for Pegasus, with its more complicated coordinates, it's especially helpful, so I thought we might want it in Ocean.

An alternative approach would be to check that all nodes/couplers are in the needed number of unit cells. That code would be simpler but more wasteful. For the target graphs that's not really a big deal, though it's uglier. My main motivations for taking this approach was that it seemed a better approach pedantically for when I thought it would stay in the JNs and it was raining that weekend anyway.

If we want to add this to Ocean, I'd still need to update the RST files.  