### PR TITLE
CI Refactor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,8 +8,6 @@ environment:
 
     # https://www.appveyor.com/docs/build-environment/#python
 
-    - PYTHON: "C:\\Python35"
-    - PYTHON: "C:\\Python35-x64"
     - PYTHON: "C:\\Python36"
     - PYTHON: "C:\\Python36-x64"
     - PYTHON: "C:\\Python37"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,9 +1,4 @@
 environment:
-
-  DWAVE_API_ENDPOINT: https://cloud.dwavesys.com/sapi
-  DWAVE_API_TOKEN:
-    secure: YekPDE0jzk9VymUkPeswJ8SBhhsvHcb0yP9b+bvx/YPs/wZUWDsl1GrNfCLe4Iys
-
   matrix:
 
     # https://www.appveyor.com/docs/build-environment/#python

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,6 +185,7 @@ workflows:
 
               dimod-version: [==0.9.11, <0.10.0]
       - test-osx:
+          name: test-osx-<< matrix.python-version >>
           matrix:
             parameters:
               python-version: *python-versions

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,11 @@ version: 2.1
 jobs:
   test-linux: &test-linux-template
     parameters:
+      dimod-version:
+        type: string
       python-version:
+        type: string
+      integration-test-python-version:
         type: string
 
     docker:
@@ -22,6 +26,7 @@ jobs:
             python -m venv env
             . env/bin/activate
             pip install -r requirements.txt -r tests/requirements.txt
+            pip install --upgrade 'dimod<< parameters.dimod-version >>'
 
       - save_cache: &save-test-cache-template
           paths:
@@ -32,6 +37,7 @@ jobs:
           name: run unittests
           command: |
             . env/bin/activate
+            if [[ << parameters.integration-test-python-version >> != << parameters.python-version >>]] then export SKIP_INT_TESTS=1 fi
             coverage run -m unittest discover
 
       - run: &codecov-template
@@ -164,9 +170,17 @@ workflows:
   test:
     jobs:
       - test-linux:
+          name: test-linux-<< matrix.python-version >>-dimod<< matrix.dimod-version >>
           matrix:
             parameters:
               python-version: &python-versions [3.6.8, 3.7.9, 3.8.9, 3.9.4]
+
+              # only ever put one version in here, it's a bit of a silly
+              # way to do it but it keeps this number near the other python
+              # versions
+              integration-test-python-version: [3.9.4]
+
+              dimod-version: [==0.9.11, <0.10.0]
       - test-osx:
           matrix:
             parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,9 @@ jobs:
           name: run unittests
           command: |
             . env/bin/activate
-            if [[ << parameters.integration-test-python-version >> != << parameters.python-version >>]] then export SKIP_INT_TESTS=1 fi
+            if [[ << parameters.integration-test-python-version >> != << parameters.python-version >> ]]; then
+              export SKIP_INT_TESTS=1
+            fi
             coverage run -m unittest discover
 
       - run: &codecov-template
@@ -87,13 +89,14 @@ jobs:
     parameters:
       python-version:
         type: string
+      integration-test-python-version:
+        type: string
 
     macos:
       xcode: "12.2.0"
 
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
-      SKIP_INT_TESTS: 1
 
     steps:
       - checkout
@@ -178,13 +181,14 @@ workflows:
               # only ever put one version in here, it's a bit of a silly
               # way to do it but it keeps this number near the other python
               # versions
-              integration-test-python-version: [3.9.4]
+              integration-test-python-version: &integration-python-versions [3.9.4]
 
               dimod-version: [==0.9.11, <0.10.0]
       - test-osx:
           matrix:
             parameters:
               python-version: *python-versions
+              integration-test-python-version: *integration-python-versions
       - test-doctest
 
   deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,11 +170,10 @@ workflows:
                 - 3.8-buster
                 - 3.7-stretch
                 - 3.6-jessie
-                - 3.5-jessie
       - test-osx:
           matrix:
             parameters:
-              python-version: ["3.5.4", "3.6.8", "3.7.5", "3.8.6", "3.9.0"]
+              python-version: ["3.6.8", "3.7.5", "3.8.6", "3.9.0"]
       - test-doctest
 
   deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,12 +176,8 @@ workflows:
           name: test-linux-<< matrix.python-version >>-dimod<< matrix.dimod-version >>
           matrix:
             parameters:
-              python-version: &python-versions [3.6.8, 3.7.9, 3.8.9, 3.9.4]
-
-              # only ever put one version in here, it's a bit of a silly
-              # way to do it but it keeps this number near the other python
-              # versions
-              integration-test-python-version: &integration-python-versions [3.9.4]
+              python-version: &python-versions [3.6.8, 3.7.9, 3.8.9, &latest-python 3.9.4]
+              integration-test-python-version: &integration-python-versions [*latest-python]
 
               dimod-version: [==0.9.11, <0.10.0]
       - test-osx:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,13 @@
 version: 2.1
 
 jobs:
-  test-linux:
+  test-linux: &test-linux-template
     parameters:
-      image:
+      python-version:
         type: string
 
     docker:
-      - image: circleci/python:<< parameters.image >>
+      - image: circleci/python:<< parameters.python-version >>
 
     steps:
       - checkout
@@ -87,6 +87,7 @@ jobs:
 
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
+      SKIP_INT_TESTS: 1
 
     steps:
       - checkout
@@ -165,15 +166,11 @@ workflows:
       - test-linux:
           matrix:
             parameters:
-              image:
-                - 3.9-buster
-                - 3.8-buster
-                - 3.7-stretch
-                - 3.6-jessie
+              python-version: &python-versions [3.6.8, 3.7.9, 3.8.9, 3.9.4]
       - test-osx:
           matrix:
             parameters:
-              python-version: ["3.6.8", "3.7.5", "3.8.6", "3.9.0"]
+              python-version: *python-versions
       - test-doctest
 
   deploy:

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ os.chdir(setup_folder_loc)
 exec(open(os.path.join(".", "dwave", "system", "package_info.py")).read())
 
 
+# if the dimod version range changes, update in .circleci/config.yml
 install_requires = ['dimod>=0.9.11,<0.10.0',
                     'dwave-cloud-client>=0.8.4,<0.9.0',
                     'dwave-networkx>=0.8.4',

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ install_requires = ['dimod>=0.9.11,<0.10.0',
 extras_require = {'drivers': ['dwave-drivers>=0.4.0,<0.5.0'],
                   }
 
-python_requires = '>=3.5'
+python_requires = '>=3.6'
 
 packages = ['dwave',
             'dwave.embedding',

--- a/tests/qpu/test_dwavecliquesampler.py
+++ b/tests/qpu/test_dwavecliquesampler.py
@@ -13,6 +13,7 @@
 #    limitations under the License.
 
 import itertools
+import os
 import unittest
 
 import dimod
@@ -21,6 +22,7 @@ from dwave.cloud.exceptions import ConfigFileError, SolverNotFoundError
 from dwave.system import DWaveCliqueSampler
 
 
+@unittest.skipIf(os.getenv('SKIP_INT_TESTS'), "Skipping integration test.")
 class TestDWaveCliqueSampler(unittest.TestCase):
     def test_chimera(self):
         try:

--- a/tests/qpu/test_dwavesampler.py
+++ b/tests/qpu/test_dwavesampler.py
@@ -13,6 +13,7 @@
 #    limitations under the License.
 
 import unittest
+import os
 from unittest import mock
 
 import numpy
@@ -24,6 +25,7 @@ from dwave.cloud.client import Client
 from dwave.system.samplers import DWaveSampler
 
 
+@unittest.skipIf(os.getenv('SKIP_INT_TESTS'), "Skipping integration test.")
 class TestDWaveSampler(unittest.TestCase):
 
     @classmethod
@@ -127,6 +129,7 @@ class TestDWaveSampler(unittest.TestCase):
         self.assertNotIn('problem_label', sampleset.info)
 
 
+@unittest.skipIf(os.getenv('SKIP_INT_TESTS'), "Skipping integration test.")
 class TestMissingQubits(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -152,6 +155,7 @@ class TestMissingQubits(unittest.TestCase):
         assert len(sampleset.variables) < 2048  # sanity check
 
 
+@unittest.skipIf(os.getenv('SKIP_INT_TESTS'), "Skipping integration test.")
 class TestClientSelection(unittest.TestCase):
 
     def test_client_type(self):

--- a/tests/qpu/test_embeddingcomposite.py
+++ b/tests/qpu/test_embeddingcomposite.py
@@ -12,6 +12,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+import os
 import unittest
 import warnings
 
@@ -22,6 +23,7 @@ from dwave.cloud.exceptions import ConfigFileError
 from dwave.system import DWaveSampler, EmbeddingComposite
 
 
+@unittest.skipIf(os.getenv('SKIP_INT_TESTS'), "Skipping integration test.")
 class TestEmbeddingCompositeExactSolver(unittest.TestCase):
 
     @classmethod

--- a/tests/qpu/test_leaphybriddqmsampler.py
+++ b/tests/qpu/test_leaphybriddqmsampler.py
@@ -13,6 +13,7 @@
 #    limitations under the License.
 #
 
+import os
 import unittest
 
 import dimod
@@ -26,6 +27,7 @@ except (ValueError, ConfigFileError, SolverNotFoundError):
     sampler = None
 
 
+@unittest.skipIf(os.getenv('SKIP_INT_TESTS'), "Skipping integration test.")
 @unittest.skipIf(sampler is None, "no hybrid sampler available")
 class TestLeapHybridSampler(unittest.TestCase):
     def test_smoke(self):

--- a/tests/qpu/test_leaphybridsampler.py
+++ b/tests/qpu/test_leaphybridsampler.py
@@ -13,6 +13,7 @@
 #    limitations under the License.
 #
 
+import os
 import unittest
 
 import dimod
@@ -26,6 +27,7 @@ except (ValueError, ConfigFileError, SolverNotFoundError):
     sampler = None
 
 
+@unittest.skipIf(os.getenv('SKIP_INT_TESTS'), "Skipping integration test.")
 @unittest.skipIf(sampler is None, "no hybrid sampler available")
 # @dimod.testing.load_sampler_bqm_tests(sampler)  # these take a while
 class TestLeapHybridSampler(unittest.TestCase):

--- a/tests/qpu/test_schedules.py
+++ b/tests/qpu/test_schedules.py
@@ -12,6 +12,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+import os
 import unittest
 
 from dwave.cloud.exceptions import ConfigFileError
@@ -20,6 +21,7 @@ from dwave.system.schedules import ramp
 from dwave.system.samplers import DWaveSampler
 
 
+@unittest.skipIf(os.getenv('SKIP_INT_TESTS'), "Skipping integration test.")
 class TestRamp(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/tests/qpu/test_virtual_graph_composite.py
+++ b/tests/qpu/test_virtual_graph_composite.py
@@ -12,6 +12,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+import os
 import itertools
 import unittest
 
@@ -24,6 +25,7 @@ from dwave.system.composites import VirtualGraphComposite
 from dwave.system.samplers import DWaveSampler
 
 
+@unittest.skipIf(os.getenv('SKIP_INT_TESTS'), "Skipping integration test.")
 class TestVirtualGraphComposite(unittest.TestCase):
 
     @classmethod


### PR DESCRIPTION
- [x] drop python 3.5
- [x] run fewer integration tests
    - [x] only run integration tests on that latest python version
- [x] Test across dimod version range
- [ ] ~Test across cloud-client version range (maybe)~