### PR TITLE
Remove docs badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,9 +7,6 @@
 .. image:: https://codecov.io/gh/dwavesystems/dwave-system/branch/master/graph/badge.svg
    :target: https://codecov.io/gh/dwavesystems/dwave-system
 
-.. image:: https://readthedocs.com/projects/d-wave-systems-dwave-system/badge/?version=latest
-   :target: https://docs.ocean.dwavesys.com/projects/system/en/latest/?badge=latest
-
 .. image:: https://circleci.com/gh/dwavesystems/dwave-system.svg?style=svg
    :target: https://circleci.com/gh/dwavesystems/dwave-system
 


### PR DESCRIPTION
Closes https://github.com/dwavesystems/dwave-system/issues/440 when combined with a change in URL in the repo settings (already done).