### PR TITLE
Suggest using `EmbeddingComposite` when the hardware graph is incompatible

### DIFF
--- a/dwave/system/samplers/dwave_sampler.py
+++ b/dwave/system/samplers/dwave_sampler.py
@@ -378,7 +378,7 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
         if isinstance(h, list):
             if len(h) > self.solver.num_qubits:
                 msg = ("Problem graph incompatible with solver. Please use 'EmbeddingComposite' "
-                      "to map the problem graph to the solver.")
+                       "to map the problem graph to the solver.")
                 raise BinaryQuadraticModelStructureError(msg)
             nodes = self.solver.nodes
             h = dict((v, b) for v, b in enumerate(h) if b and v in nodes)

--- a/dwave/system/samplers/dwave_sampler.py
+++ b/dwave/system/samplers/dwave_sampler.py
@@ -376,8 +376,8 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
         # on missing nodes for lists
         if isinstance(h, list):
             if len(h) > self.solver.num_qubits:
-                msg = "Problem graph incompatible with solver. Please use 'EmbeddingComposite' "
-                      "to map the problem graph to the solver."
+                msg = ("Problem graph incompatible with solver. Please use 'EmbeddingComposite' "
+                      "to map the problem graph to the solver.")
                 raise BinaryQuadraticModelStructureError(msg)
             nodes = self.solver.nodes
             h = dict((v, b) for v, b in enumerate(h) if b and v in nodes)

--- a/dwave/system/samplers/dwave_sampler.py
+++ b/dwave/system/samplers/dwave_sampler.py
@@ -347,7 +347,8 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
 
         if not (solver.nodes.issuperset(bqm.linear) and
                 solver.edges.issuperset(bqm.quadratic)):
-            msg = "Problem graph incompatible with solver."
+            msg = ("Problem graph incompatible with solver. Please use 'EmbeddingComposite' "
+                   "to map the problem graph to the solver.")
             raise BinaryQuadraticModelStructureError(msg)
 
         future = solver.sample_bqm(bqm, **kwargs)

--- a/dwave/system/samplers/dwave_sampler.py
+++ b/dwave/system/samplers/dwave_sampler.py
@@ -376,7 +376,8 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
         # on missing nodes for lists
         if isinstance(h, list):
             if len(h) > self.solver.num_qubits:
-                msg = "Problem graph incompatible with solver."
+                msg = "Problem graph incompatible with solver. Please use 'EmbeddingComposite' "
+                      "to map the problem graph to the solver."
                 raise BinaryQuadraticModelStructureError(msg)
             nodes = self.solver.nodes
             h = dict((v, b) for v, b in enumerate(h) if b and v in nodes)


### PR DESCRIPTION
**Description of the Change:**
Updated the error message in `sample_ising()` method to suggest using `EmbeddingComposite` when the hardware graph is incompatible with the solver.

**Related Issue:**
Closes #407
