### PR TITLE
Fix QPU failover - signal solver failover condition (on resolve)

### DIFF
--- a/dwave/system/exceptions.py
+++ b/dwave/system/exceptions.py
@@ -18,12 +18,12 @@ class MissingFluxBias(Exception):
 
 
 class FailoverCondition(Exception):
-    """QPU/SolverAPI call failed with an error that might be mitigated by
+    """QPU or Solver API call failed with an error that might be mitigated by
     retrying on a different solver.
     """
 
 
 class RetryCondition(FailoverCondition):
-    """QPU/SolverAPI call failed with an error that might be mitigated by
+    """QPU or Solver API call failed with an error that might be mitigated by
     retrying on the same solver.
     """

--- a/dwave/system/exceptions.py
+++ b/dwave/system/exceptions.py
@@ -15,3 +15,15 @@
 
 class MissingFluxBias(Exception):
     """"""
+
+
+class FailoverCondition(Exception):
+    """QPU/SolverAPI call failed with an error that might be mitigated by
+    retrying on a different solver.
+    """
+
+
+class RetryCondition(FailoverCondition):
+    """QPU/SolverAPI call failed with an error that might be mitigated by
+    retrying on the same solver.
+    """

--- a/dwave/system/samplers/clique.py
+++ b/dwave/system/samplers/clique.py
@@ -143,22 +143,24 @@ class DWaveCliqueSampler(dimod.Sampler):
 
     Args:
         failover (bool, optional, default=False):
-            Set to ``True`` in order to signal a failover condition on sampling error.
-            Failover is signalled by raising :exc:`.FailoverCondition` or
-            :exc:`.RetryCondition` on sampleset resolve.
+            Signal a failover condition if a sampling error occurs. When ``True``,
+            raises :exc:`~dwave.system.exceptions.FailoverCondition` or
+            :exc:`~dwave.system.exceptions.RetryCondition` on sampleset resolve
+            to signal failover.
 
             Actual failover, i.e. selection of a new solver, has to be handled
             by the user. A convenience method :meth:`.trigger_failover` is available
-            for this. Note that different QPUs may have different hardware graphs and a
-            failover will result in a regenerated :attr:`.nodelist`, :attr:`.edgelist`,
+            for this. Note that hardware graphs vary between QPUs, so triggering
+            failover results in regenerated :attr:`.nodelist`, :attr:`.edgelist`,
             :attr:`.properties` and :attr:`.parameters`.
 
             .. versionchanged:: 1.16.0
 
-               Some time ago, in the era of blocking :meth:`sample` response,
-               ``failover=True`` would cause QPU/solver failover and sampling
-               retry. However, ever since we made :meth:`sample` non-blocking/async,
-               failover was broken (setting ``failover=True`` had no effect).
+               In the past, the :meth:`.sample` method was blocking and
+               ``failover=True`` caused a solver failover and sampling retry.
+               However, this failover implementation broke when :meth:`sample`
+               became non-blocking (asynchronous), Setting ``failover=True`` had
+               no effect.
 
         retry_interval (number, optional, default=-1):
             Ignored, but kept for backward compatibility.

--- a/dwave/system/samplers/clique.py
+++ b/dwave/system/samplers/clique.py
@@ -241,7 +241,7 @@ class DWaveCliqueSampler(dimod.Sampler):
             energy_range = tuple(self.child.properties['h_range'])
         except KeyError as err:
             # for backwards compatibility with old software solvers
-            if self.child.solver.is_software:
+            if self.child.solver.software:
                 energy_range = (-2, 2)
             else:
                 raise err
@@ -265,7 +265,7 @@ class DWaveCliqueSampler(dimod.Sampler):
                                           self.child.properties['j_range']))
         except KeyError as err:
             # for backwards compatibility with old software solvers
-            if self.child.solver.is_software:
+            if self.child.solver.software:
                 energy_range = (-1, 1)
             else:
                 raise err

--- a/dwave/system/samplers/clique.py
+++ b/dwave/system/samplers/clique.py
@@ -29,7 +29,7 @@ except ImportError:
     # fall back on dimod of dwave.preprocessing is not installed
     from dimod import ScaleComposite
 
-from dwave.system.samplers.dwave_sampler import DWaveSampler, _failover
+from dwave.system.samplers.dwave_sampler import DWaveSampler
 from dwave.system.coupling_groups import coupling_groups
 
 __all__ = ['DWaveCliqueSampler']
@@ -142,18 +142,30 @@ class DWaveCliqueSampler(dimod.Sampler):
     :class:`.DWaveSampler`.
 
     Args:
-        failover (optional, default=False):
-            Switch to a new QPU in the rare event that the currently connected
-            system goes offline. Note that different QPUs may have different
-            hardware graphs and a failover will result in a regenerated
-            :attr:`.nodelist`, :attr:`.edgelist`, :attr:`.properties` and
-            :attr:`.parameters`.
+        failover (bool, optional, default=False):
+            Set to ``True`` in order to signal a failover condition on sampling error.
+            Failover is signalled by raising :exc:`.FailoverCondition` or
+            :exc:`.RetryCondition` on sampleset resolve.
 
-        retry_interval (optional, default=-1):
-            The amount of time (in seconds) to wait to poll for a solver in
-            the case that no solver is found. If `retry_interval` is negative
-            then it will instead propogate the `SolverNotFoundError` to the
-            user.
+            Actual failover, i.e. selection of a new solver, has to be handled
+            by the user. A convenience method :meth:`.trigger_failover` is available
+            for this. Note that different QPUs may have different hardware graphs and a
+            failover will result in a regenerated :attr:`.nodelist`, :attr:`.edgelist`,
+            :attr:`.properties` and :attr:`.parameters`.
+
+            .. versionchanged:: 1.16.0
+
+               Some time ago, in the era of blocking :meth:`sample` response,
+               ``failover=True`` would cause QPU/solver failover and sampling
+               retry. However, ever since we made :meth:`sample` non-blocking/async,
+               failover was broken (setting ``failover=True`` had no effect).
+
+        retry_interval (number, optional, default=-1):
+            Ignored, but kept for backward compatibility.
+
+            .. versionchanged:: 1.16.0
+
+               Ignored since 1.16.0. See note for ``failover`` parameter above.
 
         **config:
             Keyword arguments, as accepted by :class:`.DWaveSampler`
@@ -162,7 +174,7 @@ class DWaveCliqueSampler(dimod.Sampler):
         This example creates a BQM based on a 6-node clique (complete graph),
         with random :math:`\pm 1` values assigned to nodes, and submits it to
         a D-Wave system. Parameters for communication with the system, such
-        as its URL and an autentication token, are implicitly set in a
+        as its URL and an authentication token, are implicitly set in a
         configuration file or as environment variables, as described in
         `Configuring Access to D-Wave Solvers <https://docs.ocean.dwavesys.com/en/stable/overview/sapi.html>`_.
 
@@ -180,10 +192,8 @@ class DWaveCliqueSampler(dimod.Sampler):
     def __init__(self, *,
                  failover: bool = False, retry_interval: Number = -1,
                  **config):
-        self.child = DWaveSampler(failover=False, **config)
-
-        self.failover = failover
-        self.retry_interval = retry_interval
+        self.child = DWaveSampler(
+            failover=failover, retry_interval=retry_interval, **config)
 
     @property
     def parameters(self) -> dict:
@@ -298,15 +308,8 @@ class DWaveCliqueSampler(dimod.Sampler):
         return busgraph_cache(self.target_graph).largest_clique()
 
     def trigger_failover(self):
-        """Trigger a failover and connect to a new solver.
+        """Trigger a failover and connect to a new solver."""
 
-        retry_interval (number, optional):
-            The amount of time (in seconds) to wait to poll for a solver in
-            the case that no solver is found. If `retry_interval` is negative
-            then it will instead propogate the `SolverNotFoundError` to the
-            user. Defaults to :attr:`DWaveSampler.retry_interval`.
-
-        """
         self.child.trigger_failover()
 
         try:
@@ -324,7 +327,6 @@ class DWaveCliqueSampler(dimod.Sampler):
         except AttributeError:
             pass
 
-    @_failover
     def sample(self, bqm, chain_strength=None, **kwargs):
         """Sample from the specified binary quadratic model.
 

--- a/dwave/system/samplers/dwave_sampler.py
+++ b/dwave/system/samplers/dwave_sampler.py
@@ -98,22 +98,24 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
 
     Args:
         failover (bool, optional, default=False):
-            Set to ``True`` in order to signal a failover condition on sampling error.
-            Failover is signalled by raising :exc:`.FailoverCondition` or
-            :exc:`.RetryCondition` on sampleset resolve.
+            Signal a failover condition if a sampling error occurs. When ``True``,
+            raises :exc:`~dwave.system.exceptions.FailoverCondition` or
+            :exc:`~dwave.system.exceptions.RetryCondition` on sampleset resolve
+            to signal failover.
 
             Actual failover, i.e. selection of a new solver, has to be handled
             by the user. A convenience method :meth:`.trigger_failover` is available
-            for this. Note that different QPUs may have different hardware graphs and a
-            failover will result in a regenerated :attr:`.nodelist`, :attr:`.edgelist`,
+            for this. Note that hardware graphs vary between QPUs, so triggering
+            failover results in regenerated :attr:`.nodelist`, :attr:`.edgelist`,
             :attr:`.properties` and :attr:`.parameters`.
 
             .. versionchanged:: 1.16.0
 
-               Some time ago, in the era of blocking :meth:`sample` response,
-               ``failover=True`` would cause QPU/solver failover and sampling
-               retry. However, ever since we made :meth:`sample` non-blocking/async,
-               failover was broken (setting ``failover=True`` had no effect).
+               In the past, the :meth:`.sample` method was blocking and
+               ``failover=True`` caused a solver failover and sampling retry.
+               However, this failover implementation broke when :meth:`sample`
+               became non-blocking (asynchronous), Setting ``failover=True`` had
+               no effect.
 
         retry_interval (number, optional, default=-1):
             Ignored, but kept for backward compatibility.
@@ -136,7 +138,7 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
         adjacent qubits on a D-Wave system. ``qubit_a`` is the first qubit in
         the QPU's indexed list of qubits and ``qubit_b`` is one of the qubits
         coupled to it. Other required parameters for communication with the system, such
-        as its URL and an autentication token, are implicitly set in a configuration file
+        as its URL and an authentication token, are implicitly set in a configuration file
         or as environment variables, as described in
         `Configuring Access to D-Wave Solvers <https://docs.ocean.dwavesys.com/en/stable/overview/sapi.html>`_.
         Given sufficient reads (here 100), the quantum

--- a/dwave/system/samplers/dwave_sampler.py
+++ b/dwave/system/samplers/dwave_sampler.py
@@ -19,11 +19,7 @@ See :std:doc:`Ocean Glossary <oceandocs:glossary>`
 for explanations of technical terms in descriptions of Ocean tools.
 """
 
-import time
-import functools
 import collections.abc as abc
-
-from warnings import warn
 
 import dimod
 
@@ -34,23 +30,13 @@ from dwave.cloud.exceptions import (
     RequestTimeout, PollingTimeout, ProblemUploadError, ProblemStructureError,
 )
 
+from dwave.system.exceptions import FailoverCondition, RetryCondition
 from dwave.system.warnings import WarningHandler, WarningAction
 
 import dwave_networkx as dnx
 import networkx as nx
 
 __all__ = ['DWaveSampler', 'qpu_graph']
-
-
-class FailoverCondition(Exception):
-    """QPU/SolverAPI call failed with an error that might be mitigated by
-    retrying on a different solver.
-    """
-
-class RetryCondition(FailoverCondition):
-    """QPU/SolverAPI call failed with an error that might be mitigated by
-    retrying on the same solver.
-    """
 
 
 def qpu_graph(topology_type, topology_shape, nodelist, edgelist):

--- a/dwave/system/samplers/dwave_sampler.py
+++ b/dwave/system/samplers/dwave_sampler.py
@@ -139,17 +139,29 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
 
     Args:
         failover (bool, optional, default=False):
-            Switch to a new QPU in the rare event that the currently connected
-            system goes offline. Note that different QPUs may have different
-            hardware graphs and a failover will result in a regenerated
-            :attr:`.nodelist`, :attr:`.edgelist`, :attr:`.properties` and
-            :attr:`.parameters`.
+            Set to ``True`` in order to signal a failover condition on sampling error.
+            Failover is signalled by raising :exc:`.FailoverCondition` or
+            :exc:`.RetryCondition` on sampleset resolve.
+
+            Actual failover, i.e. selection of a new solver, has to be handled
+            by the user. A convenience method :meth:`.trigger_failover` is available
+            for this. Note that different QPUs may have different hardware graphs and a
+            failover will result in a regenerated :attr:`.nodelist`, :attr:`.edgelist`,
+            :attr:`.properties` and :attr:`.parameters`.
+
+            .. versionchanged:: 1.16.0
+
+               Some time ago, in the era of blocking :meth:`sample` response,
+               ``failover=True`` would cause QPU/solver failover and sampling
+               retry. However, ever since :meth:`sample` is non-blocking/async,
+               failover is broken, i.e. setting ``failover=True`` does nothing.
 
         retry_interval (number, optional, default=-1):
-            The amount of time (in seconds) to wait to poll for a solver in
-            the case that no solver is found. If `retry_interval` is negative
-            then it will instead propogate the `SolverNotFoundError` to the
-            user.
+            Ignored, but kept for backward compatibility.
+
+            .. versionchanged:: 1.16.0
+
+               Ignored since 1.16.0. See note for ``failover`` parameter above.
 
         **config:
             Keyword arguments passed to :meth:`dwave.cloud.client.Client.from_config`.
@@ -352,7 +364,6 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
         except AttributeError:
             pass
 
-    @_failover
     def sample(self, bqm, warnings=None, **kwargs):
         """Sample from the specified binary quadratic model.
 

--- a/dwave/system/samplers/dwave_sampler.py
+++ b/dwave/system/samplers/dwave_sampler.py
@@ -314,7 +314,7 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
 
         # the requested features are saved on the client object, so
         # we just need to request a new solver
-        self.solver = self.client.get_solver()
+        self.solver = self.client.get_solver(refresh=True)
 
         # delete the lazily-constructed attributes
         try:

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,5 @@
 parameterized==0.7.4
+networkx>=2.6
 
 coverage
 codecov

--- a/tests/test_dwavecliquesampler.py
+++ b/tests/test_dwavecliquesampler.py
@@ -24,7 +24,7 @@ import dwave_networkx as dnx
 from dwave.cloud import exceptions
 from dwave.cloud import computation
 from dwave.system import DWaveCliqueSampler, DWaveSampler
-from dwave.system.samplers.dwave_sampler import FailoverCondition, RetryCondition
+from dwave.system.exceptions import FailoverCondition, RetryCondition
 
 
 class MockDWaveSampler(dimod.RandomSampler, dimod.Structured):

--- a/tests/test_dwavecliquesampler.py
+++ b/tests/test_dwavecliquesampler.py
@@ -16,12 +16,15 @@ import itertools
 import unittest
 import unittest.mock
 
+from parameterized import parameterized
+
 import dimod
 import dwave_networkx as dnx
 
-from dwave.cloud.exceptions import SolverOfflineError, SolverNotFoundError
-
+from dwave.cloud import exceptions
+from dwave.cloud import computation
 from dwave.system import DWaveCliqueSampler, DWaveSampler
+from dwave.system.samplers.dwave_sampler import FailoverCondition, RetryCondition
 
 
 class MockDWaveSampler(dimod.RandomSampler, dimod.Structured):
@@ -146,62 +149,67 @@ class TestDWaveCliqueSampler(unittest.TestCase):
 
 
 class TestFailover(unittest.TestCase):
-    @unittest.mock.patch('dwave.system.samplers.clique.DWaveSampler',
-                         MockChimeraDWaveSampler)
-    def test_default(self):
+
+    @staticmethod
+    def patch_solver(solver, exc):
+        """Patch mock `solver` to fail with `exc` on sampleset resolve."""
+
+        # clique sampler needs a valid topology
+        solver.properties = {
+            'topology': {
+                'type': 'pegasus',
+                'shape': [4]
+            },
+            'parameters': {},
+            'h_range': [-2, 2],
+            'j_range': [-1, 1]
+        }
+
+        # simulate solver failure on sampleset resolve
+        fut = computation.Future(solver, None)
+        fut._set_exception(exc)
+        solver.sample_bqm = unittest.mock.Mock()
+        solver.sample_bqm.return_value = fut
+
+        return solver
+
+    @unittest.mock.patch('dwave.system.samplers.dwave_sampler.Client')
+    def test_default(self, mock_client):
         sampler = DWaveCliqueSampler()
 
-        def mocksample(*args, **kwargs):
-            raise SolverOfflineError
+        self.patch_solver(sampler.child.solver, exceptions.SolverOfflineError)
 
-        sampler.child.sample = mocksample
+        with self.assertRaises(exceptions.SolverOfflineError):
+            sampler.sample_ising({}, {}).resolve()
 
-        with self.assertRaises(SolverOfflineError):
-            sampler.sample_ising({}, {})
-
-    @unittest.mock.patch('dwave.system.samplers.clique.DWaveSampler',
-                         MockChimeraDWaveSampler)
-    def test_noretry(self):
-        sampler = DWaveCliqueSampler(failover=True, retry_interval=-1)
-
-        def mocksample(*args, **kwargs):
-            raise SolverOfflineError
-
-        sampler.child.sample = mocksample
-
-        def mocktrigger(*args, **kwargs):
-            raise SolverNotFoundError
-
-        sampler.child.trigger_failover = mocktrigger
-
-        with self.assertRaises(SolverNotFoundError):
-            sampler.sample_ising({}, {})
-
-    @unittest.mock.patch('dwave.system.samplers.clique.DWaveSampler',
-                         MockChimeraDWaveSampler)
-    def test_properties(self):
+    @parameterized.expand([
+        (exceptions.InvalidAPIResponseError, FailoverCondition),
+        (exceptions.SolverNotFoundError, FailoverCondition),
+        (exceptions.SolverOfflineError, FailoverCondition),
+        (exceptions.SolverError, FailoverCondition),
+        (exceptions.PollingTimeout, RetryCondition),
+        (exceptions.SolverAuthenticationError, exceptions.SolverAuthenticationError),   # auth error propagated
+        (KeyError, KeyError),   # unrelated errors propagated
+    ])
+    @unittest.mock.patch('dwave.system.samplers.dwave_sampler.Client')
+    def test_async_failover(self, source_exc, target_exc, mock_client):
         sampler = DWaveCliqueSampler(failover=True)
 
-        def mocksample(*args, **kwargs):
-            count = getattr(mocksample, 'count', 0)
+        self.patch_solver(sampler.child.solver, source_exc)
 
-            if count:
-                return dimod.SampleSet.from_samples([], energy=0., vartype='SPIN')
-            else:
-                mocksample.count = count + 1
-                raise SolverOfflineError
+        with self.assertRaises(target_exc):
+            sampler.sample_ising({}, {}).resolve()
 
-        sampler.child.sample = mocksample
+    @unittest.mock.patch('dwave.system.samplers.clique.DWaveSampler',
+                         MockChimeraDWaveSampler)
+    def test_properties_reinit(self):
+        sampler = DWaveCliqueSampler()
 
         G = sampler.target_graph
         qlr = sampler.qpu_linear_range
         qqr = sampler.qpu_quadratic_range
 
-        self.assertIs(G, sampler.target_graph)
-        self.assertIs(qlr, sampler.qpu_linear_range)
-        self.assertIs(qqr, sampler.qpu_quadratic_range)
-
-        sampler.sample_ising({}, {})
+        sampler.trigger_failover()
 
         self.assertIsNot(G, sampler.target_graph)
         self.assertIsNot(qlr, sampler.qpu_linear_range)

--- a/tests/test_dwavesampler.py
+++ b/tests/test_dwavesampler.py
@@ -14,15 +14,13 @@
 
 import sys
 import unittest
-import random
-import warnings
 
-from collections import namedtuple
 from concurrent.futures import Future
 from unittest import mock
 from uuid import uuid4
 
 import numpy as np
+from networkx.utils import graphs_equal
 
 import dimod
 import dwave_networkx as dnx
@@ -32,7 +30,6 @@ from dwave.cloud.exceptions import SolverOfflineError, SolverNotFoundError
 from dwave.system.samplers import DWaveSampler, qpu_graph
 from dwave.system.warnings import EnergyScaleWarning, TooFewSamplesWarning
 
-from networkx.utils.misc import graphs_equal
 
 C16 = dnx.chimera_graph(16)
 

--- a/tests/test_dwavesampler.py
+++ b/tests/test_dwavesampler.py
@@ -12,12 +12,10 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-import sys
 import unittest
-
-from concurrent.futures import Future
-from unittest import mock
 from uuid import uuid4
+from unittest import mock
+from concurrent.futures import Future
 
 import numpy as np
 from networkx.utils import graphs_equal
@@ -31,7 +29,7 @@ from dwave.cloud import computation
 
 from dwave.system.samplers import DWaveSampler, qpu_graph
 from dwave.system.warnings import EnergyScaleWarning, TooFewSamplesWarning
-from dwave.system.samplers.dwave_sampler import RetryCondition, FailoverCondition
+from dwave.system.exceptions import FailoverCondition, RetryCondition
 
 
 C16 = dnx.chimera_graph(16)

--- a/tests/test_dwavesampler.py
+++ b/tests/test_dwavesampler.py
@@ -21,14 +21,17 @@ from uuid import uuid4
 
 import numpy as np
 from networkx.utils import graphs_equal
+from parameterized import parameterized
 
 import dimod
 import dwave_networkx as dnx
 
-from dwave.cloud.exceptions import SolverOfflineError, SolverNotFoundError
+from dwave.cloud import exceptions
+from dwave.cloud import computation
 
 from dwave.system.samplers import DWaveSampler, qpu_graph
 from dwave.system.warnings import EnergyScaleWarning, TooFewSamplesWarning
+from dwave.system.samplers.dwave_sampler import RetryCondition, FailoverCondition
 
 
 C16 = dnx.chimera_graph(16)
@@ -91,7 +94,7 @@ class MockSolver():
         return future
 
 
-class TestDwaveSampler(unittest.TestCase):
+class TestDWaveSampler(unittest.TestCase):
     @mock.patch('dwave.system.samplers.dwave_sampler.Client')
     def setUp(self, MockClient):
 
@@ -200,28 +203,32 @@ class TestDwaveSampler(unittest.TestCase):
         self.assertEqual(ss.info.get('problem_label'), label)
 
     @mock.patch('dwave.system.samplers.dwave_sampler.Client')
-    def test_failover_false(self, MockClient):
+    def test_failover_off(self, MockClient):
         sampler = DWaveSampler(failover=False)
 
-        sampler.solver.sample_ising.side_effect = SolverOfflineError
-        sampler.solver.sample_qubo.side_effect = SolverOfflineError
-        sampler.solver.sample_bqm.side_effect = SolverOfflineError
+        sampler.solver.sample_bqm.side_effect = exceptions.SolverOfflineError
 
-        with self.assertRaises(SolverOfflineError):
+        with self.assertRaises(exceptions.SolverOfflineError):
             sampler.sample_ising({}, {})
 
+    @parameterized.expand([
+        (exceptions.InvalidAPIResponseError, FailoverCondition),
+        (exceptions.SolverNotFoundError, FailoverCondition),
+        (exceptions.SolverOfflineError, FailoverCondition),
+        (exceptions.SolverError, FailoverCondition),
+        (exceptions.PollingTimeout, RetryCondition),
+        (exceptions.SolverAuthenticationError, exceptions.SolverAuthenticationError),   # auth error propagated
+        (KeyError, KeyError),   # unrelated errors propagated
+    ])
     @mock.patch('dwave.system.samplers.dwave_sampler.Client')
-    def test_failover_offline(self, MockClient):
-        if sys.version_info.major <= 2 or sys.version_info.minor < 6:
-            raise unittest.SkipTest("need mock features only available in 3.6+")
-
+    def test_async_failover(self, source_exc, target_exc, MockClient):
         sampler = DWaveSampler(failover=True)
 
         mocksolver = sampler.solver
         edgelist = sampler.edgelist
 
-        # call once
-        ss = sampler.sample_ising({}, {})
+        # call once (async, no need to resolve)
+        sampler.sample_ising({}, {})
 
         self.assertIs(mocksolver, sampler.solver)  # still same solver
 
@@ -230,36 +237,25 @@ class TestDwaveSampler(unittest.TestCase):
                          + sampler.solver.sample_qubo.call_count
                          + sampler.solver.sample_bqm.call_count, 1)
 
-        # add a side-effect
-        sampler.solver.sample_ising.side_effect = SolverOfflineError
-        sampler.solver.sample_qubo.side_effect = SolverOfflineError
-        sampler.solver.sample_bqm.side_effect = SolverOfflineError
+        # simulate solver exception on sampleset resolve
+        fut = computation.Future(mocksolver, None)
+        fut._set_exception(source_exc)
+        sampler.solver.sample_bqm = mock.Mock()
+        sampler.solver.sample_bqm.return_value = fut
 
-        # and make sure get_solver makes a new mock solver
+        # verify failover signalled
+        with self.assertRaises(target_exc):
+            sampler.sample_ising({}, {}).resolve()
+
+        # make sure get_solver makes a new mock solver
         sampler.client.get_solver.reset_mock(return_value=True)
 
-        ss = sampler.sample_ising({}, {})
+        # trigger failover
+        sampler.trigger_failover()
 
+        # verify failover
         self.assertIsNot(mocksolver, sampler.solver)  # new solver
         self.assertIsNot(edgelist, sampler.edgelist)  # also should be new
-
-    @mock.patch('dwave.system.samplers.dwave_sampler.Client')
-    def test_failover_notfound_noretry(self, MockClient):
-
-        sampler = DWaveSampler(failover=True, retry_interval=-1)
-
-        mocksolver = sampler.solver
-
-        # add a side-effect
-        sampler.solver.sample_ising.side_effect = SolverOfflineError
-        sampler.solver.sample_qubo.side_effect = SolverOfflineError
-        sampler.solver.sample_bqm.side_effect = SolverOfflineError
-
-        # and make sure get_solver makes a new mock solver
-        sampler.client.get_solver.side_effect = SolverNotFoundError
-
-        with self.assertRaises(SolverNotFoundError):
-            sampler.sample_ising({}, {})
 
     def test_warnings_energy_range(self):
         sampler = self.sampler


### PR DESCRIPTION
Change in `DWaveSampler`/`DWaveCliqueSampler` behavior: when `failover=True` is specified on construction, solver failover is **only signalled**, and the actual failover is left as an exercise for the developer. :laughing:

The "dirty" bit we solve here is SAPI/solver exception unification:
- if we think sampling call is worth retrying on the same solver, we'll raise `RetryCondition` on sampleset resolve; and
- if we think sampling should be retried on a different solver, we'll raise `FailoverCondition` on sampleset resolve.

Note that `RetryCondition` is a specialization of `FailoverCondition`, so catching `FailoverCondition` and doing `sampler.trigger_failover()` should handle all failover cases.