### PR TITLE
Restore `coupling_groups` documentation

### DIFF
--- a/docs/reference/composites.rst
+++ b/docs/reference/composites.rst
@@ -4,7 +4,7 @@
 Composites
 ==========
 
-:std:doc:`dimod composites <oceandocs:docs_dimod/introduction>` that provide layers of pre- and
+:std:doc:`dimod composites <oceandocs:docs_dimod/intro/intro_samplers>` that provide layers of pre- and
 post-processing (e.g., :term:`minor-embedding`) when using the D-Wave system:
 
 .. currentmodule:: dwave.system.composites

--- a/docs/reference/utilities.rst
+++ b/docs/reference/utilities.rst
@@ -13,9 +13,11 @@ Utilities
 
    common_working_graph
 
-.. automodule:: dwave.system.coupling_groups
-
 .. currentmodule:: dwave.system.coupling_groups
+
+.. autosummary::
+   :toctree: generated/
+
    coupling_groups
 
 Temperature Utilities


### PR DESCRIPTION
[This commit](https://github.com/dwavesystems/dwave-system/commit/c617b7e2e0460cb9adcb4418f4e8512d718d5ad9) rebased `coupling_groups` out of existence. 