### PR TITLE
Fix formatting for sample_dqm() docstring

### DIFF
--- a/dwave/system/samplers/leap_hybrid_sampler.py
+++ b/dwave/system/samplers/leap_hybrid_sampler.py
@@ -412,8 +412,8 @@ class LeapHybridDQMSampler:
         Returns:
             :class:`dimod.SampleSet`: A sample set.
 
-    Examples:
-        See the example in :class:`LeapHybridDQMSampler`.
+        Examples:
+            See the example in :class:`LeapHybridDQMSampler`.
 
         """
         if time_limit is None:


### PR DESCRIPTION
The current misalignment messes up the formatting for the function: https://docs.ocean.dwavesys.com/en/stable/docs_system/reference/generated/dwave.system.samplers.LeapHybridDQMSampler.sample_dqm.html#dwave-system-samplers-leaphybriddqmsampler-sample-dqm (for comparison see https://docs.ocean.dwavesys.com/en/stable/docs_system/reference/generated/dwave.system.samplers.DWaveSampler.sample.html#dwave.system.samplers.DWaveSampler.sample)