### PR TITLE
Skip doctest on cliquesampler

### DIFF
--- a/dwave/system/composites/reversecomposite.py
+++ b/dwave/system/composites/reversecomposite.py
@@ -52,9 +52,9 @@ class ReverseAdvanceComposite(dimod.ComposedSampler):
        >>> import dimod
        >>> from dwave.system import DWaveCliqueSampler, ReverseAdvanceComposite
        ...
-       >>> sampler = DWaveCliqueSampler(solver={'qpu': True})
-       >>> sampler_reverse = ReverseAdvanceComposite(sampler)
-       >>> schedule = schedule = [[[0.0, 1.0], [t, 0.5], [20, 1.0]] for t in (5, 10, 15)]
+       >>> sampler = DWaveCliqueSampler()     # doctest: +SKIP
+       >>> sampler_reverse = ReverseAdvanceComposite(sampler)    # doctest: +SKIP
+       >>> schedule = [[[0.0, 1.0], [t, 0.5], [20, 1.0]] for t in (5, 10, 15)]
        ...
        >>> bqm = dimod.generators.ran_r(1, 15)
        >>> init_samples = {i: -1 for i in range(15)}
@@ -62,7 +62,7 @@ class ReverseAdvanceComposite(dimod.ComposedSampler):
        ...                                    anneal_schedules=schedule,
        ...                                    initial_state=init_samples,
        ...                                    num_reads=100,
-       ...                                    reinitialize_state=True)
+       ...                                    reinitialize_state=True)     # doctest: +SKIP
 
     """
 
@@ -111,9 +111,9 @@ class ReverseAdvanceComposite(dimod.ComposedSampler):
            >>> import dimod
            >>> from dwave.system import DWaveCliqueSampler, ReverseAdvanceComposite
            ...
-           >>> sampler = DWaveCliqueSampler(solver={'qpu': True})
-           >>> sampler_reverse = ReverseAdvanceComposite(sampler)
-           >>> schedule = schedule = [[[0.0, 1.0], [t, 0.5], [20, 1.0]] for t in (5, 10, 15)]
+           >>> sampler = DWaveCliqueSampler()         # doctest: +SKIP
+           >>> sampler_reverse = ReverseAdvanceComposite(sampler)    # doctest: +SKIP
+           >>> schedule = [[[0.0, 1.0], [t, 0.5], [20, 1.0]] for t in (5, 10, 15)]
            ...
            >>> bqm = dimod.generators.ran_r(1, 15)
            >>> init_samples = {i: -1 for i in range(15)}
@@ -121,7 +121,7 @@ class ReverseAdvanceComposite(dimod.ComposedSampler):
            ...                                    anneal_schedules=schedule,
            ...                                    initial_state=init_samples,
            ...                                    num_reads=100,
-           ...                                    reinitialize_state=True)
+           ...                                    reinitialize_state=True)  # doctest: +SKIP
 
 
         """
@@ -195,8 +195,8 @@ class ReverseBatchStatesComposite(dimod.ComposedSampler):
        >>> import dimod
        >>> from dwave.system import DWaveCliqueSampler, ReverseBatchStatesComposite
        ...
-       >>> sampler = DWaveCliqueSampler(solver={'qpu': True})
-       >>> sampler_reverse = ReverseBatchStatesComposite(sampler)
+       >>> sampler = DWaveCliqueSampler()      # doctest: +SKIP
+       >>> sampler_reverse = ReverseBatchStatesComposite(sampler)    # doctest: +SKIP
        >>> schedule = [[0.0, 1.0], [10.0, 0.5], [20, 1.0]]
        ...
        >>> bqm = dimod.generators.ran_r(1, 15)
@@ -205,7 +205,7 @@ class ReverseBatchStatesComposite(dimod.ComposedSampler):
        ...                                    anneal_schedule=schedule,
        ...                                    initial_states=init_samples,
        ...                                    num_reads=100,
-       ...                                    reinitialize_state=True)
+       ...                                    reinitialize_state=True)   # doctest: +SKIP
 
 
 
@@ -250,8 +250,8 @@ class ReverseBatchStatesComposite(dimod.ComposedSampler):
            >>> import dimod
            >>> from dwave.system import DWaveCliqueSampler, ReverseBatchStatesComposite
            ...
-           >>> sampler = DWaveCliqueSampler(solver={'qpu': True})
-           >>> sampler_reverse = ReverseBatchStatesComposite(sampler)
+           >>> sampler = DWaveCliqueSampler()       # doctest: +SKIP
+           >>> sampler_reverse = ReverseBatchStatesComposite(sampler)   # doctest: +SKIP
            >>> schedule = [[0.0, 1.0], [10.0, 0.5], [20, 1.0]]
            ...
            >>> bqm = dimod.generators.ran_r(1, 15)
@@ -260,7 +260,7 @@ class ReverseBatchStatesComposite(dimod.ComposedSampler):
            ...                                    anneal_schedule=schedule,
            ...                                    initial_states=init_samples,
            ...                                    num_reads=100,
-           ...                                    reinitialize_state=True)
+           ...                                    reinitialize_state=True)  # doctest: +SKIP
 
 
         """

--- a/dwave/system/samplers/clique.py
+++ b/dwave/system/samplers/clique.py
@@ -48,10 +48,10 @@ class DWaveCliqueSampler(dimod.Sampler):
         ...
         >>> bqm = dimod.generators.ran_r(1, 6)
         ...
-        >>> sampler = DWaveCliqueSampler(solver={'qpu': True})
-        >>> sampler.largest_clique_size > 5
+        >>> sampler = DWaveCliqueSampler()   # doctest: +SKIP
+        >>> sampler.largest_clique_size > 5  # doctest: +SKIP
         True
-        >>> sampleset = sampler.sample(bqm, num_reads=100)
+        >>> sampleset = sampler.sample(bqm, num_reads=100)   # doctest: +SKIP
 
     """
     def __init__(self, **config):


### PR DESCRIPTION
Until I have time to make a mock DWaveCliqueSampler, this should prevent doctest failures that we have now in https://github.com/dwavesystems/dwave-ocean-sdk/pull/93 post-update to `dwave-system==0.9.13` 