### PR TITLE
Remove use of dimod's preprocessing extra install arg

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,7 +179,7 @@ workflows:
               python-version: &python-versions [3.6.8, 3.7.9, 3.8.9, &latest-python 3.9.4]
               integration-test-python-version: &integration-python-versions [*latest-python]
 
-              dimod-version: [==0.9.11, <0.10.0, '[preprocessing]==0.10.0rc1']
+              dimod-version: [==0.9.11, <0.10.0, <0.11]
       - test-osx:
           name: test-osx-<< matrix.python-version >>
           matrix:

--- a/setup.py
+++ b/setup.py
@@ -25,9 +25,7 @@ os.chdir(setup_folder_loc)
 exec(open(os.path.join(".", "dwave", "system", "package_info.py")).read())
 
 
-# in the future, dwave-preprocessing will become a full dependency, but let's
-# let dimod handle it for now
-install_requires = ['dimod[preprocessing]>=0.9.11,<0.11.0',
+install_requires = ['dimod>=0.9.11,<0.11.0',
                     'dwave-cloud-client>=0.8.4,<0.9.0',
                     'dwave-networkx>=0.8.4',
                     'networkx>=2.0,<3.0',


### PR DESCRIPTION
`dwave-preprocessing` was promoted to a full dependency in `dimod==0.10.5` and the `preprocessing` extra install argument was removed. 

This will fix a `pkg_resources.UnknownExtra` error that comes up when another package requires `dwave-system` but `dwave-preprocessing` is not installed (despite `dwave-preprocessing` not being a requirement). 