### PR TITLE
Improve default chain strength in embed_bqm 

### DIFF
--- a/dwave/embedding/chain_strengths.py
+++ b/dwave/embedding/chain_strengths.py
@@ -17,8 +17,10 @@ import math
 __all__ = ['uniform_torque_compensation']
 
 def uniform_torque_compensation(bqm, embedding=None, prefactor=1.414):
-    """Calculates chain strength using the RMS of the problem's quadratic biases.
-    Attempts to compensate for the torque that would break the chain. 
+    """Chain strength that attempts to compensate for torque that would break
+    the chain.
+
+    The RMS of the problem's quadratic biases is used for calculation.
 
     Args: 
         bqm (:obj:`.BinaryQuadraticModel`):

--- a/dwave/embedding/chain_strengths.py
+++ b/dwave/embedding/chain_strengths.py
@@ -1,0 +1,42 @@
+# Copyright 2020 D-Wave Systems Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+import math
+
+__all__ = ['scaled_degree_rms']
+
+def scaled_degree_rms(bqm, prefactor=1.414, **kwargs):
+    """Calculates chain strength using the RMS of the problem's quadratic biases. 
+
+    Args: 
+        bqm (:obj:`.BinaryQuadraticModel`):
+            A binary quadratic model.
+
+        prefactor (float, optional, default=1.414):
+            Prefactor used for scaling. For non-pathological problems, the recommended 
+            range of prefactors to try is [0.5, 2].
+
+    Returns:
+        float: The chain strength, or 1 if chain strength is not applicable
+               to the problem. 
+            
+    """
+    if bqm.num_interactions > 0:
+        squared_j = (j ** 2 for j in bqm.quadratic.values())
+        rms = math.sqrt(sum(squared_j)/bqm.num_interactions)
+        avg_degree = bqm.degrees(array=True).mean()
+
+        return prefactor * rms * math.sqrt(avg_degree)
+    else:
+        return 1    # won't matter (chain strength isn't needed to embed this problem)

--- a/dwave/embedding/chain_strengths.py
+++ b/dwave/embedding/chain_strengths.py
@@ -14,14 +14,19 @@
 
 import math
 
-__all__ = ['scaled_degree_rms']
+__all__ = ['uniform_torque_compensation']
 
-def scaled_degree_rms(bqm, prefactor=1.414, **kwargs):
-    """Calculates chain strength using the RMS of the problem's quadratic biases. 
+def uniform_torque_compensation(bqm, embedding=None, prefactor=1.414):
+    """Calculates chain strength using the RMS of the problem's quadratic biases.
+    Attempts to compensate for the torque that would break the chain. 
 
     Args: 
         bqm (:obj:`.BinaryQuadraticModel`):
             A binary quadratic model.
+
+        embedding (dict/:class:`.EmbeddedStructure`, default=None):
+            Included to satisfy the `chain_strength` callable specifications 
+            for `embed_bqm`. 
 
         prefactor (float, optional, default=1.414):
             Prefactor used for scaling. For non-pathological problems, the recommended 

--- a/dwave/embedding/transforms.py
+++ b/dwave/embedding/transforms.py
@@ -99,7 +99,7 @@ class EmbeddedStructure(dict):
 
     @property
     def chain_strength(self):
-        """Returns the chain strength selected for embedding."""
+        """callable: Return the chain strength selected for embedding."""
         return self._chain_strength
 
     def chain_edges(self, u):

--- a/dwave/embedding/transforms.py
+++ b/dwave/embedding/transforms.py
@@ -25,7 +25,7 @@ from collections import defaultdict
 from dwave.embedding.chain_breaks import majority_vote, broken_chains
 from dwave.embedding.exceptions import MissingEdgeError, MissingChainError, InvalidNodeError, DisconnectedChainError
 from dwave.embedding.utils import adjacency_to_edges, intlabel_disjointsets
-from dwave.embedding.chain_strengths import scaled_degree_rms
+from dwave.embedding.chain_strengths import uniform_torque_compensation
 
 
 __all__ = ['embed_bqm',
@@ -173,7 +173,7 @@ class EmbeddedStructure(dict):
                 variables to create chains, with the energy penalty of chain
                 breaks set to 2 * `chain_strength`.  If a mapping is passed, a 
                 chain-specific strength is applied.  If a callable is passed, it
-                will be called on `chain_strength(source_bqm, embedding=self)` 
+                will be called on `chain_strength(source_bqm, self)` 
                 and should return a float or mapping, to be interpreted as above. 
                 By default, `chain_strength` is scaled to the problem.
 
@@ -231,10 +231,10 @@ class EmbeddedStructure(dict):
         target_bqm.add_offset(source_bqm.offset)
 
         if chain_strength is None:
-            chain_strength = scaled_degree_rms
+            chain_strength = uniform_torque_compensation
 
         if callable(chain_strength):
-            chain_strength = chain_strength(source_bqm, embedding=self)
+            chain_strength = chain_strength(source_bqm, self)
 
         self._chain_strength = chain_strength
 
@@ -320,7 +320,7 @@ def embed_bqm(source_bqm, embedding=None, target_adjacency=None,
             variables to form a chain, with the energy penalty of chain breaks
             set to 2 * `chain_strength`.  If a mapping is passed, a chain-specific 
             strength is applied.  If a callable is passed, it will be called on 
-            `chain_strength(source_bqm, embedding=embedding)` and should return a 
+            `chain_strength(source_bqm, embedding)` and should return a 
             float or mapping, to be interpreted as above. By default,
             `chain_strength` is scaled to the problem.
 
@@ -393,12 +393,15 @@ def embed_ising(source_h, source_J, embedding, target_adjacency, chain_strength=
             Adjacency of the target graph as a dict of form {t: Nt, ...},
             where t is a target-graph variable and Nt is its set of neighbours.
 
-        chain_strength (float/mapping, optional):
+        chain_strength (float/mapping/callable, optional):
             Magnitude of the quadratic bias (in SPIN-space) applied between
             variables to form a chain, with the energy penalty of chain breaks
-            set to 2 * `chain_strength`.  If a dict is passed, a chain-specific
-            strength is applied. By default, `chain_strength` is scaled to the problem.
-
+            set to 2 * `chain_strength`.  If a mapping is passed, a chain-specific 
+            strength is applied.  If a callable is passed, it will be called on 
+            `chain_strength(source_bqm, embedding)` and should return a 
+            float or mapping, to be interpreted as above. By default,
+            `chain_strength` is scaled to the problem.
+    
     Returns:
         tuple: A 2-tuple:
 
@@ -457,7 +460,7 @@ def embed_qubo(source_Q, embedding, target_adjacency, chain_strength=None):
             variables to form a chain, with the energy penalty of chain breaks
             set to 2 * `chain_strength`.  If a mapping is passed, a 
             chain-specific strength is applied.  If a callable is passed, it
-            will be called on `chain_strength(source_bqm, embedding=embedding)` 
+            will be called on `chain_strength(source_bqm, embedding)` 
             and should return a float or mapping, to be interpreted as above. 
             By default, `chain_strength` is scaled to the problem.
 

--- a/dwave/embedding/transforms.py
+++ b/dwave/embedding/transforms.py
@@ -68,6 +68,7 @@ class EmbeddedStructure(dict):
         target_label = {}
         self._chain_edges = chain_edges = {}
         self._interaction_edges = interaction_edges = defaultdict(list)
+        self._chain_strength = None
 
         disjoint_sets = {}
         # prepare the data structures and compute the labeling of target nodes
@@ -95,6 +96,10 @@ class EmbeddedStructure(dict):
             if len(emb_u) != disjoint_sets[u].size(0):
                 raise DisconnectedChainError(u)
 
+    @property
+    def chain_strength(self):
+        """Returns the chain strength selected for embedding."""
+        return self._chain_strength
 
     def chain_edges(self, u):
         """Iterate over edges contained in the chain for u
@@ -197,7 +202,7 @@ class EmbeddedStructure(dict):
             >>> # Embed and show the chain strength
             >>> target_bqm = dwave.embedding.embed_bqm(bqm, embedding, target)
             >>> target_bqm.quadratic[(2, 3)]
-            -1.0
+            -2.00111219075793
             >>> print(target_bqm.quadratic)  # doctest: +SKIP
             {(0, 1): 1.0, (0, 3): 1.0, (1, 2): 1.0, (2, 3): -1.0}
 
@@ -231,6 +236,8 @@ class EmbeddedStructure(dict):
 
         if callable(chain_strength):
             chain_strength = chain_strength(source_bqm, self)
+
+        self._chain_strength = chain_strength
 
         if isinstance(chain_strength, abc.Mapping):
             strength_iter = (chain_strength[v] for v in source_bqm.linear)
@@ -344,7 +351,7 @@ def embed_bqm(source_bqm, embedding=None, target_adjacency=None,
         >>> # Embed and show the chain strength
         >>> target_bqm = dwave.embedding.embed_bqm(bqm, embedding, target)
         >>> target_bqm.quadratic[(2, 3)]
-        -1.0
+        -2.00111219075793
         >>> print(target_bqm.quadratic)  # doctest: +SKIP
         {(0, 1): 1.0, (0, 3): 1.0, (1, 2): 1.0, (2, 3): -1.0}
 

--- a/dwave/embedding/utils.py
+++ b/dwave/embedding/utils.py
@@ -25,32 +25,7 @@ from six import iteritems
 from dwave.embedding.chain_breaks import broken_chains
 
 
-__all__ = 'get_chain_strength', 'target_to_source', 'chain_to_quadratic', 'chain_break_frequency', 'adjacency_to_edges'
-
-def get_chain_strength(bqm, prefactor):
-    """Calculates a chain strength scaled to the problem.
-
-    Args: 
-        bqm (:obj:`.BinaryQuadraticModel`):
-            A binary quadratic model.
-
-        prefactor (float):
-            Prefactor used for scaling. For optimal chain strength, the prefactor
-            should fall in the range of [0.5, 2].
-
-    Returns:
-        float: The chain strength, or 1 if chain strength is not applicable
-               to the problem. 
-            
-    """
-    if bqm.num_interactions > 0:
-        squared_j = (j ** 2 for j in bqm.quadratic.values())
-        rms = math.sqrt(sum(squared_j)/bqm.num_interactions)
-        avg_degree = bqm.degrees(array=True).mean()
-
-        return prefactor * rms * math.sqrt(avg_degree)
-    else:
-        return 1    # won't matter (chain strength isn't needed to embed this problem)
+__all__ = ['target_to_source', 'chain_to_quadratic', 'chain_break_frequency', 'adjacency_to_edges']
 
 def target_to_source(target_adjacency, embedding):
     """Derive the source adjacency from an embedding and target adjacency.

--- a/dwave/embedding/utils.py
+++ b/dwave/embedding/utils.py
@@ -18,7 +18,6 @@ from __future__ import division, absolute_import
 
 import dimod
 import numpy as np
-import math
 
 from six import iteritems
 

--- a/dwave/embedding/utils.py
+++ b/dwave/embedding/utils.py
@@ -18,14 +18,35 @@ from __future__ import division, absolute_import
 
 import dimod
 import numpy as np
+import math
 
 from six import iteritems
 
 from dwave.embedding.chain_breaks import broken_chains
 
 
-__all__ = 'target_to_source', 'chain_to_quadratic', 'chain_break_frequency', 'adjacency_to_edges'
+__all__ = 'get_chain_strength', 'target_to_source', 'chain_to_quadratic', 'chain_break_frequency', 'adjacency_to_edges'
 
+def get_chain_strength(bqm, prefactor):
+    """Calculates a chain strength scaled to the problem.
+
+    Args: 
+        bqm (:obj:`.BinaryQuadraticModel`):
+            A binary quadratic model.
+
+        prefactor (float):
+            Prefactor used for scaling. For optimal chain strength, the prefactor
+            should fall in the range of [0.5, 2].
+
+    Returns:
+        float: The chain strength.
+
+    """
+    squared_j = (j ** 2 for j in bqm.quadratic.values())
+    rms = math.sqrt(sum(squared_j)/bqm.num_interactions)
+    avg_degree = bqm.degrees(array=True).mean()
+
+    return prefactor * rms * math.sqrt(avg_degree)
 
 def target_to_source(target_adjacency, embedding):
     """Derive the source adjacency from an embedding and target adjacency.
@@ -323,5 +344,3 @@ class intlabel_disjointsets:
             int: the size of the set containing q
         """
         return self._size[self.find(q)]
-
-

--- a/dwave/embedding/utils.py
+++ b/dwave/embedding/utils.py
@@ -39,14 +39,18 @@ def get_chain_strength(bqm, prefactor):
             should fall in the range of [0.5, 2].
 
     Returns:
-        float: The chain strength.
-
+        float: The chain strength, or 1 if chain strength is not applicable
+               to the problem. 
+            
     """
-    squared_j = (j ** 2 for j in bqm.quadratic.values())
-    rms = math.sqrt(sum(squared_j)/bqm.num_interactions)
-    avg_degree = bqm.degrees(array=True).mean()
+    if bqm.num_interactions > 0:
+        squared_j = (j ** 2 for j in bqm.quadratic.values())
+        rms = math.sqrt(sum(squared_j)/bqm.num_interactions)
+        avg_degree = bqm.degrees(array=True).mean()
 
-    return prefactor * rms * math.sqrt(avg_degree)
+        return prefactor * rms * math.sqrt(avg_degree)
+    else:
+        return 1    # won't matter (chain strength isn't needed to embed this problem)
 
 def target_to_source(target_adjacency, embedding):
     """Derive the source adjacency from an embedding and target adjacency.

--- a/dwave/embedding/utils.py
+++ b/dwave/embedding/utils.py
@@ -348,3 +348,5 @@ class intlabel_disjointsets:
             int: the size of the set containing q
         """
         return self._size[self.find(q)]
+
+

--- a/dwave/system/composites/embedding.py
+++ b/dwave/system/composites/embedding.py
@@ -146,7 +146,7 @@ class EmbeddingComposite(dimod.ComposedSampler):
     """Defines the default behabior for :meth:`.sample`'s `warnings` kwarg.
     """
 
-    def sample(self, bqm, chain_strength=1.0,
+    def sample(self, bqm, chain_strength=None,
                chain_break_method=None,
                chain_break_fraction=True,
                embedding_parameters=None,
@@ -165,7 +165,8 @@ class EmbeddingComposite(dimod.ComposedSampler):
                 is 2 * `chain_strength`.  If a mapping is passed, a 
                 chain-specific strength is applied.  If a callable is passed, it
                 will be called on `chain_strength(bqm, embedding)` and should
-                return a float or mapping, to be interpreted as above.
+                return a float or mapping, to be interpreted as above. By default,
+                `chain_strength` is scaled to the problem.
 
             chain_break_method (function/list, optional):
                 Method or methods used to resolve chain breaks. If multiple
@@ -451,7 +452,8 @@ class LazyFixedEmbeddingComposite(EmbeddingComposite, dimod.Structured):
                 breaks set to 2 * `chain_strength`.  If a mapping is passed, a 
                 chain-specific strength is applied.  If a callable is passed, it
                 will be called on `chain_strength(bqm, embedding)` and should
-                return a float or mapping, to be interpreted as above.
+                return a float or mapping, to be interpreted as above. By default,
+                `chain_strength` is scaled to the problem.
 
             chain_break_method (function, optional):
                 Method used to resolve chain breaks during sample unembedding.

--- a/dwave/system/composites/embedding.py
+++ b/dwave/system/composites/embedding.py
@@ -236,16 +236,6 @@ class EmbeddingComposite(dimod.ComposedSampler):
         embedding = self.find_embedding(source_edgelist, target_edgelist,
                                         **embedding_parameters)
 
-        if warnings is None:
-            warnings = self.warnings_default
-        elif 'warnings' in child.parameters:
-            parameters.update(warnings=warnings)
-
-        warninghandler = WarningHandler(warnings)
-
-        warninghandler.chain_strength(bqm, chain_strength, embedding)
-        warninghandler.chain_length(embedding)
-
         if bqm and not embedding:
             raise ValueError("no embedding found")
 
@@ -254,6 +244,16 @@ class EmbeddingComposite(dimod.ComposedSampler):
 
         bqm_embedded = embedding.embed_bqm(bqm, chain_strength=chain_strength,
                                            smear_vartype=dimod.SPIN)
+
+        if warnings is None:
+            warnings = self.warnings_default
+        elif 'warnings' in child.parameters:
+            parameters.update(warnings=warnings)
+
+        warninghandler = WarningHandler(warnings)
+
+        warninghandler.chain_strength(bqm, embedding.chain_strength, embedding)
+        warninghandler.chain_length(embedding)
 
         if 'initial_state' in parameters:
             # if initial_state was provided in terms of the source BQM, we want
@@ -290,7 +290,7 @@ class EmbeddingComposite(dimod.ComposedSampler):
             if return_embedding:
                 sampleset.info['embedding_context'].update(
                     embedding_parameters=embedding_parameters,
-                    chain_strength=chain_strength)
+                    chain_strength=embedding.chain_strength)
 
             if chain_break_fraction and len(sampleset):
                 warninghandler.issue("All samples have broken chains",

--- a/dwave/system/samplers/clique.py
+++ b/dwave/system/samplers/clique.py
@@ -12,8 +12,6 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-import math
-
 import dimod
 import dwave_networkx as dnx
 
@@ -176,15 +174,6 @@ class DWaveCliqueSampler(dimod.Sampler):
 
         if bqm.vartype is not dimod.SPIN:
             bqm = bqm.change_vartype(dimod.SPIN, inplace=False)
-
-        if chain_strength is None:
-            # chain length determines chain strength
-            if embedding and bqm.num_interactions > 0:
-                squared_j = (j ** 2 for j in bqm.quadratic.values())
-                rms = math.sqrt(sum(squared_j)/bqm.num_interactions)
-                chain_strength = 1.5 * rms * math.sqrt(bqm.degrees(array=True).mean())
-            else:
-                chain_strength = 1  # doesn't matter
 
         sampler = FixedEmbeddingComposite(
             dimod.ScaleComposite(self.child),

--- a/tests/test_embedding_chain_strengths.py
+++ b/tests/test_embedding_chain_strengths.py
@@ -18,9 +18,9 @@ import networkx as nx
 
 import dimod
 import dwave.embedding
-from dwave.embedding.chain_strengths import scaled_degree_rms
+from dwave.embedding.chain_strengths import uniform_torque_compensation
 
-class TestScaledDegreeRMS(unittest.TestCase):
+class TestUniformTorqueCompensation(unittest.TestCase):
     def setUp(self):
         h = {0: 0, 1: 0, 2: 0}
         J = {(0, 1): 1, (1, 2): 1, (0, 2): 1}
@@ -28,21 +28,21 @@ class TestScaledDegreeRMS(unittest.TestCase):
 
     def test_empty(self):
         empty_bqm = dimod.BinaryQuadraticModel({}, {}, 0, 'SPIN')
-        chain_strength = scaled_degree_rms(empty_bqm, prefactor=2)
+        chain_strength = uniform_torque_compensation(empty_bqm, prefactor=2)
         self.assertEqual(chain_strength, 1)
 
     def test_default_prefactor(self):
-        chain_strength = scaled_degree_rms(self.bqm)
+        chain_strength = uniform_torque_compensation(self.bqm)
         self.assertAlmostEqual(chain_strength, 1.9997, places=4)
 
     def test_typical(self):
-        chain_strength = scaled_degree_rms(self.bqm, prefactor=2)
+        chain_strength = uniform_torque_compensation(self.bqm, prefactor=2)
         self.assertAlmostEqual(chain_strength, 2.8284, places=4)
 
     def test_as_callable(self):
         embedding = {0: {0}, 1: {1}, 2: {2, 3}}
         embedded_bqm = dwave.embedding.embed_bqm(self.bqm, embedding, nx.cycle_graph(4), 
-                                                 chain_strength=scaled_degree_rms)
+                                                 chain_strength=uniform_torque_compensation)
 
         expected_bqm = dimod.BinaryQuadraticModel({0: 0, 1: 0, 2: 0, 3: 0},
                                                   {(0, 1): 1, (1, 2): 1, (2, 3): -1.9997, (0, 3): 1},

--- a/tests/test_embedding_chain_strengths.py
+++ b/tests/test_embedding_chain_strengths.py
@@ -1,0 +1,52 @@
+# Copyright 2020 D-Wave Systems Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+import unittest
+
+import networkx as nx
+
+import dimod
+import dwave.embedding
+from dwave.embedding.chain_strengths import scaled_degree_rms
+
+class TestScaledDegreeRMS(unittest.TestCase):
+    def setUp(self):
+        h = {0: 0, 1: 0, 2: 0}
+        J = {(0, 1): 1, (1, 2): 1, (0, 2): 1}
+        self.bqm = dimod.BinaryQuadraticModel.from_ising(h, J)
+
+    def test_empty(self):
+        empty_bqm = dimod.BinaryQuadraticModel({}, {}, 0, 'SPIN')
+        chain_strength = scaled_degree_rms(empty_bqm, prefactor=2)
+        self.assertEqual(chain_strength, 1)
+
+    def test_default_prefactor(self):
+        chain_strength = scaled_degree_rms(self.bqm)
+        self.assertAlmostEqual(chain_strength, 1.9997, places=4)
+
+    def test_typical(self):
+        chain_strength = scaled_degree_rms(self.bqm, prefactor=2)
+        self.assertAlmostEqual(chain_strength, 2.8284, places=4)
+
+    def test_as_callable(self):
+        embedding = {0: {0}, 1: {1}, 2: {2, 3}}
+        embedded_bqm = dwave.embedding.embed_bqm(self.bqm, embedding, nx.cycle_graph(4), 
+                                                 chain_strength=scaled_degree_rms)
+
+        expected_bqm = dimod.BinaryQuadraticModel({0: 0, 1: 0, 2: 0, 3: 0},
+                                                  {(0, 1): 1, (1, 2): 1, (2, 3): -1.9997, (0, 3): 1},
+                                                  1.9997,  # offset the energy from satisfying chains
+                                                  dimod.SPIN)
+
+        dimod.testing.assert_bqm_almost_equal(embedded_bqm, expected_bqm, places=4) 

--- a/tests/test_embedding_composite.py
+++ b/tests/test_embedding_composite.py
@@ -249,7 +249,7 @@ class TestEmbeddingComposite(unittest.TestCase):
         self.assertEqual(sampleset.info['embedding_context']['embedding_parameters'], {})  # the default
 
         self.assertIn('chain_strength', sampleset.info['embedding_context'])
-        self.assertEqual(sampleset.info['embedding_context']['chain_strength'], 1.0)  # the default
+        self.assertEqual(sampleset.info['embedding_context']['chain_strength'], 1.415)  # the default
 
         # default False
         sampleset = sampler.sample_ising({'a': -1}, {'ac': 1})
@@ -278,7 +278,7 @@ class TestEmbeddingComposite(unittest.TestCase):
         self.assertEqual(sampleset.info['embedding_context']['embedding_parameters'], {})  # the default
 
         self.assertIn('chain_strength', sampleset.info['embedding_context'])
-        self.assertEqual(sampleset.info['embedding_context']['chain_strength'], 1.0)  # the default
+        self.assertEqual(sampleset.info['embedding_context']['chain_strength'], 1.415)  # the default
 
         # restore the default
         EmbeddingComposite.return_embedding_default = False
@@ -305,7 +305,7 @@ class TestEmbeddingComposite(unittest.TestCase):
         # use a triangle so there is a chain of length 2
         J = {(0, 1): 100, (1, 2): 100, (0, 2): 1}
 
-        ss = sampler.sample_ising({}, J, warnings='SAVE')
+        ss = sampler.sample_ising({}, J, chain_strength=1, warnings='SAVE')
         self.assertIn('warnings', ss.info)
 
         count = 0

--- a/tests/test_embedding_composite.py
+++ b/tests/test_embedding_composite.py
@@ -249,7 +249,7 @@ class TestEmbeddingComposite(unittest.TestCase):
         self.assertEqual(sampleset.info['embedding_context']['embedding_parameters'], {})  # the default
 
         self.assertIn('chain_strength', sampleset.info['embedding_context'])
-        self.assertEqual(sampleset.info['embedding_context']['chain_strength'], 1.415)  # the default
+        self.assertEqual(sampleset.info['embedding_context']['chain_strength'], 1.414)  # the default
 
         # default False
         sampleset = sampler.sample_ising({'a': -1}, {'ac': 1})
@@ -278,7 +278,7 @@ class TestEmbeddingComposite(unittest.TestCase):
         self.assertEqual(sampleset.info['embedding_context']['embedding_parameters'], {})  # the default
 
         self.assertIn('chain_strength', sampleset.info['embedding_context'])
-        self.assertEqual(sampleset.info['embedding_context']['chain_strength'], 1.415)  # the default
+        self.assertEqual(sampleset.info['embedding_context']['chain_strength'], 1.414)  # the default
 
         # restore the default
         EmbeddingComposite.return_embedding_default = False

--- a/tests/test_embedding_transforms.py
+++ b/tests/test_embedding_transforms.py
@@ -368,7 +368,7 @@ class TestEmbedBQM(unittest.TestCase):
         adj.add_edges_from({(0, 1), (1, 2), (2, 3), (3, 0), (2, 0)})
 
         expected_h0 = {0: 0, 1: 1, 2: 5, 3: 5}
-        expected_j0 = {(0, 1): 3, (0, 2): -4, (0, 3): -4, (1, 2): 15, (2, 3): -19.94430662286024}
+        expected_j0 = {(0, 1): 3, (0, 2): -4, (0, 3): -4, (1, 2): 15, (2, 3): -19.9302}
 
         h0, j0 = dwave.embedding.embed_ising(h, j, embeddings, adj)
         self.assertEqual(h0, expected_h0)
@@ -379,9 +379,9 @@ class TestEmbedBQM(unittest.TestCase):
             self.assertFalse((u, v) in expected_j0 and (v, u) in expected_j0)
 
             if (u, v) in expected_j0:
-                self.assertEqual(expected_j0[(u, v)], bias)
+                self.assertAlmostEqual(expected_j0[(u, v)], bias, 4)
             else:
-                self.assertEqual(expected_j0[(v, u)], bias)
+                self.assertAlmostEqual(expected_j0[(v, u)], bias, 4)
 
     def test_embed_ising_embedding_not_in_adj(self):
         """embedding refers to a variable not in the adjacency"""
@@ -587,7 +587,7 @@ class TestEmbeddedStructure(unittest.TestCase):
         dimod.testing.assert_bqm_almost_equal(target_bqm, goal_bqm)
 
         #test the chain_strength is a function case:
-        def strength_func(S, E):
+        def strength_func(S, **kwargs):
             return chain_strength
 
         target_bqm = emb_s.embed_bqm(source_bqm, chain_strength=strength_func)

--- a/tests/test_embedding_transforms.py
+++ b/tests/test_embedding_transforms.py
@@ -368,7 +368,7 @@ class TestEmbedBQM(unittest.TestCase):
         adj.add_edges_from({(0, 1), (1, 2), (2, 3), (3, 0), (2, 0)})
 
         expected_h0 = {0: 0, 1: 1, 2: 5, 3: 5}
-        expected_j0 = {(0, 1): 3, (0, 2): -4, (0, 3): -4, (1, 2): 15, (2, 3): -1}
+        expected_j0 = {(0, 1): 3, (0, 2): -4, (0, 3): -4, (1, 2): 15, (2, 3): -19.94430662286024}
 
         h0, j0 = dwave.embedding.embed_ising(h, j, embeddings, adj)
         self.assertEqual(h0, expected_h0)

--- a/tests/test_embedding_transforms.py
+++ b/tests/test_embedding_transforms.py
@@ -587,7 +587,7 @@ class TestEmbeddedStructure(unittest.TestCase):
         dimod.testing.assert_bqm_almost_equal(target_bqm, goal_bqm)
 
         #test the chain_strength is a function case:
-        def strength_func(S, **kwargs):
+        def strength_func(S, E):
             return chain_strength
 
         target_bqm = emb_s.embed_bqm(source_bqm, chain_strength=strength_func)


### PR DESCRIPTION
Closes #300 .

Addresses the conversation in #326. After discussing with @alexzucca90, I went with an average of 1.33 and 1.5 as our default prefactor (using the formula described by @pau557 [here](https://github.com/dwavesystems/dwave-system/pull/326#issuecomment-685185755)). I didn't implement the topology dependency for reasons described [here](https://github.com/dwavesystems/dwave-system/pull/326#issuecomment-685961599), but perhaps there are other spots that we could do that. For example, @alexzucca90 mentioned that the DWaveCliqueSampler may benefit from using a topology dependent coefficient (as opposed to an average or the current 1.5). 

Also, a lot of the tests in test_embedding_transforms.py are using chain_strength=1. I wasn't entirely sure whether to change them, but can definitely do so once we're more certain of these changes.