### PR TITLE
TilingComposite support for Advantage processor

### DIFF
--- a/dwave/system/composites/tiling.py
+++ b/dwave/system/composites/tiling.py
@@ -35,6 +35,7 @@ import numpy as np
 
 import dwave.embedding
 
+import warnings
 __all__ = ['TilingComposite']
 
 

--- a/dwave/system/composites/tiling.py
+++ b/dwave/system/composites/tiling.py
@@ -35,7 +35,6 @@ import numpy as np
 
 import dwave.embedding
 
-import warnings
 __all__ = ['TilingComposite']
 
 
@@ -131,7 +130,7 @@ class TilingComposite(dimod.Sampler, dimod.Composite, dimod.Structured):
             # case we would need to know how many tiles to use
             raise ValueError("given child sampler should be structured")
         self.children = [sampler]
-        #Chimera values (unless pegasus specified)
+        # Chimera values (unless pegasus specified)
         num_sublattices=1
         nodes_per_cell = t * 2
         edges_per_cell = t * t
@@ -139,12 +138,10 @@ class TilingComposite(dimod.Sampler, dimod.Composite, dimod.Structured):
             and 'type' in sampler.properties['topology']
             and 'shape' in sampler.properties['topology']):
             raise ValueError('To use this composite it is necessary for the'
-                             'structured sampler to have an explicity topology'
+                             'structured sampler to have an explicit topology'
                              '(sampler.properties[\'topology\']). Necessary'
                              'fields are \'type\' and \'shape\'. ')
         if sampler.properties['topology']['type'] == 'chimera':
-            #Similar to legacy branch, but using properties information to
-            #robustly define target solver graph (system)
             if len(sampler.properties['topology']['shape']) != 3: 
                 raise ValueError('topology shape is not of length 3 '
                                  '(not compatible with chimera)')
@@ -157,12 +154,12 @@ class TilingComposite(dimod.Sampler, dimod.Composite, dimod.Structured):
             if len(sampler.properties['topology']['shape']) != 1: 
                 raise ValueError('topology shape is not of length 1 '
                                  '(not compatible with pegasus)')
-            #Full yield in odd-couplers also required.
-            #Generalizes chimera subgraph requirement and leads to some 
-            #simplification of expressions, but at with a cost in cell-yield
+            # Full yield in odd-couplers also required.
+            # Generalizes chimera subgraph requirement and leads to some 
+            # simplification of expressions, but at with a cost in cell-yield
             edges_per_cell += t
-            #Square solvers only by pegasus lattice definition PN yields
-            #3 by N-1 by N-1 cells:
+            # Square solvers only by pegasus lattice definition PN yields
+            # 3 by N-1 by N-1 cells:
             num_sublattices=3
             m = n = sampler.properties['topology']['shape'][0] - 1
             if t!=4:
@@ -173,7 +170,7 @@ class TilingComposite(dimod.Sampler, dimod.Composite, dimod.Structured):
              
         
         if num_sublattices==1:
-            #Chimera defaults. Appended coordinates (treat as first and only sublattice)
+            # Chimera defaults. Appended coordinates (treat as first and only sublattice)
             system = dnx.chimera_graph(m, n, t,
                                        node_list=sampler.structure.nodelist,
                                        edge_list=sampler.structure.edgelist)
@@ -185,7 +182,7 @@ class TilingComposite(dimod.Sampler, dimod.Composite, dimod.Structured):
             system = dnx.pegasus_graph(m,
                                        node_list=sampler.structure.nodelist,
                                        edge_list=sampler.structure.edgelist)
-            #Vector specification in terms of nice coordinates:
+            # Vector specification in terms of nice coordinates:
             c2i = {dnx.pegasus_coordinates(m+1).linear_to_nice(linear_index):
                    linear_index for linear_index in system.nodes()}
         

--- a/dwave/system/composites/tiling.py
+++ b/dwave/system/composites/tiling.py
@@ -133,7 +133,7 @@ class TilingComposite(dimod.Sampler, dimod.Composite, dimod.Structured):
         edges_per_cell = t * t
         if ('topology' in sampler.properties
             and 'type' in sampler.properties['topology']
-            and 'shape' in sampler.properties['topology']);
+            and 'shape' in sampler.properties['topology']):
             if sampler.properties['topology']['type'] == 'chimera':
                 #Similar to legacy branch, but using properties information to
                 #robustly define target solver graph (system)
@@ -247,14 +247,14 @@ class TilingComposite(dimod.Sampler, dimod.Composite, dimod.Structured):
                                 cells[s][i + sub_i][j + sub_j] = False  # Mark cell as matched
                                 for u in range(2):
                                     for k in range(t):
-                                        embedding[sub_c2i[sub_i, sub_j, u, k]]
-                                        = {c2i[(s,i + sub_i, j + sub_j, u, k)]}
+                                        embedding[sub_c2i[sub_i, sub_j, u, k]] = {
+                                            c2i[(s,i + sub_i, j + sub_j, u, k)]}
 
                         embeddings.append(embedding)
 
         if len(embeddings) == 0:
-            raise ValueError("no tile embeddings found; '
-            'is the sampler Pegasus or Chimera structured?")
+            raise ValueError("no tile embeddings found; "
+                             "is the sampler Pegasus or Chimera structured?")
         
     @dimod.bqm_structured
     def sample(self, bqm, **kwargs):

--- a/dwave/system/composites/tiling.py
+++ b/dwave/system/composites/tiling.py
@@ -13,14 +13,14 @@
 #    limitations under the License.
 
 """
-A :std:doc:`dimod composite <oceandocs:docs_dimod/reference/samplers>` that tiles small problems
-multiple times to a Chimera-structured sampler.
+A :std:doc:dimod composite <oceandocs:docs_dimod/reference/samplers> that tiles 
+small problems multiple times to a structured sampler.
 
-The :class:`.TilingComposite` takes a problem that can fit on a small
-:term:`Chimera` graph and replicates it across a larger
+The :class:.TilingComposite class takes a problem that can fit on a small
+:term:Chimera graph and replicates it across a larger Pegasus or
 Chimera graph to obtain samples from multiple areas of the solver in one call.
-For example, a 2x2 Chimera lattice could be tiled 64 times (8x8) on a fully-yielded
-D-Wave 2000Q system (16x16).
+For example, a 2x2 Chimera lattice could be tiled 64 times (8x8) on a 
+fully-yielded D-Wave 2000Q system (16x16).
 
 See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/stable/concepts/index.html>`_
 for explanations of technical terms in descriptions of Ocean tools.
@@ -39,25 +39,28 @@ __all__ = ['TilingComposite']
 
 
 class TilingComposite(dimod.Sampler, dimod.Composite, dimod.Structured):
-    """Composite to tile a small problem across a sampler.
+    """Composite to tile a small problem across a structured sampler.
 
-    Enables parallel sampling for small problems (problems that are 
-    minor-embeddable in a :term:`Chimera` graph of dimensions (``sub_m``, ``sub_n``, ``t``). 
-    The sampler used can be Chimera or Pegasus structured, since Chimera graphs
-    are subgraphs of Pegasus graphs.
+
+
+    Enables parallel sampling on Chimera or Pegasus structured samplers of 
+    small problems. The small problem should be defined on a :term:`Chimera` 
+    graph of dimensions ``sub_m``, ``sub_n``, ``t``, or minor-embeddable to 
+    such a graph.
 
     Notation *CN* refers to a Chimera graph consisting of an NxN grid of unit 
     cells, where each unit cell is a bipartite graph with shores of size t. 
     The D-Wave 2000Q QPU supports a C16 Chimera graph: its 2048 qubits are 
-    logically mapped into a 16x16 matrix of unit cell of 8 qubits (t=4).
+    logically mapped into a 16x16 matrix of unit cells of 8 qubits (t=4). 
+    See also :func:dwave_networkx.chimera_graph 
 
-    Notation *PN* referes to a Pegasus graph consisting of 3x(N-1)x(N-1) grid 
+    Notation *PN* referes to a Pegasus graph consisting of a 3x(N-1)x(N-1) grid 
     of cells, where each unit cell is a bipartite graph with shore of size t, 
     supplemented with odd couplers (see nice_coordinate definition). The 
-    Advantage QPU supports a P16 Pegasus graph: It's qubits may be mapped to 
-    3x15x15 matrix of unit cells each of 8 qubits. This code supports tiling of 
-    chimera-structured problems, with an option of additional odd-couplers,
-    onto Pegasus. 
+    Advantage QPU supports a P16 Pegasus graph: its qubits may be mapped to a 
+    3x15x15 matrix of unit cells, each of 8 qubits. This code supports tiling of
+    Chimera-structured problems, with an option of additional odd-couplers,
+    onto Pegasus. See also :func:dwave_networkx.pegasus_graph .
 
     A problem that can be minor-embedded in a single chimera unit cell, for 
     example, can therefore be tiled across the unit cells of a D-Wave 2000Q as 
@@ -68,9 +71,9 @@ class TilingComposite(dimod.Sampler, dimod.Composite, dimod.Structured):
        sampler (:class:`dimod.Sampler`): Structured dimod sampler such as a 
            :class:`~dwave.system.samplers.DWaveSampler()`.
        sub_m (int): Minimum number of Chimera unit cell rows required for
-           minor-embedding without duplication.
+           minor-embedding a single instance of the problem.
        sub_n (int): Minimum number of Chimera unit cell columns required for 
-           minor-embedding without duplication.
+           minor-embedding a single instance of the problem.
        t (int, optional, default=4): Size of the shore within each Chimera unit 
            cell.
 

--- a/dwave/system/composites/tiling.py
+++ b/dwave/system/composites/tiling.py
@@ -170,7 +170,7 @@ class TilingComposite(dimod.Sampler, dimod.Composite, dimod.Structured):
         else:
             warnings.warn("Incomplete solver topology information."
                           "Falling back to unsafe legacy branch.",
-                          warnings.DeprecationWarning)
+                          DeprecationWarning)
             # assume square lattice shape, and high yield, chimera system
             m = n = int(ceil(sqrt(ceil(len(sampler.structure.nodelist) / nodes_per_cell))))  
         

--- a/dwave/system/composites/tiling.py
+++ b/dwave/system/composites/tiling.py
@@ -135,44 +135,42 @@ class TilingComposite(dimod.Sampler, dimod.Composite, dimod.Structured):
         num_sublattices=1
         nodes_per_cell = t * 2
         edges_per_cell = t * t
-        if ('topology' in sampler.properties
+        if not ('topology' in sampler.properties
             and 'type' in sampler.properties['topology']
             and 'shape' in sampler.properties['topology']):
-            if sampler.properties['topology']['type'] == 'chimera':
-                #Similar to legacy branch, but using properties information to
-                #robustly define target solver graph (system)
-                if len(sampler.properties['topology']['shape']) != 3: 
-                    raise ValueError('topology shape is not of length 3 '
-                                     '(not compatible with chimera)')
-                if sampler.properties['topology']['shape'][2] != t: 
-                    raise ValueError('Tiling methodology requires that solver'
-                                     'and subproblem have identical shore size')
-                m = sampler.properties['topology']['shape'][0]
-                n = sampler.properties['topology']['shape'][1]
-            else:
-                if len(sampler.properties['topology']['shape']) != 1: 
-                    raise ValueError('topology shape is not of length 1 '
-                                     '(not compatible with pegasus)')
-                #Full yield in odd-couplers also required.
-                #Generalizes chimera subgraph requirement and leads to some 
-                #simplification of expressions, but at with a cost in cell-yield
-                edges_per_cell += t
-                #Square solvers only by pegasus lattice definition PN yields
-                #3 by N-1 by N-1 cells:
-                num_sublattices=3
-                m = n = sampler.properties['topology']['shape'][0] - 1
-                if t!=4:
-                    raise ValueError(
-                        't=4 for all pegasus processors, value is not typically'
-                        'stored in solver properties and is difficult to infer.'
-                        'Therefore only the value t=4 is supported.')
-                    
+            raise ValueError('To use this composite it is necessary for the'
+                             'structured sampler to have an explicity topology'
+                             '(sampler.properties[\'topology\']). Necessary'
+                             'fields are \'type\' and \'shape\'. ')
+        if sampler.properties['topology']['type'] == 'chimera':
+            #Similar to legacy branch, but using properties information to
+            #robustly define target solver graph (system)
+            if len(sampler.properties['topology']['shape']) != 3: 
+                raise ValueError('topology shape is not of length 3 '
+                                 '(not compatible with chimera)')
+            if sampler.properties['topology']['shape'][2] != t: 
+                raise ValueError('Tiling methodology requires that solver'
+                                 'and subproblem have identical shore size')
+            m = sampler.properties['topology']['shape'][0]
+            n = sampler.properties['topology']['shape'][1]
         else:
-            warnings.warn("Incomplete solver topology information."
-                          "Falling back to unsafe legacy branch.",
-                          DeprecationWarning)
-            # assume square lattice shape, and high yield, chimera system
-            m = n = int(ceil(sqrt(ceil(len(sampler.structure.nodelist) / nodes_per_cell))))  
+            if len(sampler.properties['topology']['shape']) != 1: 
+                raise ValueError('topology shape is not of length 1 '
+                                 '(not compatible with pegasus)')
+            #Full yield in odd-couplers also required.
+            #Generalizes chimera subgraph requirement and leads to some 
+            #simplification of expressions, but at with a cost in cell-yield
+            edges_per_cell += t
+            #Square solvers only by pegasus lattice definition PN yields
+            #3 by N-1 by N-1 cells:
+            num_sublattices=3
+            m = n = sampler.properties['topology']['shape'][0] - 1
+            if t!=4:
+                raise ValueError(
+                    't=4 for all pegasus processors, value is not typically'
+                    'stored in solver properties and is difficult to infer.'
+                    'Therefore only the value t=4 is supported.')
+             
         
         if num_sublattices==1:
             #Chimera defaults. Appended coordinates (treat as first and only sublattice)

--- a/dwave/system/composites/tiling.py
+++ b/dwave/system/composites/tiling.py
@@ -39,25 +39,40 @@ __all__ = ['TilingComposite']
 
 
 class TilingComposite(dimod.Sampler, dimod.Composite, dimod.Structured):
-    """Composite to tile a small problem across a Chimera-structured sampler.
+    """Composite to tile a small problem across a sampler.
 
-    Enables parallel sampling for small problems (problems that are minor-embeddable in
-    a small part of a D-Wave solver's :term:`Chimera` graph).
+    Enables parallel sampling for small problems (problems that are 
+    minor-embeddable in a :term:`Chimera` graph of dimensions (``sub_m``, ``sub_n``, ``t``). 
+    The sampler used can be Chimera or Pegasus structured, since Chimera graphs
+    are subgraphs of Pegasus graphs.
 
-    Notation *CN* refers to a Chimera graph consisting of an NxN grid of unit cells, where
-    each unit cell is a bipartite graph with shores of size t. The D-Wave 2000Q QPU
-    supports a C16 Chimera graph: its 2048 qubits are logically mapped into a 16x16 matrix of
-    unit cell of 8 qubits (t=4).
+    Notation *CN* refers to a Chimera graph consisting of an NxN grid of unit 
+    cells, where each unit cell is a bipartite graph with shores of size t. 
+    The D-Wave 2000Q QPU supports a C16 Chimera graph: its 2048 qubits are 
+    logically mapped into a 16x16 matrix of unit cell of 8 qubits (t=4).
 
-    A problem that can be minor-embedded in a single unit cell, for example, can therefore
-    be tiled across the unit cells of a D-Wave 2000Q as 16x16 duplicates. This enables
-    sampling 256 solutions in a single call.
+    Notation *PN* referes to a Pegasus graph consisting of 3x(N-1)x(N-1) grid 
+    of cells, where each unit cell is a bipartite graph with shore of size t, 
+    supplemented with odd couplers (see nice_coordinate definition). The 
+    Advantage QPU supports a P16 Pegasus graph: It's qubits may be mapped to 
+    3x15x15 matrix of unit cells each of 8 qubits. This code supports tiling of 
+    chimera-structured problems, with an option of additional odd-couplers,
+    onto Pegasus. 
+
+    A problem that can be minor-embedded in a single chimera unit cell, for 
+    example, can therefore be tiled across the unit cells of a D-Wave 2000Q as 
+    16x16 duplicates (or Advantage as 3x15x15 duplicates), subject to solver
+    yield. This enables up to 256 (625) parallel samples per read.
 
     Args:
-       sampler (:class:`dimod.Sampler`): Structured dimod sampler such as a :class:`~dwave.system.samplers.DWaveSampler()`.
-       sub_m (int): Number of rows of Chimera unit cells for minor-embedding the problem once.
-       sub_n (int): Number of columns of Chimera unit cells for minor-embedding the problem once.
-       t (int, optional, default=4): Size of the shore within each Chimera unit cell.
+       sampler (:class:`dimod.Sampler`): Structured dimod sampler such as a 
+           :class:`~dwave.system.samplers.DWaveSampler()`.
+       sub_m (int): Minimum number of Chimera unit cell rows required for
+           minor-embedding without duplication.
+       sub_n (int): Minimum number of Chimera unit cell columns required for 
+           minor-embedding without duplication.
+       t (int, optional, default=4): Size of the shore within each Chimera unit 
+           cell.
 
     Examples:
        This example submits a two-variable QUBO problem representing a logical
@@ -104,73 +119,143 @@ class TilingComposite(dimod.Sampler, dimod.Composite, dimod.Structured):
         tile = dnx.chimera_graph(sub_m, sub_n, t)
         self.nodelist = sorted(tile.nodes)
         self.edgelist = sorted(sorted(edge) for edge in tile.edges)
-        # dimod.Structured abstract base class automatically populates adjacency and structure as
-        # mixins based on nodelist and edgelist
+        # dimod.Structured abstract base class automatically populates adjacency
+        # and structure as mixins based on nodelist and edgelist
 
         if not isinstance(sampler, dimod.Structured):
-            # we could also just tile onto the unstructured sampler but in that case we would need
-            # to know how many tiles to use
+            # we could also just tile onto the unstructured sampler but in that
+            # case we would need to know how many tiles to use
             raise ValueError("given child sampler should be structured")
         self.children = [sampler]
-
+        #Chimera values (unless pegasus specified)
+        num_sublattices=1
         nodes_per_cell = t * 2
         edges_per_cell = t * t
-        m = n = int(ceil(sqrt(ceil(len(sampler.structure.nodelist) / nodes_per_cell))))  # assume square lattice shape
-        system = dnx.chimera_graph(m, n, t, node_list=sampler.structure.nodelist, edge_list=sampler.structure.edgelist)
-        c2i = {chimera_index: linear_index for (linear_index, chimera_index) in system.nodes(data='chimera_index')}
-        sub_c2i = {chimera_index: linear_index for (linear_index, chimera_index) in tile.nodes(data='chimera_index')}
-
+        if ('topology' in sampler.properties
+            and 'type' in sampler.properties['topology']
+            and 'shape' in sampler.properties['topology']);
+            if sampler.properties['topology']['type'] == 'chimera':
+                #Similar to legacy branch, but using properties information to
+                #robustly define target solver graph (system)
+                if len(sampler.properties['topology']['shape']) != 3: 
+                    raise ValueError('topology shape is not of length 3 '
+                                     '(not compatible with chimera)')
+                if sampler.properties['topology']['shape'][2] != t: 
+                    raise ValueError('Tiling methodology requires that solver'
+                                     'and subproblem have identical shore size')
+                m = sampler.properties['topology']['shape'][0]
+                n = sampler.properties['topology']['shape'][1]
+            else:
+                if len(sampler.properties['topology']['shape']) != 1: 
+                    raise ValueError('topology shape is not of length 1 '
+                                     '(not compatible with pegasus)')
+                #Full yield in odd-couplers also required.
+                #Generalizes chimera subgraph requirement and leads to some 
+                #simplification of expressions, but at with a cost in cell-yield
+                edges_per_cell += t
+                #Square solvers only by pegasus lattice definition PN yields
+                #3 by N-1 by N-1 cells:
+                num_sublattices=3
+                m = n = sampler.properties['topology']['shape'][0] - 1
+                if t!=4:
+                    raise ValueError(
+                        't=4 for all pegasus processors, value is not typically'
+                        'stored in solver properties and is difficult to infer.'
+                        'Therefore only the value t=4 is supported.')
+                    
+        else:
+            warnings.warn("Incomplete solver topology information."
+                          "Falling back to unsafe legacy branch.",
+                          warnings.DeprecationWarning)
+            # assume square lattice shape, and high yield, chimera system
+            m = n = int(ceil(sqrt(ceil(len(sampler.structure.nodelist) / nodes_per_cell))))  
+        
+        if num_sublattices==1:
+            #Chimera defaults. Appended coordinates (treat as first and only sublattice)
+            system = dnx.chimera_graph(m, n, t,
+                                       node_list=sampler.structure.nodelist,
+                                       edge_list=sampler.structure.edgelist)
+            
+            c2i = {(0, *chimera_index) : linear_index
+                   for (linear_index, chimera_index)
+                   in system.nodes(data='chimera_index')}
+        else:
+            system = dnx.pegasus_graph(m,
+                                       node_list=sampler.structure.nodelist,
+                                       edge_list=sampler.structure.edgelist)
+            #Vector specification in terms of nice coordinates:
+            c2i = {dnx.pegasus_coordinates(m+1).linear_to_nice(linear_index):
+                   linear_index for linear_index in system.nodes()}
+        
+        sub_c2i = {chimera_index: linear_index for (linear_index, chimera_index)
+                   in tile.nodes(data='chimera_index')}
+        
         # Count the connections between these qubits
         def _between(qubits1, qubits2):
-            edges = [edge for edge in system.edges if edge[0] in qubits1 and edge[1] in qubits2]
+            edges = [edge for edge in system.edges if edge[0] in qubits1
+                     and edge[1] in qubits2]
             return len(edges)
-
+        
         # Get the list of qubits in a cell
-        def _cell_qubits(i, j):
-            return [c2i[(i, j, u, k)] for u in range(2) for k in range(t) if (i, j, u, k) in c2i]
+        def _cell_qubits(s, i, j):
+            return [c2i[(s, i, j, u, k)] for u in range(2) for k in range(t)
+                    if (s, i, j, u, k) in c2i]
 
         # get a mask of complete cells
-        cells = [[False for _ in range(n)] for _ in range(m)]
-        for i in range(m):
-            for j in range(n):
-                qubits = _cell_qubits(i, j)
-                cells[i][j] = len(qubits) == nodes_per_cell and _between(qubits, qubits) == edges_per_cell
-
+        cells = [[[False for _ in range(n)] for _ in range(m)]
+                 for _ in range(num_sublattices)]
+        
+        for s in range(num_sublattices):
+            for i in range(m):
+                for j in range(n):
+                    qubits = _cell_qubits(s, i, j)
+                    cells[s][i][j] = (
+                        len(qubits) == nodes_per_cell
+                        and _between(qubits, qubits) == edges_per_cell)
+                    
         # List of 'embeddings'
         self.embeddings = properties['embeddings'] = embeddings = []
 
         # For each possible chimera cell check if the next few cells are complete
-        for i in range(m + 1 - sub_m):
-            for j in range(n + 1 - sub_n):
-
-                # Check if the sub cells are matched
-                match = all(cells[i + sub_i][j + sub_j] for sub_i in range(sub_m) for sub_j in range(sub_n))
-
-                # Check if there are connections between the cells.
-                for sub_i in range(sub_m):
-                    for sub_j in range(sub_n):
-                        if sub_m > 1 and sub_i < sub_m - 1:
-                            match &= _between(_cell_qubits(i + sub_i, j + sub_j),
-                                              _cell_qubits(i + sub_i + 1, j + sub_j)) == t
-                        if sub_n > 1 and sub_j < sub_n - 1:
-                            match &= _between(_cell_qubits(i + sub_i, j + sub_j),
-                                              _cell_qubits(i + sub_i, j + sub_j + 1)) == t
-
-                if match:
-                    # Pull those cells out into an embedding.
-                    embedding = {}
+        for s in range(num_sublattices):
+            for i in range(m + 1 - sub_m):
+                for j in range(n + 1 - sub_n):
+                    
+                    # Check if the sub cells are matched
+                    match = all(cells[s][i + sub_i][j + sub_j]
+                                for sub_i in range(sub_m)
+                                for sub_j in range(sub_n))
+                    
+                    # Check if there are connections between the cells.
+                    # Both Pegasus and Chimera have t vertical and t horizontal between cells:
                     for sub_i in range(sub_m):
                         for sub_j in range(sub_n):
-                            cells[i + sub_i][j + sub_j] = False  # Mark cell as matched
-                            for u in range(2):
-                                for k in range(t):
-                                    embedding[sub_c2i[sub_i, sub_j, u, k]] = {c2i[(i + sub_i, j + sub_j, u, k)]}
+                            if sub_m > 1 and sub_i < sub_m - 1:
+                                match &= _between(
+                                    _cell_qubits(s, i + sub_i, j + sub_j),
+                                    _cell_qubits(s, i + sub_i + 1, j + sub_j)) == t
+                            if sub_n > 1 and sub_j < sub_n - 1:
+                                match &= _between(
+                                    _cell_qubits(s, i + sub_i, j + sub_j),
+                                    _cell_qubits(s, i + sub_i, j + sub_j + 1)) == t
+                    
+                    if match:
+                        # Pull those cells out into an embedding.
+                        embedding = {}
+                        for sub_i in range(sub_m):
+                            for sub_j in range(sub_n):
+                                cells[s][i + sub_i][j + sub_j] = False  # Mark cell as matched
+                                for u in range(2):
+                                    for k in range(t):
+                                        embedding[sub_c2i[sub_i, sub_j, u, k]]
+                                        = {c2i[(s,i + sub_i, j + sub_j, u, k)]}
 
-                    embeddings.append(embedding)
+                        embeddings.append(embedding)
 
         if len(embeddings) == 0:
-            raise ValueError("no tile embeddings found; is the sampler Chimera structured?")
-
+            raise ValueError("no tile embeddings found; '
+            'is the sampler Pegasus or Chimera structured?")
+        
     @dimod.bqm_structured
     def sample(self, bqm, **kwargs):
         """Sample from the specified binary quadratic model.

--- a/dwave/system/testing.py
+++ b/dwave/system/testing.py
@@ -84,14 +84,12 @@ class MockDWaveSampler(dimod.Sampler, dimod.Structured):
         else:
             if broken_nodes == None:
                 broken_nodes = []
-                self.nodelist = sorted(solver_graph.nodes)
+            self.nodelist = sorted(v for v in solver_graph.nodes if v not in broken_nodes)
             if broken_edges == None:
                 broken_edges = []
-                self.nodelist = sorted(v for v in solver_graph.nodes if v not in broken_nodes) 
             self.edgelist = sorted(tuple(sorted((u, v))) for u, v in solver_graph.edges
                                    if u not in broken_nodes and v not in broken_nodes
                                    and (u, v) not in broken_edges and (v, u) not in broken_edges)
-
         # mark the sample kwargs
         self.parameters = parameters = {}
         parameters['num_reads'] = ['num_reads_range']

--- a/tests/test_mock_sampler.py
+++ b/tests/test_mock_sampler.py
@@ -26,6 +26,14 @@ class TestMockDWaveSampler(unittest.TestCase):
         sampler = MockDWaveSampler()
         dit.assert_sampler_api(sampler)
         dit.assert_structured_api(sampler)
+        
+    def test_topology_arguments(self):
+        pegasus_size = 4
+        sampler = MockDWaveSampler(topology_type='pegasus',topology_shape=[pegasus_size])
+        #P4 fabric only has 264 nodes
+        self.assertTrue(len(sampler.nodelist)==264)
+        dit.assert_sampler_api(sampler)
+        dit.assert_structured_api(sampler)
 
 class TestMockLeapHybridDQMSampler(unittest.TestCase):
     def test_sampler(self):

--- a/tests/test_mock_sampler.py
+++ b/tests/test_mock_sampler.py
@@ -47,7 +47,7 @@ class TestMockDWaveSampler(unittest.TestCase):
         # Delete final external edge (1 edge)
     
         delete_nodes = [0]
-        delete_edges = [(5, 5)]
+        delete_edges = [(5, 7)]
         
         chimera_shape = [2, 2, 1]
         sampler = MockDWaveSampler(topology_type='chimera',

--- a/tests/test_mock_sampler.py
+++ b/tests/test_mock_sampler.py
@@ -30,11 +30,33 @@ class TestMockDWaveSampler(unittest.TestCase):
     def test_topology_arguments(self):
         pegasus_size = 4
         sampler = MockDWaveSampler(topology_type='pegasus',topology_shape=[pegasus_size])
-        #P4 fabric only has 264 nodes
+        # P4 fabric only has 264 nodes
         self.assertTrue(len(sampler.nodelist)==264)
         dit.assert_sampler_api(sampler)
         dit.assert_structured_api(sampler)
-
+        
+    def test_yield_arguments(self):
+        # Request 1 node and 1 edge deletion, check resulting graph 
+        #    1      3
+        #  X      2
+        #
+        #    5 -X-  7
+        #  4      6
+        # Defect free case: 8 nodes. 4 external edges, 4 internal edges
+        # Delete first node (2 edges, 1 node)
+        # Delete final external edge (1 edge)
+    
+        delete_nodes = [0]
+        delete_edges = [(5, 5)]
+        
+        chimera_shape = [2, 2, 1]
+        sampler = MockDWaveSampler(topology_type='chimera',
+                                   topology_shape=chimera_shape,
+                                   broken_nodes=delete_nodes,
+                                   broken_edges=delete_edges)
+        self.assertTrue(len(sampler.nodelist)==7)
+        self.assertTrue(len(sampler.edgelist)==5)
+        
 class TestMockLeapHybridDQMSampler(unittest.TestCase):
     def test_sampler(self):
         sampler = MockLeapHybridDQMSampler()

--- a/tests/test_tiling_composite.py
+++ b/tests/test_tiling_composite.py
@@ -23,6 +23,43 @@ from dwave.system.composites import TilingComposite
 
 
 class TestTiling(unittest.TestCase):
+    def test_pegasus_single_cell(self):
+        #Test trivial case of single cell (K4,4+4*odd) embedding over defect free
+        mock_sampler = MockDWaveSampler(topology_type='pegasus')  # C4 structured sampler
+        self.assertTrue('topology' in mock_sampler.properties and 'type' in mock_sampler.properties['topology'])
+        self.assertTrue(mock_sampler.properties['topology']['type'] == 'pegasus' and 'shape' in mock_sampler.properties['topology'])
+        sampler = TilingComposite(mock_sampler, 1, 1)
+        h = {node: random.uniform(-1, 1) for node in sampler.structure.nodelist}
+        J = {(u, v): random.uniform(-1, 1) for u, v in sampler.structure.edgelist}
+
+        m = n = mock_sampler.properties['topology']['shape'][0] - 1
+        expected_number_of_cells = m*n*3
+        num_reads = 10
+        response = sampler.sample_ising(h, J, num_reads=num_reads)
+        self.assertTrue(sum(response.record.num_occurrences)==expected_number_of_cells*num_reads)
+        
+    def test_pegasus_multi_cell(self):
+        #Test case of 2x3 cell embedding over defect free
+        mock_sampler = MockDWaveSampler(topology_type='pegasus',topology_shape=[8])  # C4 structured sampler
+        self.assertTrue('topology' in mock_sampler.properties and 'type' in mock_sampler.properties['topology'])
+        self.assertTrue(mock_sampler.properties['topology']['type'] == 'pegasus' and 'shape' in mock_sampler.properties['topology'])
+        sampler = TilingComposite(mock_sampler, 1, 1)
+        h = {node: random.uniform(-1, 1) for node in sampler.structure.nodelist}
+        J = {(u, v): random.uniform(-1, 1) for u, v in sampler.structure.edgelist}
+        
+        m_sub = 2
+        n_sub = 3
+        sampler = TilingComposite(mock_sampler, m_sub, n_sub)
+        h = {node: random.uniform(-1, 1) for node in sampler.structure.nodelist}
+        J = {(u, v): random.uniform(-1, 1) for u, v in sampler.structure.edgelist}
+
+        m = n = mock_sampler.properties['topology']['shape'][0] - 1
+        expected_number_of_cells = (m//m_sub)*(n//3)*3
+        num_reads = 1
+        response = sampler.sample_ising(h, J, num_reads = num_reads)
+        self.assertTrue(sum(response.record.num_occurrences)==expected_number_of_cells*num_reads)
+        
+        
     def test_sample_ising(self):
         mock_sampler = MockDWaveSampler()  # C4 structured sampler
 


### PR DESCRIPTION
The TilingComposite has been modified to allow tiling of Chimera structured problems over Pegasus as well as Chimera solvers.
This is an important use case for certain users, who wish to compare Chimera-structured (or chimera embeddable) problems between the DW2000Q and Advantage generation processors, at high sample density.
Some minor fixes were also introduced for Chimera case, catching some pathological behaviours.

The DWaveMockSampler has been modified to support Pegasus as well as Chimera structured solver emulation.

These changes allow straightforward generalization for the case of Zephyr topologies.
These changes do not resolve all known outstanding issues with TilingComposite e.g. https://github.com/dwavesystems/dwave-system/issues/295 . This supports tiling of Chimera problems over Advantage (Pegasus-structured) processors, further changes are required to support tiling of Pegasus problems over Advantage (or DW2000Q) processors. 