### PR TITLE
Make QPU tests insensitive to QPU topology availability

### DIFF
--- a/tests/qpu/test_dwavesampler.py
+++ b/tests/qpu/test_dwavesampler.py
@@ -19,7 +19,7 @@ from unittest import mock
 import numpy
 
 import dimod
-from dwave.cloud.exceptions import ConfigFileError
+from dwave.cloud.exceptions import ConfigFileError, SolverNotFoundError
 from dwave.cloud.client import Client
 
 from dwave.system.samplers import DWaveSampler
@@ -32,7 +32,7 @@ class TestDWaveSampler(unittest.TestCase):
     def setUpClass(cls):
         try:
             cls.qpu = DWaveSampler()
-        except (ValueError, ConfigFileError):
+        except (ValueError, ConfigFileError, SolverNotFoundError):
             raise unittest.SkipTest("no qpu available")
 
     @classmethod
@@ -136,7 +136,7 @@ class TestMissingQubits(unittest.TestCase):
         try:
             # get a QPU with less than 100% yield
             cls.qpu = DWaveSampler(solver=dict(num_active_qubits__lt=2048))
-        except (ValueError, ConfigFileError):
+        except (ValueError, ConfigFileError, SolverNotFoundError):
             raise unittest.SkipTest("no qpu available")
 
     @classmethod

--- a/tests/qpu/test_embeddingcomposite.py
+++ b/tests/qpu/test_embeddingcomposite.py
@@ -18,7 +18,7 @@ import warnings
 
 import dimod
 
-from dwave.cloud.exceptions import ConfigFileError
+from dwave.cloud.exceptions import ConfigFileError, SolverNotFoundError
 
 from dwave.system import DWaveSampler, EmbeddingComposite
 
@@ -31,7 +31,7 @@ class TestEmbeddingCompositeExactSolver(unittest.TestCase):
         try:
             cls.qpu = DWaveSampler(
                 solver=dict(initial_state=True, anneal_schedule=True))
-        except (ValueError, ConfigFileError):
+        except (ValueError, ConfigFileError, SolverNotFoundError):
             raise unittest.SkipTest("no qpu available")
 
     @classmethod

--- a/tests/qpu/test_schedules.py
+++ b/tests/qpu/test_schedules.py
@@ -15,7 +15,7 @@
 import os
 import unittest
 
-from dwave.cloud.exceptions import ConfigFileError
+from dwave.cloud.exceptions import ConfigFileError, SolverNotFoundError
 
 from dwave.system.schedules import ramp
 from dwave.system.samplers import DWaveSampler
@@ -27,7 +27,7 @@ class TestRamp(unittest.TestCase):
     def setUpClass(cls):
         try:
             cls.qpu = DWaveSampler(solver=dict(h_gain_schedule=True))
-        except (ValueError, ConfigFileError):
+        except (ValueError, ConfigFileError, SolverNotFoundError):
             raise unittest.SkipTest("no qpu available")
 
     @classmethod

--- a/tests/qpu/test_virtual_graph_composite.py
+++ b/tests/qpu/test_virtual_graph_composite.py
@@ -19,7 +19,7 @@ import unittest
 import minorminer
 import dimod.testing as dtest
 
-from dwave.cloud.exceptions import ConfigFileError
+from dwave.cloud.exceptions import ConfigFileError, SolverNotFoundError
 
 from dwave.system.composites import VirtualGraphComposite
 from dwave.system.samplers import DWaveSampler
@@ -32,7 +32,7 @@ class TestVirtualGraphComposite(unittest.TestCase):
     def setUpClass(cls):
         try:
             cls.qpu = DWaveSampler(solver=dict(flux_biases=True))
-        except (ValueError, ConfigFileError):
+        except (ValueError, ConfigFileError, SolverNotFoundError):
             raise unittest.SkipTest("no qpu available")
 
     @classmethod


### PR DESCRIPTION
Fix failing `tests.qpu.test_dwavesampler.TestMissingQubits` tests in [build 195](https://app.circleci.com/pipelines/github/dwavesystems/dwave-system/195/workflows/69b25e8d-a78b-4c75-889f-c1a32a2f5136).