### PR TITLE
Remove six dependency and make minor pep8 refactors

### DIFF
--- a/dwave/__init__.py
+++ b/dwave/__init__.py
@@ -11,7 +11,6 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-#
-# ================================================================================================
+
 import pkgutil
 __path__ = pkgutil.extend_path(__path__, __name__)

--- a/dwave/embedding/__init__.py
+++ b/dwave/embedding/__init__.py
@@ -11,8 +11,6 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-#
-# ================================================================================================
 
 import minorminer  # into this namespace
 import dwave.embedding.chimera

--- a/dwave/embedding/chain_breaks.py
+++ b/dwave/embedding/chain_breaks.py
@@ -11,10 +11,8 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-#
-# =============================================================================
+
 """Unembedding samples with broken chains."""
-from __future__ import division
 
 from collections import Callable
 from heapq import heapify, heappop

--- a/dwave/embedding/chain_strength.py
+++ b/dwave/embedding/chain_strength.py
@@ -11,8 +11,7 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-#
-# ================================================================================================
+
 """Utility functions for calculating chain strength.
 
 Examples:

--- a/dwave/embedding/drawing.py
+++ b/dwave/embedding/drawing.py
@@ -11,8 +11,6 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-#
-# ================================================================================================
 
 from math import ceil, sqrt
 

--- a/dwave/embedding/transforms.py
+++ b/dwave/embedding/transforms.py
@@ -11,8 +11,6 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-#
-# ================================================================================================
 
 import collections.abc as abc
 import itertools

--- a/dwave/embedding/utils.py
+++ b/dwave/embedding/utils.py
@@ -11,20 +11,18 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-#
-# ================================================================================================
-
-from __future__ import division, absolute_import
 
 import dimod
 import numpy as np
 
-from six import iteritems
-
 from dwave.embedding.chain_breaks import broken_chains
 
 
-__all__ = ['target_to_source', 'chain_to_quadratic', 'chain_break_frequency', 'adjacency_to_edges']
+__all__ = ['target_to_source',
+           'chain_to_quadratic',
+           'chain_break_frequency',
+           'adjacency_to_edges']
+
 
 def target_to_source(target_adjacency, embedding):
     """Derive the source adjacency from an embedding and target adjacency.
@@ -67,14 +65,14 @@ def target_to_source(target_adjacency, embedding):
 
     # we need the mapping from each node in the target to its source node
     reverse_embedding = {}
-    for v, chain in iteritems(embedding):
+    for v, chain in embedding.items():
         for u in chain:
             if u in reverse_embedding:
                 raise ValueError("target node {} assigned to more than one source node".format(u))
             reverse_embedding[u] = v
 
     # v is node in target, n node in source
-    for v, n in iteritems(reverse_embedding):
+    for v, n in reverse_embedding.items():
         neighbors = target_adjacency[v]
 
         # u is node in target

--- a/dwave/system/__init__.py
+++ b/dwave/system/__init__.py
@@ -11,8 +11,7 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-#
-# =============================================================================
+
 import dwave.system.flux_bias_offsets
 
 from dwave.system.samplers import *

--- a/dwave/system/cache/__init__.py
+++ b/dwave/system/cache/__init__.py
@@ -11,7 +11,6 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-#
-# ================================================================================================
+
 from dwave.system.cache.cache_manager import *
 from dwave.system.cache.database_manager import *

--- a/dwave/system/cache/cache_manager.py
+++ b/dwave/system/cache/cache_manager.py
@@ -11,8 +11,7 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-#
-# ================================================================================================
+
 import os
 
 import homebase

--- a/dwave/system/cache/database_manager.py
+++ b/dwave/system/cache/database_manager.py
@@ -11,8 +11,7 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-#
-# ================================================================================================
+
 """Utilities for accessing the sqlite cache.
 
 Note:
@@ -25,9 +24,6 @@ import os
 import struct
 import base64
 import datetime
-
-from six import iteritems
-from six.moves import range
 
 from dwave.system.cache.cache_manager import cache_file
 from dwave.system.cache.schema import schema
@@ -500,7 +496,7 @@ def insert_embedding(cur, source_nodelist, source_edgelist, target_nodelist, tar
             chain.chain_length = :chain_length
         """
 
-    for v, chain in iteritems(embedding):
+    for v, chain in embedding.items():
         chain_data = {'source_node': v}
         insert_chain(cur, chain, chain_data)
 

--- a/dwave/system/composites/__init__.py
+++ b/dwave/system/composites/__init__.py
@@ -11,8 +11,7 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-#
-# ================================================================================================
+
 from dwave.system.composites.cutoffcomposite import *
 from dwave.system.composites.embedding import *
 from dwave.system.composites.tiling import *

--- a/dwave/system/composites/cutoffcomposite.py
+++ b/dwave/system/composites/cutoffcomposite.py
@@ -11,8 +11,7 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-#
-# =============================================================================
+
 """
 Composites that remove any interactions below a cutoff value. Isolated
 variables are then also removed.

--- a/dwave/system/composites/embedding.py
+++ b/dwave/system/composites/embedding.py
@@ -12,8 +12,7 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-#
-# =============================================================================
+
 """Embedding composites for various types of problems and application.
 For example:
 
@@ -24,6 +23,7 @@ For example:
 * :class:`.LazyFixedEmbeddingComposite` can benefit applications that
   resubmit a BQM with changes in some values.
 """
+
 import itertools
 
 from warnings import warn

--- a/dwave/system/composites/reversecomposite.py
+++ b/dwave/system/composites/reversecomposite.py
@@ -11,21 +11,17 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-#
-# =============================================================================
+
 """
 Composites that do batch operations for reverse annealing.
 """
 
-try:
-    import collections.abc as abc
-except ImportError:
-    import collections as abc
+import collections.abc as abc
 
 import dimod
 import numpy as np
 
-__all__ = 'ReverseAdvanceComposite', 'ReverseBatchStatesComposite'
+__all__ = ['ReverseAdvanceComposite', 'ReverseBatchStatesComposite']
 
 
 class ReverseAdvanceComposite(dimod.ComposedSampler):

--- a/dwave/system/composites/tiling.py
+++ b/dwave/system/composites/tiling.py
@@ -11,8 +11,7 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-#
-# ================================================================================================
+
 """
 A :std:doc:`dimod composite <oceandocs:docs_dimod/reference/samplers>` that tiles small problems
 multiple times to a Chimera-structured sampler.
@@ -27,7 +26,7 @@ See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/stable/concepts/index.ht
 for explanations of technical terms in descriptions of Ocean tools.
 
 """
-from __future__ import division
+
 from math import sqrt, ceil
 
 import dimod

--- a/dwave/system/composites/virtual_graph.py
+++ b/dwave/system/composites/virtual_graph.py
@@ -11,8 +11,7 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-#
-# =============================================================================
+
 """
 A :std:doc:`dimod composite <oceandocs:docs_dimod/reference/samplers>` that uses the D-Wave virtual
 graph feature for improved :std:doc:`minor-embedding <oceandocs:docs_system/intro>`.
@@ -26,6 +25,7 @@ couplings.
 See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/stable/concepts/index.html>`_
 for explanations of technical terms in descriptions of Ocean tools.
 """
+
 import dimod
 
 from dwave.system.composites.embedding import FixedEmbeddingComposite

--- a/dwave/system/exceptions.py
+++ b/dwave/system/exceptions.py
@@ -11,8 +11,6 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-#
-# ================================================================================================
 
 
 class MissingFluxBias(Exception):

--- a/dwave/system/flux_bias_offsets.py
+++ b/dwave/system/flux_bias_offsets.py
@@ -12,8 +12,7 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-#
-# ================================================================================================
+
 import warnings
 
 import dimod

--- a/dwave/system/package_info.py
+++ b/dwave/system/package_info.py
@@ -11,8 +11,7 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-#
-# =============================================================================
+
 __all__ = ['__version__', '__author__', '__authoremail__', '__description__']
 
 __version__ = '1.3.0'

--- a/dwave/system/samplers/dwave_sampler.py
+++ b/dwave/system/samplers/dwave_sampler.py
@@ -11,15 +11,13 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-#
-# ================================================================================================
+
 """
 A :std:doc:`dimod sampler <oceandocs:docs_dimod/reference/samplers>` for the D-Wave system.
 
 See :std:doc:`Ocean Glossary <oceandocs:glossary>`
 for explanations of technical terms in descriptions of Ocean tools.
 """
-from __future__ import division
 
 import time
 import functools

--- a/dwave/system/samplers/leap_hybrid_sampler.py
+++ b/dwave/system/samplers/leap_hybrid_sampler.py
@@ -11,12 +11,11 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-#
-# ================================================================================================
+
 """
 A :std:doc:`dimod sampler <oceandocs:docs_dimod/reference/samplers>` for Leap's hybrid solvers.
 """
-from __future__ import division
+
 import numpy as np
 from warnings import warn
 from numbers import Number

--- a/dwave/system/schedules.py
+++ b/dwave/system/schedules.py
@@ -11,9 +11,6 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-#
-# =============================================================================
-from __future__ import division
 
 
 def ramp(s, width, annealing_time):

--- a/dwave/system/testing.py
+++ b/dwave/system/testing.py
@@ -11,9 +11,9 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-#
-# ================================================================================================
+
 import collections
+import unittest.mock as mock
 
 import dimod
 import dwave_networkx as dnx
@@ -28,12 +28,6 @@ except ImportError:
 import concurrent.futures
 import numpy as np
 
-try:
-    # py3
-    import unittest.mock as mock
-except ImportError:
-    # py2
-    import mock
 
 C4 = dnx.chimera_graph(4, 4, 4)
 

--- a/dwave/system/utilities.py
+++ b/dwave/system/utilities.py
@@ -11,8 +11,7 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-#
-# =============================================================================
+
 """Utility functions."""
 
 import networkx as nx

--- a/dwave/system/warnings.py
+++ b/dwave/system/warnings.py
@@ -11,14 +11,12 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-#
-# =============================================================================
+
 import enum
 import logging
 
 import dimod
 import numpy as np
-import six
 import collections.abc as abc
 
 from dwave.embedding import broken_chains
@@ -44,7 +42,7 @@ SAVE = WarningAction.SAVE
 def as_action(action):
     if isinstance(action, WarningAction):
         return action
-    elif isinstance(action, six.string_types):
+    elif isinstance(action, str):
         return WarningAction[action.upper()]
     else:
         raise TypeError('unknown warning action provided')

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,5 @@ dwave-drivers==0.4.4
 dwave-tabu==0.3.1
 homebase==1.0.1
 minorminer==0.2.4
-six==1.11.0
-mock==2.0.0
 numpy==1.19.4; python_version >= '3.6'
 numpy==1.18.5; python_version == '3.5'

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ install_requires = ['dimod>=0.9.11,<0.10.0',
                     'networkx>=2.0,<3.0',
                     'homebase>=1.0.0,<2.0.0',
                     'minorminer>=0.2.4,<0.3.0',
-                    'six>=1.11.0,<2.0.0',
                     'numpy>=1.14.0,<2.0.0',
                     'dwave-tabu>=0.2.0',
                     ]

--- a/tests/qpu/test_dwavesampler.py
+++ b/tests/qpu/test_dwavesampler.py
@@ -11,8 +11,7 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-#
-# =============================================================================
+
 import unittest
 from unittest import mock
 

--- a/tests/qpu/test_embeddingcomposite.py
+++ b/tests/qpu/test_embeddingcomposite.py
@@ -11,8 +11,7 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-#
-# =============================================================================
+
 import unittest
 import warnings
 

--- a/tests/qpu/test_schedules.py
+++ b/tests/qpu/test_schedules.py
@@ -11,8 +11,7 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-#
-# =============================================================================
+
 import unittest
 
 from dwave.cloud.exceptions import ConfigFileError

--- a/tests/qpu/test_virtual_graph_composite.py
+++ b/tests/qpu/test_virtual_graph_composite.py
@@ -11,8 +11,7 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-#
-# =============================================================================
+
 import itertools
 import unittest
 

--- a/tests/test_cutoffcomposite.py
+++ b/tests/test_cutoffcomposite.py
@@ -11,8 +11,7 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-#
-# =============================================================================
+
 import unittest
 
 import dimod

--- a/tests/test_database_manager.py
+++ b/tests/test_database_manager.py
@@ -11,8 +11,7 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-#
-# ================================================================================================
+
 import unittest
 import time
 import homebase

--- a/tests/test_dwavesampler.py
+++ b/tests/test_dwavesampler.py
@@ -11,8 +11,7 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-#
-# =============================================================================
+
 import sys
 import unittest
 import random

--- a/tests/test_embedding_chain_breaks.py
+++ b/tests/test_embedding_chain_breaks.py
@@ -11,16 +11,13 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-#
-# =============================================================================
+
 import unittest
 
 from contextlib import contextmanager
 
-
 import dimod
 import numpy as np
-import six
 
 import dwave.embedding
 
@@ -66,15 +63,6 @@ class TestBrokenChains(unittest.TestCase):
 
 class TestChainBreakResolutionAPI():
     chains = [[0, 1], [2, 4], [3]]  # needs to be available to MinimizeEnergy
-
-    def subTest(self, *args, **kwargs):
-        # python2 does not support subTest so we just use a null context manager
-        if six.PY2:
-            @contextmanager
-            def nullcontext(enter_result=None):
-                yield enter_result
-            return nullcontext()
-        return super(TestChainBreakResolutionAPI, self).subTest(*args, **kwargs)
 
     def test_api(self):
         cases = {}

--- a/tests/test_embedding_chimera.py
+++ b/tests/test_embedding_chimera.py
@@ -11,8 +11,6 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-#
-# ================================================================================================
 
 import unittest
 

--- a/tests/test_embedding_composite.py
+++ b/tests/test_embedding_composite.py
@@ -11,8 +11,7 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-#
-# =============================================================================
+
 import itertools
 import unittest
 import warnings

--- a/tests/test_embedding_pegasus.py
+++ b/tests/test_embedding_pegasus.py
@@ -1,3 +1,17 @@
+# Copyright 2018 D-Wave Systems Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
 from dwave.embedding.pegasus import find_clique_embedding, find_biclique_embedding
 from dwave.embedding.diagnostic import is_valid_embedding
 from dwave_networkx.generators.pegasus import pegasus_graph

--- a/tests/test_embedding_transforms.py
+++ b/tests/test_embedding_transforms.py
@@ -11,8 +11,6 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-#
-# ================================================================================================
 
 import unittest
 import itertools

--- a/tests/test_embedding_utils.py
+++ b/tests/test_embedding_utils.py
@@ -11,8 +11,6 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-#
-# =============================================================================
 
 import unittest
 import itertools

--- a/tests/test_leaphybridsolver.py
+++ b/tests/test_leaphybridsolver.py
@@ -11,21 +11,14 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-#
-# =============================================================================
+
 import unittest
+import unittest.mock as mock
 import numpy as np
 
 import dimod
 from dwave.cloud import Client
 from dwave.cloud.exceptions import SolverNotFoundError
-
-try:
-    # py3
-    import unittest.mock as mock
-except ImportError:
-    # py2
-    import mock
 
 from dwave.system.samplers import LeapHybridSampler
 from dwave.system.testing import MockLeapHybridSolver

--- a/tests/test_mock_sampler.py
+++ b/tests/test_mock_sampler.py
@@ -11,8 +11,7 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-#
-# ================================================================================================
+
 """who watches the watchmen?"""
 import unittest
 

--- a/tests/test_polycutoffcomposite.py
+++ b/tests/test_polycutoffcomposite.py
@@ -11,8 +11,7 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-#
-# =============================================================================
+
 import unittest
 
 import dimod

--- a/tests/test_reverse_composite.py
+++ b/tests/test_reverse_composite.py
@@ -11,8 +11,7 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-#
-# =============================================================================
+
 import unittest
 
 import dimod

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -11,8 +11,6 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-#
-# =============================================================================
 
 import unittest
 

--- a/tests/test_tiling_composite.py
+++ b/tests/test_tiling_composite.py
@@ -11,8 +11,7 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-#
-# ================================================================================================
+
 import unittest
 import random
 

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -11,9 +11,6 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-#
-# =============================================================================
-from __future__ import division
 
 import unittest
 

--- a/tests/test_virtual_graph_composite.py
+++ b/tests/test_virtual_graph_composite.py
@@ -11,8 +11,7 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-#
-# ================================================================================================
+
 import unittest
 import collections
 


### PR DESCRIPTION
`six` is still a dependency of `fasteners` which is a dependency of `minorminer`.