### PR TITLE
Add CliqueEmbeddingComposite

### DIFF
--- a/dwave/system/__init__.py
+++ b/dwave/system/__init__.py
@@ -13,8 +13,6 @@
 #    limitations under the License.
 #
 # =============================================================================
-import dwave.system.flux_bias_offsets
-
 from dwave.system.samplers import *
 import dwave.system.samplers
 
@@ -22,3 +20,5 @@ from dwave.system.composites import *
 import dwave.system.composites
 
 from dwave.system.utilities import *
+
+import dwave.system.flux_bias_offsets

--- a/dwave/system/composites/clique_embedding.py
+++ b/dwave/system/composites/clique_embedding.py
@@ -1,0 +1,76 @@
+# Copyright 2020 D-Wave Systems Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+import dimod
+import networkx as nx
+
+from dwave.embedding import chimera, pegasus
+from dwave.system.composites.embedding import EmbeddingComposite
+from dwave.system.samplers import DWaveSampler
+
+__all__ = ['CliqueEmbeddingComposite']
+
+
+class CliqueEmbeddingComposite(EmbeddingComposite):
+    """
+    """
+
+    def __init__(self, child_sampler, scale_aware=False):
+
+        # go looking for a DWaveSampler in the child-chain. We could handle
+        # the multiple children case a la dimod.child_structure_dfs but
+        # for simplicty we just assume one
+        qpu = child_sampler
+        while not isinstance(qpu, DWaveSampler):
+            try:
+                qpu = qpu.child
+            except AttributeError:
+                raise ValueError("child_sampler must be or wrap DWaveSampler")
+        self._qpu = qpu  # save for later
+
+        try:
+            topology_type = qpu.properties['topology']['type']
+            topology_shape = qpu.properties['topology']['shape']
+        except KeyError:
+            raise ValueError("given sampler has unknown topology format")
+
+        # Dev note: for now we'll calculate the clique embeddings on the fly.
+        # In the future we'll want some sort of caching system
+        if topology_type == 'chimera':
+            def find_embedding(S, T):
+                k = set().union(*S)  # source nodes
+                m, n, t = topology_shape
+                return chimera.find_clique_embedding(k, m, n, t,
+                                                     target_edges=T)
+
+        elif topology_type == 'pegasus':
+            def find_embedding(S, T):
+                k = set().union(*S)
+
+                # We need a networkx graph with certain properties. In the
+                # future it would be good for DWaveSampler to handle this.
+                # See https://github.com/dwavesystems/dimod/issues/647
+                P = nx.Graph(T)
+                P.graph['rows'] = topology_shape[0]
+                P.graph['labels'] = 'int'
+
+                return pegasus.find_clique_embedding(k, target_graph=P)
+
+        else:
+            raise ValueError("given solver has an unknown topology")
+
+        super().__init__(child_sampler,
+                         scale_aware=scale_aware,
+                         find_embedding=find_embedding)

--- a/dwave/system/samplers/__init__.py
+++ b/dwave/system/samplers/__init__.py
@@ -15,3 +15,4 @@
 # ================================================================================================
 from dwave.system.samplers.dwave_sampler import *
 from dwave.system.samplers.leap_hybrid_sampler import *
+from dwave.system.samplers.reference import *

--- a/dwave/system/samplers/reference.py
+++ b/dwave/system/samplers/reference.py
@@ -1,4 +1,4 @@
-# Copyright 2018 D-Wave Systems Inc.
+# Copyright 2020 D-Wave Systems Inc.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -12,10 +12,21 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #
-# ================================================================================================
-from dwave.system.composites.clique_embedding import *
-from dwave.system.composites.cutoffcomposite import *
-from dwave.system.composites.embedding import *
-from dwave.system.composites.tiling import *
-from dwave.system.composites.virtual_graph import *
-from dwave.system.composites.reversecomposite import *
+
+import dimod
+
+from dwave.system.composites.clique_embedding import CliqueEmbeddingComposite
+from dwave.system.samplers.dwave_sampler import DWaveSampler
+
+__all__ = ['CliqueEmbeddingScalingDWaveSampler']
+
+
+def CliqueEmbeddingScalingDWaveSampler(**config):
+    sampler = \
+        CliqueEmbeddingComposite(
+            dimod.ScaleComposite(
+                DWaveSampler(**config)
+                )
+            )
+
+    return sampler

--- a/tests/qpu/test_reference.py
+++ b/tests/qpu/test_reference.py
@@ -1,4 +1,4 @@
-# Copyright 2018 D-Wave Systems Inc.
+# Copyright 2020 D-Wave Systems Inc.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -12,10 +12,20 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #
-# ================================================================================================
-from dwave.system.composites.clique_embedding import *
-from dwave.system.composites.cutoffcomposite import *
-from dwave.system.composites.embedding import *
-from dwave.system.composites.tiling import *
-from dwave.system.composites.virtual_graph import *
-from dwave.system.composites.reversecomposite import *
+
+import unittest
+
+from dwave.cloud.exceptions import ConfigFileError
+from dwave.system import CliqueEmbeddingScalingDWaveSampler
+
+
+class TestCliqueEmbeddingScalingDWaveSampler(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        try:
+            cls.sampler = CliqueEmbeddingScalingDWaveSampler(solver=dict(qpu=True))
+        except (ValueError, ConfigFileError):
+            raise unittest.SkipTest("no qpu available")
+
+    def test_1(self):
+        pass


### PR DESCRIPTION
Closes #301 

So far only the embedding part has been implemented. Todo:
- [ ] chain strength
- [ ] automorphisms
- [ ] caching, see https://github.com/dwavesystems/dwave-system/issues/228#issuecomment-640854941

I have also added a new `dwave/system/samplers/reference.py` to contain some pre-built samplers. The relevant one here is the so-called `CliqueEmbeddingScalingSampler`.