### PR TITLE
Add references to additional composites & samplers

### DIFF
--- a/docs/reference/composites.rst
+++ b/docs/reference/composites.rst
@@ -5,12 +5,18 @@ Composites
 ==========
 
 :std:doc:`dimod composites <oceandocs:docs_dimod/introduction>` that provide layers of pre- and
-post-processing (e.g., :term:`minor-embedding`) when using the D-Wave system.
+post-processing (e.g., :term:`minor-embedding`) when using the D-Wave system:
 
 .. currentmodule:: dwave.system.composites
 
 .. contents::
-    :depth: 3
+    :local:
+    :depth: 2
+
+Other Ocean packages provide additional composites; for example,
+:std:doc:`dimod <oceandocs:docs_dimod/sdk_index>` provides composites that operate
+on the problem (e.g., scaling values), track inputs and outputs for debugging,
+and other useful functionality relevant to generic samplers.
 
 CutOffs
 =======

--- a/docs/reference/samplers.rst
+++ b/docs/reference/samplers.rst
@@ -12,7 +12,12 @@ distributions defined by the problem.
 .. currentmodule:: dwave.system.samplers
 
 .. contents::
-    :depth: 2
+    :local:
+    :depth: 1
+
+Other Ocean packages provide additional samplers; for example,
+:std:doc:`dimod <oceandocs:docs_dimod/sdk_index>` provides samplers for testing
+your code.
 
 DWaveSampler
 ============


### PR DESCRIPTION
dwave-system part of fix for https://github.com/dwavesystems/dwave-system/issues/380 together with https://github.com/dwavesystems/dimod/pull/775. 
Also makes content lists of samplers/composites look nicer. 
