### PR TITLE
Add **kwargs to MockDWaveSampler

### DIFF
--- a/dwave/system/testing.py
+++ b/dwave/system/testing.py
@@ -75,7 +75,7 @@ class MockDWaveSampler(dimod.Sampler, dimod.Structured):
         properties['extended_j_range'] = [-2.0, 1.0]
 
     @dimod.bqm_structured
-    def sample(self, bqm, num_reads=10, flux_biases=[]):
+    def sample(self, bqm, num_reads=10, flux_biases=[], **kwargs):
         # we are altering the bqm
 
         if not flux_biases:


### PR DESCRIPTION
To prevent doctest failures such as this one:  https://github.com/dwavesystems/dwave-ocean-sdk/pull/93, in the interest of maximum coverage
```
Document: examples/pp_greedy
 File "examples/pp_greedy.rst", line 139, in default
Failed example:
    from greedy import SteepestDescentSolver

    solver_greedy = SteepestDescentSolver()

    sampleset_qpu = sampler.sample_ising(h, J, num_reads=100, answer_mode='raw')
    # Postprocess
    sampleset_pp = solver_greedy.sample_ising(h, J, initial_states=sampleset_qpu)
Exception raised:
    Traceback (most recent call last):
      File "/usr/local/lib/python3.7/doctest.py", line 1337, in __run
        compileflags, 1), test.globs)
      File "<doctest default[0]>", line 5, in <module>
        sampleset_qpu = sampler.sample_ising(h, J, num_reads=100, answer_mode='raw')
      File "/home/circleci/repo/env/lib/python3.7/site-packages/dimod/core/sampler.py", line 211, in sample_ising
        return self.sample(bqm, **parameters)
      File "/home/circleci/repo/env/lib/python3.7/site-packages/dimod/decorators.py", line 165, in new_f
        return f(sampler, bqm, **kwargs)
    TypeError: sample() got an unexpected keyword argument 'answer_mode'

``` 