### PR TITLE
Specialized dwave samplers

### DIFF
--- a/docs/reference/minimize_energy/dwave.embedding.chain_breaks.MinimizeEnergy.rst
+++ b/docs/reference/minimize_energy/dwave.embedding.chain_breaks.MinimizeEnergy.rst
@@ -1,7 +1,16 @@
-dwave.embedding.chain_breaks.MinimizeEnergy
-===========================================
+﻿dwave.embedding.chain\_breaks.MinimizeEnergy
+============================================
 
 .. currentmodule:: dwave.embedding.chain_breaks
 
 .. autoclass:: MinimizeEnergy
-    :members: __call__
+
+
+   .. automethod:: __init__
+
+
+   .. rubric:: Methods
+
+   .. autosummary::
+
+      ~MinimizeEnergy.__init__

--- a/dwave/system/samplers/clique.py
+++ b/dwave/system/samplers/clique.py
@@ -56,10 +56,15 @@ class DWaveCliqueSampler(dimod.Sampler):
     """
     def __init__(self, **config):
 
-        # get the QPU with the most qubits available, subject to other
-        # constraints specified in **config
-        self.child = child = DWaveSampler(order_by='-num_active_qubits',
-                                          **config)
+        # to get the QPU with the most qubits available (subject to other
+        # constraints specified in **config), we need to set order_by
+        # (use simple solver parsing for now, i.e. until we have
+        # https://github.com/dwavesystems/dwave-cloud-client/issues/424)
+        solver = config.pop('solver', {})
+        if isinstance(solver, str):
+            solver = dict(name__eq=solver)
+        solver.update(order_by='-num_active_qubits')
+        self.child = child = DWaveSampler(solver=solver, **config)
 
         # do some topology checking
         try:

--- a/dwave/system/samplers/clique.py
+++ b/dwave/system/samplers/clique.py
@@ -56,15 +56,7 @@ class DWaveCliqueSampler(dimod.Sampler):
     """
     def __init__(self, **config):
 
-        # to get the QPU with the most qubits available (subject to other
-        # constraints specified in **config), we need to set order_by
-        # (use simple solver parsing for now, i.e. until we have
-        # https://github.com/dwavesystems/dwave-cloud-client/issues/424)
-        solver = config.pop('solver', {})
-        if isinstance(solver, str):
-            solver = dict(name__eq=solver)
-        solver.update(order_by='-num_active_qubits')
-        self.child = child = DWaveSampler(solver=solver, **config)
+        self.child = child = DWaveSampler(**config)
 
         # do some topology checking
         try:

--- a/dwave/system/samplers/dwave_sampler.py
+++ b/dwave/system/samplers/dwave_sampler.py
@@ -120,6 +120,18 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
         profile (str, optional):
             Profile to select from the configuration file.
 
+        client (str, optional, default='qpu'):
+            Client type used for accessing the API. Client type effectively
+            constraints the solver's ``category``. Supported values are
+            ``qpu``, ``sw`` and ``hybrid`` for QPU, software and hybrid solvers
+            respectively. In addition, ``base`` client type doesn't filter
+            solvers at all.
+
+            Note:
+                Until version 0.10.0 of ``dwave-system``, :class:`DWaveSampler`
+                used the ``base`` client, allowing non-QPU solvers to be
+                selected. To emulate the old behavior, set ``client='base'``.
+
         endpoint (str, optional):
             D-Wave API endpoint URL.
 
@@ -131,9 +143,6 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
             as a set of required features. Supported features and values are described in
             :meth:`~dwave.cloud.client.Client.get_solvers`. For backward
             compatibility, a solver name, formatted as a string, is accepted.
-
-        proxy (str, optional):
-            Proxy URL to be used for accessing the D-Wave API.
 
         **config:
             Keyword arguments passed directly to :meth:`~dwave.cloud.client.Client.from_config`.
@@ -176,6 +185,9 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
                 raise ValueError("can not combine 'solver' and 'solver_features'")
 
             config['solver'] = config.pop('solver_features')
+
+        # we want a QPU solver by default, but allow override
+        config.setdefault('client', 'qpu')
 
         self.client = Client.from_config(**config)
 

--- a/dwave/system/samplers/dwave_sampler.py
+++ b/dwave/system/samplers/dwave_sampler.py
@@ -184,15 +184,6 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
     """
     def __init__(self, failover=False, retry_interval=-1, order_by=None, **config):
 
-        if config.get('solver_features') is not None:
-            warn("'solver_features' argument has been renamed to 'solver'.",
-                 DeprecationWarning)
-
-            if config.get('solver') is not None:
-                raise ValueError("can not combine 'solver' and 'solver_features'")
-
-            config['solver'] = config.pop('solver_features')
-
         # fold isolated order_by under solver
         if order_by is not None:
             warn("'order_by' has been moved under 'solver' dict.",

--- a/dwave/system/samplers/dwave_sampler.py
+++ b/dwave/system/samplers/dwave_sampler.py
@@ -133,9 +133,9 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
             solvers at all.
 
             Note:
-                Until version 0.10.0 of ``dwave-system``, :class:`DWaveSampler`
-                used the ``base`` client, allowing non-QPU solvers to be
-                selected. To emulate the old behavior, set ``client='base'``.
+                Prior to version 0.10.0, :class:`.DWaveSampler` used the
+                ``base`` client, allowing non-QPU solvers to be selected.
+                To reproduce the old behavior, set ``client='base'``.
 
         endpoint (str, optional):
             D-Wave API endpoint URL.
@@ -230,7 +230,7 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
             >>> from dwave.system import DWaveSampler
             >>> sampler = DWaveSampler()
             >>> sampler.properties    # doctest: +SKIP
-            {u'anneal_offset_ranges': [[-0.2197463755538704, 0.03821687759418928],
+            {'anneal_offset_ranges': [[-0.2197463755538704, 0.03821687759418928],
               [-0.2242514597680286, 0.01718456460967399],
               [-0.20860153999435985, 0.05511969218508182],
             # Snipped above response for brevity
@@ -261,12 +261,12 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
             >>> from dwave.system import DWaveSampler
             >>> sampler = DWaveSampler()
             >>> sampler.parameters    # doctest: +SKIP
-            {u'anneal_offsets': ['parameters'],
-            u'anneal_schedule': ['parameters'],
-            u'annealing_time': ['parameters'],
-            u'answer_mode': ['parameters'],
-            u'auto_scale': ['parameters'],
-            # Snipped above response for brevity
+            {'anneal_offsets': ['parameters'],
+             'anneal_schedule': ['parameters'],
+             'annealing_time': ['parameters'],
+             'answer_mode': ['parameters'],
+             'auto_scale': ['parameters'],
+             # Snipped above response for brevity
 
         See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/stable/concepts/index.html>`_
         for explanations of technical terms in descriptions of Ocean tools.
@@ -519,12 +519,12 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
 
 
     def to_networkx_graph(self):
-
         """Converts DWaveSampler's structure to a Chimera or Pegasus NetworkX graph.
 
         Returns:
-            G : :class:`networkx.Graph` graph.
+            :class:`networkx.Graph`:
                 Either an (m, n, t) Chimera lattice or a Pegasus lattice of size m.
+
         Examples:
             This example converts a selected D-Wave system solver to a graph
             and verifies it has over 2000 nodes.
@@ -535,8 +535,6 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
             >>> g = sampler.to_networkx_graph()      # doctest: +SKIP
             >>> len(g.nodes) > 2000                  # doctest: +SKIP
             True
-
-
         """
 
         topology_type = self.properties['topology']['type']

--- a/dwave/system/samplers/dwave_sampler.py
+++ b/dwave/system/samplers/dwave_sampler.py
@@ -169,7 +169,7 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
 
         >>> from dwave.system import DWaveSampler
         ...
-        >>> sampler = DWaveSampler(solver={'qpu': True})
+        >>> sampler = DWaveSampler()
         ...
         >>> qubit_a = sampler.nodelist[0]
         >>> qubit_b = next(iter(sampler.adjacency[qubit_a]))
@@ -365,7 +365,7 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
 
             >>> from dwave.system import DWaveSampler
             ...
-            >>> sampler = DWaveSampler(solver={'qpu': True})
+            >>> sampler = DWaveSampler()
             ...
             >>> qubit_a = sampler.nodelist[0]
             >>> qubit_b = next(iter(sampler.adjacency[qubit_a]))
@@ -531,7 +531,7 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
 
             >>> from dwave.system import DWaveSampler
             ...
-            >>> sampler = DWaveSampler(solver={'qpu': True})
+            >>> sampler = DWaveSampler()
             >>> g = sampler.to_networkx_graph()      # doctest: +SKIP
             >>> len(g.nodes) > 2000                  # doctest: +SKIP
             True

--- a/dwave/system/samplers/leap_hybrid_sampler.py
+++ b/dwave/system/samplers/leap_hybrid_sampler.py
@@ -112,10 +112,13 @@ class LeapHybridSampler(dimod.Sampler):
             if solver.setdefault('supported_problem_types__contains', 'bqm') != 'bqm':
                 raise ValueError("the only problem type this sampler supports is 'bqm'")
 
+            # prefer the latest version, but allow kwarg override
+            solver.setdefault('order_by', '-version')
+
         self.client = Client.from_config(
             solver=solver, connection_close=connection_close, **config)
 
-        self.solver = self.client.get_solver(order_by='-version')
+        self.solver = self.client.get_solver()
 
         # For explicitly named solvers:
         if self.properties.get('category') != 'hybrid':

--- a/dwave/system/samplers/leap_hybrid_sampler.py
+++ b/dwave/system/samplers/leap_hybrid_sampler.py
@@ -29,6 +29,7 @@ from dwave.cloud import Client
 
 __all__ = ['LeapHybridSampler']
 
+
 class LeapHybridSampler(dimod.Sampler):
     """A class for using Leap's cloud-based hybrid solvers.
 
@@ -62,6 +63,10 @@ class LeapHybridSampler(dimod.Sampler):
         token (str, optional):
             Authentication token for the D-Wave API to authenticate the client session.
 
+        solver (dict/str, optional):
+            Solver (a hybrid solver on which to run submitted problems) to select,
+            formatted as a string, or as a dict of solver features required.
+
         proxy (str, optional):
             Proxy URL to be used for accessing the D-Wave API.
 
@@ -94,13 +99,14 @@ class LeapHybridSampler(dimod.Sampler):
 
     def __init__(self, solver=None, connection_close=True, **config):
 
-        # always use the base class (QPU client filters-out the hybrid solvers)
-        config['client'] = 'base'
+        # we want a Hybrid solver by default, but allow override
+        config.setdefault('client', 'hybrid')
 
         if solver is None:
             solver = {}
 
         if isinstance(solver, abc.Mapping):
+            # TODO: instead of solver selection, try with user's default first
             if solver.setdefault('category', 'hybrid') != 'hybrid':
                 raise ValueError("the only 'category' this sampler supports is 'hybrid'")
             if solver.setdefault('supported_problem_types__contains', 'bqm') != 'bqm':

--- a/dwave/system/samplers/leap_hybrid_sampler.py
+++ b/dwave/system/samplers/leap_hybrid_sampler.py
@@ -41,15 +41,6 @@ class LeapHybridSampler(dimod.Sampler):
     Inherits from :class:`dimod.Sampler`.
 
     Args:
-        solver (dict/str, optional):
-            Solver (a hybrid solver on which to run submitted problems) to select
-            named as a string or given as a set of required features. Supported
-            features and values are described in
-            :meth:`~dwave.cloud.client.Client.get_solvers`.
-
-        connection_close (bool, optional):
-            Force HTTP(S) connection close after each request.
-
         config_file (str, optional):
             Path to a configuration file that identifies a hybrid solver and provides
             connection information.
@@ -64,14 +55,13 @@ class LeapHybridSampler(dimod.Sampler):
             Authentication token for the D-Wave API to authenticate the client session.
 
         solver (dict/str, optional):
-            Solver (a hybrid solver on which to run submitted problems) to select,
-            formatted as a string, or as a dict of solver features required.
-
-        proxy (str, optional):
-            Proxy URL to be used for accessing the D-Wave API.
+            Solver (a hybrid solver on which to run submitted problems) to select
+            named as a string or given as a set of required features. Supported
+            features and values are described in
+            :meth:`~dwave.cloud.client.Client.get_solvers`.
 
         **config:
-            Keyword arguments passed directly to :meth:`~dwave.cloud.client.Client.from_config`.
+            Keyword arguments passed to :meth:`~dwave.cloud.client.Client.from_config`.
 
     Examples:
         This example builds a random sparse graph and uses a hybrid solver to find a

--- a/dwave/system/utilities.py
+++ b/dwave/system/utilities.py
@@ -47,7 +47,7 @@ def common_working_graph(graph0, graph1):
         >>> import dwave_networkx as dnx
         >>> from dwave.system import DWaveSampler, common_working_graph
         ...
-        >>> sampler = DWaveSampler(solver={'qpu': True})
+        >>> sampler = DWaveSampler()
         >>> C4 = dnx.chimera_graph(4)  # a 4x4 lattice of Chimera tiles
         >>> c4_working_graph = common_working_graph(C4, sampler.adjacency)   
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 --extra-index-url https://pypi.dwavesys.com/simple
 
 dimod==0.9.6
-dwave-cloud-client==0.7.7
+dwave-cloud-client==0.8.0
 dwave-networkx==0.8.4
 dwave-drivers==0.4.4
 dwave-tabu==0.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 --extra-index-url https://pypi.dwavesys.com/simple
 
 dimod==0.9.6
-dwave-cloud-client==0.7.5
+dwave-cloud-client==0.7.7
 dwave-networkx==0.8.4
 dwave-drivers==0.4.4
 dwave-tabu==0.2.2

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ exec(open(os.path.join(".", "dwave", "system", "package_info.py")).read())
 
 
 install_requires = ['dimod>=0.9.6,<0.10.0',
-                    'dwave-cloud-client>=0.7.7,<0.8.0',
+                    'dwave-cloud-client>=0.8.0,<0.9.0',
                     'dwave-networkx>=0.8.4',
                     'networkx>=2.0,<3.0',
                     'homebase>=1.0.0,<2.0.0',

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ exec(open(os.path.join(".", "dwave", "system", "package_info.py")).read())
 
 
 install_requires = ['dimod>=0.9.6,<0.10.0',
-                    'dwave-cloud-client>=0.7.5,<0.8.0',
+                    'dwave-cloud-client>=0.7.7,<0.8.0',
                     'dwave-networkx>=0.8.4',
                     'networkx>=2.0,<3.0',
                     'homebase>=1.0.0,<2.0.0',

--- a/tests/qpu/test_dwavecliquesampler.py
+++ b/tests/qpu/test_dwavecliquesampler.py
@@ -24,8 +24,7 @@ from dwave.system import DWaveCliqueSampler
 class TestDWaveCliqueSampler(unittest.TestCase):
     def test_chimera(self):
         try:
-            sampler = DWaveCliqueSampler(
-                solver=dict(topology__type='chimera', qpu=True))
+            sampler = DWaveCliqueSampler(solver=dict(topology__type='chimera'))
         except (ValueError, ConfigFileError, SolverNotFoundError):
             raise unittest.SkipTest("no Chimera-structured QPU available")
 
@@ -40,8 +39,7 @@ class TestDWaveCliqueSampler(unittest.TestCase):
 
     def test_pegasus(self):
         try:
-            sampler = DWaveCliqueSampler(
-                solver=dict(topology__type='pegasus', qpu=True))
+            sampler = DWaveCliqueSampler(solver=dict(topology__type='pegasus'))
         except (ValueError, ConfigFileError, SolverNotFoundError):
             raise unittest.SkipTest("no Pegasus-structured QPU available")
 

--- a/tests/qpu/test_dwavesampler.py
+++ b/tests/qpu/test_dwavesampler.py
@@ -149,5 +149,10 @@ class TestClientSelection(unittest.TestCase):
             self.assertEqual(DWaveSampler(client='hybrid').client, hybrid())
 
     def test_base_client(self):
-        self.assertIsInstance(DWaveSampler(client=None).client, Client)
-        self.assertIsInstance(DWaveSampler(client='base').client, Client)
+        # to test 'base' client instantiation offline,
+        # we would need a mock client and a mock solver
+        try:
+            self.assertEqual(type(DWaveSampler(client=None).client), Client)
+            self.assertEqual(type(DWaveSampler(client='base').client), Client)
+        except (ValueError, ConfigFileError):
+            raise unittest.SkipTest("no API token available")

--- a/tests/qpu/test_dwavesampler.py
+++ b/tests/qpu/test_dwavesampler.py
@@ -30,7 +30,7 @@ class TestDWaveSampler(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         try:
-            cls.qpu = DWaveSampler(solver=dict(qpu=True))
+            cls.qpu = DWaveSampler()
         except (ValueError, ConfigFileError):
             raise unittest.SkipTest("no qpu available")
 
@@ -115,8 +115,7 @@ class TestMissingQubits(unittest.TestCase):
     def setUpClass(cls):
         try:
             # get a QPU with less than 100% yield
-            cls.qpu = DWaveSampler(solver=dict(qpu=True,
-                                               num_active_qubits__lt=2048))
+            cls.qpu = DWaveSampler(solver=dict(num_active_qubits__lt=2048))
         except (ValueError, ConfigFileError):
             raise unittest.SkipTest("no qpu available")
 

--- a/tests/qpu/test_dwavesampler.py
+++ b/tests/qpu/test_dwavesampler.py
@@ -14,11 +14,13 @@
 #
 # =============================================================================
 import unittest
+from unittest import mock
 
 import numpy
 
 import dimod
 from dwave.cloud.exceptions import ConfigFileError
+from dwave.cloud.client import Client
 
 from dwave.system.samplers import DWaveSampler
 
@@ -132,3 +134,21 @@ class TestMissingQubits(unittest.TestCase):
 
         self.assertEqual(set(sampleset.variables), set(sampler.nodelist))
         assert len(sampleset.variables) < 2048  # sanity check
+
+
+class TestClientSelection(unittest.TestCase):
+
+    def test_client_type(self):
+        with mock.patch('dwave.cloud.qpu.Client') as qpu:
+            self.assertEqual(DWaveSampler().client, qpu())
+            self.assertEqual(DWaveSampler(client='qpu').client, qpu())
+
+        with mock.patch('dwave.cloud.sw.Client') as sw:
+            self.assertEqual(DWaveSampler(client='sw').client, sw())
+
+        with mock.patch('dwave.cloud.hybrid.Client') as hybrid:
+            self.assertEqual(DWaveSampler(client='hybrid').client, hybrid())
+
+    def test_base_client(self):
+        self.assertIsInstance(DWaveSampler(client=None).client, Client)
+        self.assertIsInstance(DWaveSampler(client='base').client, Client)

--- a/tests/qpu/test_embeddingcomposite.py
+++ b/tests/qpu/test_embeddingcomposite.py
@@ -28,8 +28,8 @@ class TestEmbeddingCompositeExactSolver(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         try:
-            cls.qpu = DWaveSampler(solver=dict(
-                qpu=True, initial_state=True, anneal_schedule=True))
+            cls.qpu = DWaveSampler(
+                solver=dict(initial_state=True, anneal_schedule=True))
         except (ValueError, ConfigFileError):
             raise unittest.SkipTest("no qpu available")
 

--- a/tests/qpu/test_schedules.py
+++ b/tests/qpu/test_schedules.py
@@ -25,7 +25,7 @@ class TestRamp(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         try:
-            cls.qpu = DWaveSampler(solver=dict(qpu=True, h_gain_schedule=True))
+            cls.qpu = DWaveSampler(solver=dict(h_gain_schedule=True))
         except (ValueError, ConfigFileError):
             raise unittest.SkipTest("no qpu available")
 

--- a/tests/qpu/test_virtual_graph_composite.py
+++ b/tests/qpu/test_virtual_graph_composite.py
@@ -30,7 +30,7 @@ class TestVirtualGraphComposite(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         try:
-            cls.qpu = DWaveSampler(solver=dict(qpu=True, flux_biases=True))
+            cls.qpu = DWaveSampler(solver=dict(flux_biases=True))
         except (ValueError, ConfigFileError):
             raise unittest.SkipTest("no qpu available")
 

--- a/tests/test_dwavecliquesampler.py
+++ b/tests/test_dwavecliquesampler.py
@@ -51,7 +51,7 @@ class MockDWaveSampler(dimod.RandomSampler, dimod.Structured):
 
 
 class MockChimeraDWaveSampler(MockDWaveSampler):
-    def __init__(self, order_by=None):
+    def __init__(self, **config):
         super().__init__()
 
         self.properties.update(topology=dict(shape=[4, 4, 4], type='chimera'))
@@ -75,7 +75,7 @@ class MockChimeraDWaveSampler(MockDWaveSampler):
 
 
 class MockPegasusDWaveSampler(MockDWaveSampler):
-    def __init__(self, order_by=None):
+    def __init__(self, **config):
         super().__init__()
 
         self.properties.update(topology=dict(shape=[6], type='pegasus'))

--- a/tests/test_dwavesampler.py
+++ b/tests/test_dwavesampler.py
@@ -20,6 +20,7 @@ import warnings
 
 from collections import namedtuple
 from concurrent.futures import Future
+from unittest import mock
 from uuid import uuid4
 
 import numpy as np
@@ -31,13 +32,6 @@ from dwave.cloud.exceptions import SolverOfflineError, SolverNotFoundError
 
 from dwave.system.samplers import DWaveSampler
 from dwave.system.warnings import EnergyScaleWarning, TooFewSamplesWarning
-
-try:
-    # py3
-    import unittest.mock as mock
-except ImportError:
-    # py2
-    import mock
 
 
 C16 = dnx.chimera_graph(16)
@@ -124,7 +118,7 @@ class TestDwaveSampler(unittest.TestCase):
         MockClient.reset_mock()
         solver = {'qpu': True, 'num_qubits__gt': 1000}
         sampler = DWaveSampler(solver=solver)
-        MockClient.from_config.assert_called_once_with(solver=solver)
+        MockClient.from_config.assert_called_once_with(client='qpu', solver=solver)
 
     def test_sample_ising_variables(self):
 

--- a/tests/test_dwavesampler.py
+++ b/tests/test_dwavesampler.py
@@ -100,11 +100,37 @@ class TestDwaveSampler(unittest.TestCase):
         self.sampler.solver = MockSolver()
 
     @mock.patch('dwave.system.samplers.dwave_sampler.Client')
-    def test_solver_init(self, MockClient):
+    def test_init_default(self, MockClient):
+        """QPU with the highest number of qubits chosen by default."""
+
+        sampler = DWaveSampler()
+
+        MockClient.from_config.assert_called_once_with(
+            client='qpu',
+            defaults={'solver': {'order_by': '-num_active_qubits'}})
+
+    @mock.patch('dwave.system.samplers.dwave_sampler.Client')
+    def test_init_generic_behavior(self, MockClient):
+        """Generic solver behavior (default prior to 0.10.0) can be forced."""
+
+        sampler = DWaveSampler(client='base')
+
+        MockClient.from_config.assert_called_once_with(
+            client='base',
+            defaults={'solver': {'order_by': '-num_active_qubits'}})
+
+    @mock.patch('dwave.system.samplers.dwave_sampler.Client')
+    def test_init_solver(self, MockClient):
+        """QPU can be explicitly selected (old default usage example)"""
 
         solver = {'qpu': True, 'num_qubits__gt': 1000}
+
         sampler = DWaveSampler(solver=solver)
-        MockClient.from_config.assert_called_once_with(client='qpu', solver=solver)
+
+        MockClient.from_config.assert_called_once_with(
+            client='qpu',
+            solver=solver,
+            defaults={'solver': {'order_by': '-num_active_qubits'}})
 
     def test_sample_ising_variables(self):
 

--- a/tests/test_dwavesampler.py
+++ b/tests/test_dwavesampler.py
@@ -101,21 +101,7 @@ class TestDwaveSampler(unittest.TestCase):
 
     @mock.patch('dwave.system.samplers.dwave_sampler.Client')
     def test_solver_init(self, MockClient):
-        """Deprecation warning is raised for `solver_features` use, but it still works."""
 
-        # assertWarns not available in py2
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            DWaveSampler(solver_features={'qpu': True})
-            self.assertEqual(len(w), 1)
-            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
-
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            DWaveSampler(solver={'qpu': True})
-            self.assertEqual(len(w), 0)
-
-        MockClient.reset_mock()
         solver = {'qpu': True, 'num_qubits__gt': 1000}
         sampler = DWaveSampler(solver=solver)
         MockClient.from_config.assert_called_once_with(client='qpu', solver=solver)

--- a/tests/test_leaphybridsolver.py
+++ b/tests/test_leaphybridsolver.py
@@ -41,7 +41,7 @@ class MockClient:
 
         self.args = kwargs
 
-    def get_solver(self, order_by=None):
+    def get_solver(self, **filters):
 
         if isinstance(self.args['solver'], str) and self.args['solver'] == 'not_hybrid_solver':
             return MockBadLeapHybridSolver()

--- a/tests/test_leaphybridsolver.py
+++ b/tests/test_leaphybridsolver.py
@@ -64,7 +64,8 @@ class TestLeapHybridSampler(unittest.TestCase):
         mock_client.from_config.assert_called_once_with(
             client='hybrid', connection_close=True,
             solver={'category': 'hybrid',
-                    'supported_problem_types__contains': 'bqm'})
+                    'supported_problem_types__contains': 'bqm',
+                    'order_by': '-version'})
 
         # Non-hybrid client setting
         mock_client.reset_mock()
@@ -73,11 +74,13 @@ class TestLeapHybridSampler(unittest.TestCase):
 
         # Explicitly set category to hybrid
         mock_client.reset_mock()
-        LeapHybridSampler(solver={'category': 'hybrid', 'supported_problem_types__contains': 'bqm'})
+        LeapHybridSampler(solver={'category': 'hybrid',
+                                  'supported_problem_types__contains': 'bqm'})
         mock_client.from_config.assert_called_once_with(
             client='hybrid', connection_close=True,
             solver={'category': 'hybrid',
-                    'supported_problem_types__contains': 'bqm'})
+                    'supported_problem_types__contains': 'bqm',
+                    'order_by': '-version'})
 
         # Explicitly set category to not hybrid
         with self.assertRaises(ValueError):
@@ -89,14 +92,16 @@ class TestLeapHybridSampler(unittest.TestCase):
         mock_client.from_config.assert_called_once_with(
             client='hybrid', connection_close=True,
             solver={'qpu': True, 'category': 'hybrid',
-                    'supported_problem_types__contains': 'bqm'})
+                    'supported_problem_types__contains': 'bqm',
+                    'order_by': '-version'})
 
         mock_client.reset_mock()
         LeapHybridSampler(solver={'qpu': True, 'anneal_schedule': False})
         mock_client.from_config.assert_called_once_with(
             client='hybrid', connection_close=True,
             solver={'anneal_schedule': False, 'qpu': True, 'category': 'hybrid',
-                    'supported_problem_types__contains': 'bqm'})
+                    'supported_problem_types__contains': 'bqm',
+                    'order_by': '-version'})
 
         # Named solver: hybrid
         mock_client.reset_mock()
@@ -119,7 +124,8 @@ class TestLeapHybridSampler(unittest.TestCase):
         mock_client.from_config.assert_called_once_with(
             client='hybrid', connection_close=False,
             solver={'category': 'hybrid',
-                    'supported_problem_types__contains': 'bqm'})
+                    'supported_problem_types__contains': 'bqm',
+                    'order_by': '-version'})
 
         mock_client.reset_mock()
         LeapHybridSampler(connection_close=False,
@@ -128,7 +134,8 @@ class TestLeapHybridSampler(unittest.TestCase):
         mock_client.from_config.assert_called_once_with(
             client='hybrid', connection_close=False,
             solver={'category': 'hybrid',
-                    'supported_problem_types__contains': 'bqm'})
+                    'supported_problem_types__contains': 'bqm',
+                    'order_by': '-version'})
 
     @mock.patch('dwave.system.samplers.leap_hybrid_sampler.Client')
     def test_sample_bqm(self, mock_client):


### PR DESCRIPTION
Closes #288.
Closes #335.

(A) and (B) have been implemented, (C) has been dropped for now.

The idea is to have `DWaveSampler`/`DWaveCliqueSampler` and `LeapHybridSampler` auto-select QPU and Hybrid solvers, but allow for user override from a configuration file/environment via `solver` parameter.

- [x] include the [fix for `order_by`](https://github.com/dwavesystems/dwave-system/pull/313/files#r460327462) here, after a client with fix for https://github.com/dwavesystems/dwave-cloud-client/issues/407 is released.
- [x] implement solver preference via config hints (aka [zero-level config](https://github.com/dwavesystems/dwave-cloud-client/issues/425))