### PR TITLE
Handle exception when BQM is passed to DQM sampler

### DIFF
--- a/dwave/system/samplers/leap_hybrid_sampler.py
+++ b/dwave/system/samplers/leap_hybrid_sampler.py
@@ -533,8 +533,12 @@ class LeapHybridDQMSampler:
             first two pairs that represent problems with "density" between 1 to
             100).
         """
-        ec = (dqm.num_variable_interactions() * dqm.num_cases() /
-              max(dqm.num_variables(), 1))
+        from dimod.discrete.discrete_quadratic_model import DiscreteQuadraticModel
+        if isinstance(dqm, DiscreteQuadraticModel):
+            ec = (dqm.num_variable_interactions() * dqm.num_cases() /
+                max(dqm.num_variables(), 1))
+        else:
+            raise TypeError(f"Expecting DiscreteQuadraticModel object, got {type(dqm)}")
         limits = np.array(self.properties['minimum_time_limit'])
         t = np.interp(ec, limits[:, 0], limits[:, 1])
         return max([5, t])

--- a/tests/test_leaphybriddqmsolver.py
+++ b/tests/test_leaphybriddqmsolver.py
@@ -54,12 +54,16 @@ class TestLeapHybridDQMSampler(unittest.TestCase):
             sampler = LeapHybridDQMSampler()
 
             dqm = dimod.DQM()
+            bqm = dimod.BinaryQuadraticModel('SPIN')
 
         with self.assertRaises(ValueError):
             sampler.sample_dqm(dqm, time_limit=1)
 
         with self.assertRaises(ValueError):
             sampler.sample_dqm(dqm, time_limit=10000000)
+
+        with self.assertRaises(TypeError):
+            sampler.sample_dqm(bqm)
 
     def test_DQM_subclass_without_serialization_can_be_sampled(self):
         """Test that DQM subclasses that do not implement serialization can


### PR DESCRIPTION
Closes #375

**Before**
BinaryQuadraticModel objects when passed to DQM sampler, raised an exception which wasn't informative.
```
>>> import dimod
>>> from dwave.system import LeapHybridDQMSampler
>>> bqm = dimod.BinaryQuadraticModel('SPIN')
>>> LeapHybridDQMSampler().sample_dqm(bqm)
...
AttributeError: 'BinaryQuadraticModel' object has no attribute 'num_variable_interactions'
```
**Now (after fix)**
```
>>> LeapHybridDQMSampler().sample_dqm(bqm)
TypeError: Expecting DiscreteQuadraticModel object, got <class 'dimod.binary.binary_quadratic_model.BinaryQuadraticModel'>
```
