### PR TITLE
Add feature flag `hss_solver_config_override`

### DIFF
--- a/dwave/system/samplers/leap_hybrid_sampler.py
+++ b/dwave/system/samplers/leap_hybrid_sampler.py
@@ -119,6 +119,12 @@ class LeapHybridSampler(dimod.Sampler):
         # default to short-lived session to prevent resets on slow uploads
         config.setdefault('connection_close', True)
 
+        if FeatureFlags.hss_solver_config_override:
+            # use legacy behavior (override solver config from env/file)
+            solver = config.setdefault('solver', {})
+            if isinstance(solver, abc.Mapping):
+                solver.update(self.default_solver)
+
         # prefer the latest hybrid BQM solver available, but allow for an easy
         # override on any config level above the defaults (file/env/kwarg)
         defaults = config.setdefault('defaults', {})
@@ -354,6 +360,12 @@ class LeapHybridDQMSampler:
 
         # default to short-lived session to prevent resets on slow uploads
         config.setdefault('connection_close', True)
+
+        if FeatureFlags.hss_solver_config_override:
+            # use legacy behavior (override solver config from env/file)
+            solver = config.setdefault('solver', {})
+            if isinstance(solver, abc.Mapping):
+                solver.update(self.default_solver)
 
         # prefer the latest hybrid DQM solver available, but allow for an easy
         # override on any config level above the defaults (file/env/kwarg)

--- a/dwave/system/samplers/leap_hybrid_sampler.py
+++ b/dwave/system/samplers/leap_hybrid_sampler.py
@@ -36,16 +36,10 @@ except ImportError:
     bqm_to_file = FileView
 
 from dwave.cloud import Client
+from dwave.system.utilities import classproperty, FeatureFlags
 
 
 __all__ = ['LeapHybridSampler', 'LeapHybridDQMSampler']
-
-
-# taken from https://stackoverflow.com/a/39542816, licensed under CC BY-SA 3.0
-# not needed in py39+
-class classproperty(property):
-    def __get__(self, obj, objtype=None):
-        return super(classproperty, self).__get__(objtype)
 
 
 class LeapHybridSampler(dimod.Sampler):

--- a/dwave/system/utilities.py
+++ b/dwave/system/utilities.py
@@ -14,9 +14,18 @@
 
 """Utility functions."""
 
+import os
+import json
 import networkx as nx
 
-__all__ = ['common_working_graph']
+__all__ = ['common_working_graph', 'classproperty']
+
+
+# taken from https://stackoverflow.com/a/39542816, licensed under CC BY-SA 3.0
+# not needed in py39+
+class classproperty(property):
+    def __get__(self, obj, objtype=None):
+        return super(classproperty, self).__get__(objtype)
 
 
 def common_working_graph(graph0, graph1):
@@ -58,3 +67,21 @@ def common_working_graph(graph0, graph1):
                      if v in graph1 and u in graph1[v])
 
     return(G)
+
+
+class FeatureFlags:
+    """User environment-level Ocean feature flags pertinent to dwave-system."""
+
+    # NOTE: This is an experimental feature. If we decide to keep it, we'll want
+    # to move this machinery level up to Ocean-common.
+
+    @staticmethod
+    def get(name, default=False):
+        try:
+            return json.loads(os.getenv('DWAVE_FEATURE_FLAGS')).get(name, default)
+        except:
+            return default
+
+    @classproperty
+    def hss_solver_config_override(cls):
+        return cls.get('hss_solver_config_override')

--- a/tests/qpu/test_leaphybrid_common.py
+++ b/tests/qpu/test_leaphybrid_common.py
@@ -1,0 +1,84 @@
+# Copyright 2021 D-Wave Systems Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+import os
+import json
+import unittest
+
+from parameterized import parameterized_class
+
+from dwave.cloud.exceptions import ConfigFileError, SolverNotFoundError
+from dwave.cloud.testing import isolated_environ
+from dwave.system import LeapHybridSampler, LeapHybridDQMSampler
+
+
+@parameterized_class(
+    ("problem_type", "sampler_cls"), [
+        ("bqm", LeapHybridSampler),
+        ("dqm", LeapHybridDQMSampler)
+    ])
+@unittest.skipIf(os.getenv('SKIP_INT_TESTS'), "Skipping integration test.")
+class TestLegacySolverSelection(unittest.TestCase):
+
+    def test_baseline(self):
+        # kwarg-level override should always work
+        try:
+            sampler = self.sampler_cls(solver=self.sampler_cls.default_solver)
+        except (ValueError, ConfigFileError):
+            raise unittest.SkipTest("config error")
+
+        self.assertIn(self.problem_type, sampler.solver.supported_problem_types)
+
+        sampler.client.close()
+
+    def test_new_positive(self):
+        # given valid solver spec in env, init succeeds
+        solver = json.dumps(self.sampler_cls.default_solver)
+        with isolated_environ(add={'DWAVE_API_SOLVER': solver},
+                              remove=('DWAVE_FEATURE_FLAGS',)):
+            try:
+                sampler = self.sampler_cls()
+            except (ValueError, ConfigFileError):
+                raise unittest.SkipTest("config error")
+
+            self.assertIn(self.problem_type, sampler.solver.supported_problem_types)
+
+        sampler.client.close()
+
+    def test_new_negative(self):
+        # given invalid solver spec in env, init fails
+        solver = json.dumps(dict(qpu=True))
+        with isolated_environ(add={'DWAVE_API_SOLVER': solver},
+                              remove=('DWAVE_FEATURE_FLAGS',)):
+            with self.assertRaises(SolverNotFoundError):
+                try:
+                    sampler = self.sampler_cls()
+                except (ValueError, ConfigFileError):
+                    raise unittest.SkipTest("config error")
+
+    def test_old(self):
+        # given invalid solver spec in env, init succeeds
+        solver = json.dumps(dict(qpu=True))
+        flags = json.dumps(dict(hss_solver_config_override=True))
+        with isolated_environ(add={'DWAVE_API_SOLVER': solver,
+                                   'DWAVE_FEATURE_FLAGS': flags}):
+            try:
+                sampler = self.sampler_cls()
+            except (ValueError, ConfigFileError):
+                raise unittest.SkipTest("config error")
+
+            self.assertIn(self.problem_type, sampler.solver.supported_problem_types)
+
+        sampler.client.close()

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -16,7 +16,10 @@ import unittest
 
 import dwave_networkx as dnx
 
+from dwave.cloud.testing import isolated_environ
+
 from dwave.system import common_working_graph
+from dwave.system.utilities import FeatureFlags
 
 
 class TestCommonWorkingGraph(unittest.TestCase):
@@ -63,3 +66,29 @@ class TestCommonWorkingGraph(unittest.TestCase):
 
         self.assertEqual(set(H.nodes), {0, 1, 2})
         self.assertEqual(set(H.edges), set())
+
+
+class TestFeatureFlagSupport(unittest.TestCase):
+    def test_base(self):
+        with isolated_environ(add={'DWAVE_FEATURE_FLAGS': '{"x": true}'}):
+            self.assertTrue(FeatureFlags.get('x'))
+        with isolated_environ(add={'DWAVE_FEATURE_FLAGS': '{"x": false}'}):
+            self.assertFalse(FeatureFlags.get('x'))
+        with isolated_environ(add={'DWAVE_FEATURE_FLAGS': '{"x": 0}'}):
+            self.assertFalse(FeatureFlags.get('x'))
+        with isolated_environ(add={'DWAVE_FEATURE_FLAGS': '{"x": 1}'}):
+            self.assertTrue(FeatureFlags.get('x'))
+        with isolated_environ(add={'DWAVE_FEATURE_FLAGS': '{"x": error}'}):
+            self.assertFalse(FeatureFlags.get('x'))
+        with isolated_environ(add={'DWAVE_FEATURE_FLAGS': '{"y": true}'}):
+            self.assertFalse(FeatureFlags.get('x'))
+        with isolated_environ(add={'DWAVE_FEATURE_FLAGS': ''}):
+            self.assertFalse(FeatureFlags.get('x'))
+        with isolated_environ(remove=('DWAVE_FEATURE_FLAGS',)):
+            self.assertFalse(FeatureFlags.get('x'))
+
+    def test_hss_solver_config_override(self):
+        with isolated_environ(add={'DWAVE_FEATURE_FLAGS': '{"hss_solver_config_override": true}'}):
+            self.assertTrue(FeatureFlags.hss_solver_config_override)
+        with isolated_environ(remove=('DWAVE_FEATURE_FLAGS',)):
+            self.assertFalse(FeatureFlags.hss_solver_config_override)


### PR DESCRIPTION
Add support for feature flags via `DWAVE_FEATURE_FLAGS` env var.

Re-introduce the #363 bug in spirit (hybrid solvers ignore solver def from config file/end), enabled by setting `hss_solver_config_override` feature flag.

This is to support LeapIDE upgrade.