### PR TITLE
Exact-solve for ground state in `MockDWaveSampler` on small problems

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -98,8 +98,6 @@ todo_include_todos = True
 modindex_common_prefix = ['dwave-system.']
 
 doctest_global_setup = """
-from __future__ import print_function, division
-
 import dimod
 from dwave.embedding import *
 

--- a/dwave/system/testing.py
+++ b/dwave/system/testing.py
@@ -384,7 +384,7 @@ class MockDWaveSampler(dimod.Sampler, dimod.Structured):
         ss.info.update(info)
 
         # determine ground state exactly for small problems
-        if len(bqm) <= self.exact_solver_cutoff:
+        if 0 < len(bqm) <= self.exact_solver_cutoff and len(ss) >= 1:
             ground = dimod.ExactSolver().sample(bqm).truncate(1)
             ss.record[0].sample = ground.record[0].sample
             ss.record[0].energy = ground.record[0].energy

--- a/dwave/system/testing.py
+++ b/dwave/system/testing.py
@@ -78,11 +78,14 @@ class MockDWaveSampler(dimod.Sampler, dimod.Structured):
             warning will be raised by default.
 
         exact_solver_cutoff (int, optional, default=:attr:`EXACT_SOLVER_CUTOFF_DEFAULT`):
-            Maximum problem size for which the :class:`~dimod.ExactSolver` is used in
-            ground state calculation. Larger problems are sampled only with
-            :class:`~greedy.SteepestDescentSampler` (if ``dwave-greedy`` is available),
-            or with :class:`dimod.SimulatedAnnealingSampler`.
-            Set to zero to disable ``ExactSolver`` run.
+            For problems smaller or equal in size to ``exact_solver_cutoff``, the
+            first sample in any sampleset returned by the sampling routines
+            is replaced by a reproducible ground state (determined exactly with
+            a brute-force :class:`~dimod.ExactSolver`). Only small cut offs
+            should be used since solution time increases exponentially with
+            problem size.
+            Set ``exact_solver_cutoff`` to zero to disable exact ground state
+            calculation.
 
     Examples
         The first example creates a MockSampler without reference to a

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ dwave-greedy==0.2.5
 homebase==1.0.1
 minorminer==0.2.9
 numpy==1.21.6
+scipy==1.7.3    # fix py310/win curve_fit import error in 1.9.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,11 @@
 --extra-index-url https://pypi.dwavesys.com/simple
 
-dimod==0.11.0
+dimod==0.11.6
 dwave-preprocessing==0.4.0
-dwave-cloud-client==0.10.0
-dwave-networkx==0.8.10
+dwave-cloud-client==0.10.2
+dwave-networkx==0.8.12
 dwave-drivers==0.4.4
-dwave-greedy
+dwave-greedy==0.2.5
 homebase==1.0.1
-minorminer==0.2.8.post1
-numpy==1.20.0; python_version < "3.10"
-numpy==1.21.4; python_version >= "3.10"
+minorminer==0.2.9
+numpy==1.21.6

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ install_requires = ['dimod>=0.10.0,<0.13.0',
                     'homebase>=1.0.0,<2.0.0',
                     'minorminer>=0.2.8,<0.3.0',
                     'numpy>=1.17.3,<2.0.0',
-                    'dwave-tabu>=0.4.2',
+                    'dwave-greedy>=0.2.0',
                     ]
 
 # NOTE: dwave-drivers can also be installed with `dwave install drivers`,

--- a/tests/test_embedding_composite.py
+++ b/tests/test_embedding_composite.py
@@ -17,6 +17,7 @@ import unittest
 import warnings
 
 from collections.abc import Mapping
+from unittest import mock
 
 import dimod
 import dwave_networkx as dnx
@@ -31,7 +32,7 @@ from dwave.system.composites import (EmbeddingComposite,
                                      AutoEmbeddingComposite,
                                      )
 
-from dwave.system.testing import MockDWaveSampler, mock
+from dwave.system.testing import MockDWaveSampler
 from dwave.embedding import chain_breaks
 from dwave.system.warnings import ChainStrengthWarning
 

--- a/tests/test_mock_sampler.py
+++ b/tests/test_mock_sampler.py
@@ -119,6 +119,12 @@ class TestMockDWaveSampler(unittest.TestCase):
         ss = sampler.sample(bqm)
         np.testing.assert_array_equal(ss.record[0].sample, ground_state)
 
+    def test_empty_bqm(self):
+        sampler = MockDWaveSampler()
+        bqm = dimod.BQM('SPIN')
+        ss = sampler.sample(bqm)
+        self.assertIs(ss.vartype, bqm.vartype)
+
     def test_chimera_topology(self):
         grid_parameter = 5
         tile_parameter = 2

--- a/tests/test_mock_sampler.py
+++ b/tests/test_mock_sampler.py
@@ -13,8 +13,12 @@
 #    limitations under the License.
 
 """who watches the watchmen?"""
-import unittest
 import os
+import unittest
+from unittest import mock
+
+import numpy as np
+import dimod
 import dimod.testing as dit
 
 from dwave.system import DWaveSampler
@@ -39,48 +43,40 @@ class TestMockDWaveSampler(unittest.TestCase):
         mock = MockDWaveSampler.from_qpu_sampler(sampler)
         self.assertEqual(mock.nodelist.sort(),sampler.nodelist.sort())
         self.assertEqual(mock.edgelist.sort(),sampler.edgelist.sort())
-        
-        
+
     def test_sampler(self):
         sampler = MockDWaveSampler()
         dit.assert_sampler_api(sampler)
         dit.assert_structured_api(sampler)
-        
+
     def test_mock_parameters(self):
         # Single cell Chimera (DW2000Q) solver:
         sampler = MockDWaveSampler(topology_type='chimera', topology_shape = [1,1,4])
         num_reads = 10
-        ss = sampler.sample_ising({0 : -1}, {}, num_reads=num_reads)
+        ss = sampler.sample_ising({0: -1}, {}, num_reads=num_reads)
         self.assertEqual(sum(ss.record.num_occurrences),num_reads)
-        self.assertTrue(len(ss.record.num_occurrences)<=2) #Binary state histogram
-        ss = sampler.sample_ising({0 : -1}, {}, num_reads=num_reads,
+        self.assertTrue(len(ss.record.num_occurrences) <= 2) #Binary state histogram
+        ss = sampler.sample_ising({0: -1}, {}, num_reads=num_reads,
                                   answer_mode='raw')
-        self.assertEqual(len(ss.record.num_occurrences),num_reads)
+        self.assertEqual(len(ss.record.num_occurrences), num_reads)
         
-        ss = sampler.sample_ising({0 : -1}, {}, num_reads=num_reads,
+        ss = sampler.sample_ising({0: -1}, {}, num_reads=num_reads,
                                   answer_mode='raw', max_answers=2)
-        self.assertEqual(len(ss.record.num_occurrences),2)
+        self.assertEqual(len(ss.record.num_occurrences), 2)
 
-            
-        try:
-            from greedy import SteepestDescentSampler as SubstituteSampler
-            mock_fallback_substitute = False
-        except:
-            mock_fallback_substitute = True
-        if not mock_fallback_substitute:
-            # If the greedy is available, we can mock more parameters (than
-            # is possible with the fallback dimod.SimulatedAnnealingSampler()
-            # method
-
+        # note: greedy should be available; it's a package/test requirement
+        # disable exact ground state calc
+        with mock.patch.object(sampler, 'EXACT_SOLVER_MAX_SIZE', 0):
             #QPU format initial states:
             initial_state = [(i,1) if i%4==0 else (i,3) for i in range(8)]
-            ss = sampler.sample_ising({0 : 1, 4 : 1}, {(0,4) : -2},
+            ss = sampler.sample_ising({0: 1, 4: 1}, {(0, 4): -2},
                                       num_reads=1,
                                       answer_mode='raw',
                                       initial_state=initial_state)
             #The initialized state is a local minima, and should
             #be returned under greedy descent mocking:
             self.assertEqual(ss.record.energy[0],0)
+
     def test_unmock_parameters(self):
         # Check valid DWaveSampler() parameter, that is not mocked throws a warning:
         sampler = MockDWaveSampler()
@@ -95,7 +91,30 @@ class TestMockDWaveSampler(unittest.TestCase):
         with warnings.catch_warnings():
             warnings.simplefilter(action="error", category=UserWarning)
             ss = sampler.sample_ising({0 : -1}, {}, annealing_time=123)
-    
+
+    def test_ground_override(self):
+        # simple two connected variables sampler (path(2))
+        sampler = MockDWaveSampler(nodelist=['a', 'b'], edgelist=[('a', 'b')])
+        # bqm with a local minimum at (-1, -1)
+        bqm = dimod.BQM.from_ising({'a': -1, 'b': -1}, {'ab': -2})
+        local_minimum = [-1, -1]    # energy: 0
+        ground_state = [1, 1]       # energy: -4
+        local_minimum_state = list(zip(bqm.variables, local_minimum))
+
+        # disable exact ground state calc and start from a local minimum -> greedy should stay stuck
+        with mock.patch.object(sampler, 'EXACT_SOLVER_MAX_SIZE', 0):
+            ss = sampler.sample(bqm, initial_state=local_minimum_state)
+            np.testing.assert_array_equal(ss.record[0].sample, local_minimum)
+
+        # boundary on which exact ground state calc kicks in
+        with mock.patch.object(sampler, 'EXACT_SOLVER_MAX_SIZE', len(bqm.variables)):
+            ss = sampler.sample(bqm, initial_state=local_minimum_state)
+            np.testing.assert_array_equal(ss.record[0].sample, ground_state)
+
+        # double-check the default
+        ss = sampler.sample(bqm)
+        np.testing.assert_array_equal(ss.record[0].sample, ground_state)
+
     def test_chimera_topology(self):
         grid_parameter = 5
         tile_parameter = 2


### PR DESCRIPTION
By default, problems of size 16 and smaller will be sampled with greedy sampler and then an `ExactSolver`-determined ground state will be injected.

Implements a suggestion from https://github.com/dwavesystems/dwave-system/issues/474#issuecomment-1291026958.

Close #474.