### PR TITLE
Allow config solver override in hybrid samplers

### DIFF
--- a/docs/reference/samplers.rst
+++ b/docs/reference/samplers.rst
@@ -102,6 +102,7 @@ Properties
 
    LeapHybridSampler.properties
    LeapHybridSampler.parameters
+   LeapHybridSampler.default_solver
 
 
 Methods
@@ -128,6 +129,7 @@ Properties
 
    LeapHybridDQMSampler.properties
    LeapHybridDQMSampler.parameters
+   LeapHybridDQMSampler.default_solver
 
 
 Methods

--- a/dwave/system/__init__.py
+++ b/dwave/system/__init__.py
@@ -21,3 +21,5 @@ from dwave.system.composites import *
 import dwave.system.composites
 
 from dwave.system.utilities import *
+
+from dwave.system.package_info import __version__

--- a/dwave/system/samplers/dwave_sampler.py
+++ b/dwave/system/samplers/dwave_sampler.py
@@ -128,7 +128,6 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
 
     """
     def __init__(self, failover=False, retry_interval=-1, **config):
-
         # strongly prefer QPU solvers; requires kwarg-level override
         config.setdefault('client', 'qpu')
 

--- a/dwave/system/samplers/leap_hybrid_sampler.py
+++ b/dwave/system/samplers/leap_hybrid_sampler.py
@@ -65,11 +65,11 @@ class LeapHybridSampler(dimod.Sampler):
     ``category=hybrid`` and ``supported_problem_type=bqm``. By default, online
     hybrid BQM solvers are returned ordered by latest ``version``.
 
-    Exact default solver specification used for feature-based solver filtering
-    (including ordering) is available as :attr:`.default_solver` property.
-    This specification is overridden when specifying solver explicitly in a
-    configuration file, an environment variable, or keyword arguments. See the
-    example below on how to extend it instead.
+    The default specification for filtering and ordering solvers by features is
+    available as :attr:`.default_solver` property. Explicitly specifying a
+    solver in a configuration file, an environment variable, or keyword
+    arguments overrides this specification. See the example below on how to
+    extend it instead.
 
     Args:
         **config:
@@ -92,16 +92,18 @@ class LeapHybridSampler(dimod.Sampler):
         >>> bqm = dimod.BQM.from_qubo(qubo)
         ...
         >>> # Find a good solution
-        >>> sampler = LeapHybridSampler()    # doctest: +SKIP
-        >>> sampleset = sampler.sample(bqm)           # doctest: +SKIP
+        >>> sampler = LeapHybridSampler()       # doctest: +SKIP
+        >>> sampleset = sampler.sample(bqm)     # doctest: +SKIP
 
         This example specializes the default solver selection by filtering out
-        bulk BQM solvers.
+        bulk BQM solvers. (Bulk solvers are throughput-optimal for heavy/batch
+        workloads, have a higher start-up latency, and are not well suited for
+        live workloads. Not all Leap accounts have access to bulk solvers.)
 
         >>> from dwave.system import LeapHybridSampler
         ...
         >>> solver = LeapHybridSampler.default_solver
-        >>> solver.update(name__regex=".*(?<!bulk)$")
+        >>> solver.update(name__regex=".*(?<!bulk)$")       # name shouldn't end with "bulk"
         >>> sampler = LeapHybridSampler(solver=solver)      # doctest: +SKIP
         >>> sampler.solver        # doctest: +SKIP
         BQMSolver(id='hybrid_binary_quadratic_model_version2')
@@ -112,7 +114,7 @@ class LeapHybridSampler(dimod.Sampler):
 
     @classproperty
     def default_solver(cls):
-        """dict: Features used to select the latest hybrid BQM solver in Leap."""
+        """dict: Features used to select the latest accessible hybrid BQM solver."""
         return dict(supported_problem_types__contains='bqm',
                     order_by='-properties.version')
 
@@ -299,11 +301,11 @@ class LeapHybridDQMSampler:
     ``category=hybrid`` and ``supported_problem_type=dqm``. By default, online
     hybrid DQM solvers are returned ordered by latest ``version``.
 
-    Exact default solver specification used for feature-based solver filtering
-    (including ordering) is available as :attr:`.default_solver` property.
-    This specification is overridden when specifying solver explicitly in a
-    configuration file, an environment variable, or keyword arguments. See the
-    example in :class:`.LeapHybridSampler` on how to extend it instead.
+    The default specification for filtering and ordering solvers by features is
+    available as :attr:`.default_solver` property. Explicitly specifying a
+    solver in a configuration file, an environment variable, or keyword
+    arguments overrides this specification. See the example in :class:`.LeapHybridSampler`
+    on how to extend it instead.
 
     Args:
         **config:
@@ -348,7 +350,7 @@ class LeapHybridDQMSampler:
 
     @classproperty
     def default_solver(self):
-        """dict: Features used to select the latest hybrid DQM solver in Leap."""
+        """dict: Features used to select the latest accessible hybrid DQM solver."""
         return dict(supported_problem_types__contains='dqm',
                     order_by='-properties.version')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,10 @@
 --extra-index-url https://pypi.dwavesys.com/simple
 
-dimod==0.9.15
-dwave-cloud-client==0.8.4
-dwave-networkx==0.8.4
+dimod==0.9.16
+dwave-cloud-client==0.8.7
+dwave-networkx==0.8.8
 dwave-drivers==0.4.4
-dwave-tabu==0.3.1
+dwave-tabu==0.4.1
 homebase==1.0.1
-minorminer==0.2.4
-numpy==1.19.4; python_version >= '3.6'
-numpy==1.18.5; python_version == '3.5'
+minorminer==0.2.6
+numpy==1.19.4

--- a/tests/test_leaphybridsolver.py
+++ b/tests/test_leaphybridsolver.py
@@ -53,6 +53,7 @@ class TestLeapHybridSampler(unittest.TestCase):
         default_solver = dict(
             supported_problem_types__contains='bqm',
             order_by='-properties.version')
+        self.assertEqual(LeapHybridSampler.default_solver, default_solver)
 
         defaults = dict(solver=default_solver)
 

--- a/tests/test_leaphybridsolver.py
+++ b/tests/test_leaphybridsolver.py
@@ -36,7 +36,7 @@ class MockClient:
 
     def get_solver(self, **filters):
 
-        if isinstance(self.args['solver'], str) and self.args['solver'] == 'not_hybrid_solver':
+        if self.args.get('solver') == 'not_hybrid_solver':
             return MockBadLeapHybridSolver()
 
         if self.args.get('client', 'base') not in ['base', 'hybrid']:
@@ -48,87 +48,65 @@ class TestLeapHybridSampler(unittest.TestCase):
 
     @mock.patch('dwave.system.samplers.leap_hybrid_sampler.Client')
     def test_solver_init(self, mock_client):
-
         mock_client.from_config.side_effect = MockClient
+
+        default_solver = dict(
+            supported_problem_types__contains='bqm',
+            order_by='-properties.version')
+
+        defaults = dict(solver=default_solver)
 
         # Default call
         mock_client.reset_mock()
         LeapHybridSampler()
         mock_client.from_config.assert_called_once_with(
-            client='hybrid', connection_close=True,
-            solver={'category': 'hybrid',
-                    'supported_problem_types__contains': 'bqm',
-                    'order_by': '-properties.version'})
+            client='hybrid',
+            connection_close=True,
+            defaults=defaults)
 
         # Non-hybrid client setting
         mock_client.reset_mock()
         with self.assertRaises(SolverNotFoundError):
             LeapHybridSampler(client='qpu')
 
-        # Explicitly set category to hybrid
+        # Explicitly set solver def
         mock_client.reset_mock()
-        LeapHybridSampler(solver={'category': 'hybrid',
-                                  'supported_problem_types__contains': 'bqm'})
+        LeapHybridSampler(solver={'supported_problem_types__contains': 'bqm'})
         mock_client.from_config.assert_called_once_with(
-            client='hybrid', connection_close=True,
-            solver={'category': 'hybrid',
-                    'supported_problem_types__contains': 'bqm',
-                    'order_by': '-properties.version'})
+            client='hybrid',
+            solver={'supported_problem_types__contains': 'bqm'},
+            connection_close=True,
+            defaults=defaults)
 
-        # Explicitly set category to not hybrid
-        with self.assertRaises(ValueError):
-            LeapHybridSampler(solver={'category': 'not hybrid'})
-
-        # Set irrelevant paremeters
+        # Named solver
+        solver_name = 'hybrid-solver-name'
         mock_client.reset_mock()
-        LeapHybridSampler(solver={'qpu': True})
+        LeapHybridSampler(solver=solver_name)
         mock_client.from_config.assert_called_once_with(
-            client='hybrid', connection_close=True,
-            solver={'qpu': True, 'category': 'hybrid',
-                    'supported_problem_types__contains': 'bqm',
-                    'order_by': '-properties.version'})
-
-        mock_client.reset_mock()
-        LeapHybridSampler(solver={'qpu': True, 'anneal_schedule': False})
-        mock_client.from_config.assert_called_once_with(
-            client='hybrid', connection_close=True,
-            solver={'anneal_schedule': False, 'qpu': True, 'category': 'hybrid',
-                    'supported_problem_types__contains': 'bqm',
-                    'order_by': '-properties.version'})
-
-        # Named solver: hybrid
-        mock_client.reset_mock()
-        LeapHybridSampler(solver="hybrid_solver")
-        mock_client.from_config.assert_called_once_with(
-            client='hybrid', connection_close=True, solver="hybrid_solver")
-
-        mock_client.reset_mock()
-        LeapHybridSampler(connection_close=False, solver="hybrid_solver")
-        mock_client.from_config.assert_called_once_with(
-            client='hybrid', connection_close=False, solver="hybrid_solver")
+            client='hybrid',
+            solver=solver_name,
+            connection_close=True,
+            defaults=defaults)
 
         # Named solver: non-hybrid
         with self.assertRaises(ValueError):
-            LeapHybridSampler(solver="not_hybrid_solver")
+            LeapHybridSampler(solver='not_hybrid_solver')
 
         # Set connection_close to False
         mock_client.reset_mock()
         LeapHybridSampler(connection_close=False)
         mock_client.from_config.assert_called_once_with(
-            client='hybrid', connection_close=False,
-            solver={'category': 'hybrid',
-                    'supported_problem_types__contains': 'bqm',
-                    'order_by': '-properties.version'})
+            client='hybrid',
+            connection_close=False,
+            defaults=defaults)
 
         mock_client.reset_mock()
-        LeapHybridSampler(connection_close=False,
-                          solver={'category': 'hybrid',
-                                  'supported_problem_types__contains': 'bqm'})
+        LeapHybridSampler(connection_close=False, solver=solver_name)
         mock_client.from_config.assert_called_once_with(
-            client='hybrid', connection_close=False,
-            solver={'category': 'hybrid',
-                    'supported_problem_types__contains': 'bqm',
-                    'order_by': '-properties.version'})
+            client='hybrid',
+            solver=solver_name,
+            connection_close=False,
+            defaults=defaults)
 
     @mock.patch('dwave.system.samplers.leap_hybrid_sampler.Client')
     def test_sample_bqm(self, mock_client):


### PR DESCRIPTION
Constrain client type to hybrid, but propagate user-specified solver definition (from config file/env/kwargs).

This is a hybrid analogue of #317 (where we applied the same fix to QPU samplers).

Closes #363.

### Note

Partial user-supplied solver definition (patch) is not yet possible, as that requires https://github.com/dwavesystems/dwave-cloud-client/issues/426.

**User-supplied solver mapping will not be updated to fix accepted problems types (bqm/dqm) or version preference.**

So, while this PR fixes the unexpected behavior or user not being able to override the solver in config file/env, it creates a new (less unexpected) gotcha -- whenever user sets `solver` (on any level above `defaults`), that solver filter is used verbatim. For example, users wanting to filter-out bulk solvers will have to make sure they specify the BQM or DQM solver explicitly, as the user selection is final.
