### PR TITLE
Simplify dependencies system

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,6 +16,7 @@ cache:
   - '%AppData%\pip-cache'
 
 build_script:
+  - "%PYTHON%\\python.exe -m pip install setuptools pip -U"
   - "%PYTHON%\\python.exe -m pip install . --cache-dir %AppData%\\pip-cache"
   - "%PYTHON%\\python.exe -m pip install -r requirements.txt -r tests\\requirements.txt --cache-dir %AppData%\\pip-cache"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,37 +3,25 @@ version: 2.1
 jobs:
   test-linux: &test-linux-template
     parameters:
-      dimod-version:
-        type: string
       python-version:
         type: string
       integration-test-python-version:
         type: string
 
     docker:
-      - image: circleci/python:<< parameters.python-version >>
+      - image: cimg/python:<< parameters.python-version >>
 
     steps:
       - checkout
-
-      - restore_cache: &restore-test-cache-template
-          keys:
-          - v2-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "tests/requirements.txt" }}-{{ .Environment.CIRCLE_JOB }}
 
       - run:
           name: create virtual env and install dependencies
           command: |
             python -m venv env
             . env/bin/activate
-            pip install -U pip
+            pip install -U pip setuptools
             pip install .     # install dwave-system to break cycle created by dwave-drivers in requirements
             pip install -r requirements.txt -r tests/requirements.txt
-            pip install 'dimod<< parameters.dimod-version >>'
-
-      - save_cache: &save-test-cache-template
-          paths:
-            - ./env
-          key: v2-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "tests/requirements.txt" }}-{{ .Environment.CIRCLE_JOB }}
 
       - run: &run-tests-template
           name: run unittests
@@ -44,6 +32,18 @@ jobs:
             fi
             coverage run -m unittest discover
 
+      - run:
+          name: create virtual env and install latest dependencies
+          command: |
+            rm -rf env/
+            python -m venv env
+            . env/bin/activate
+            pip install -U pip setuptools
+            pip install -r tests/requirements.txt
+            pip install .[drivers] -I --no-cache-dir --extra-index-url https://pypi.dwavesys.com/simple
+
+      - run: *run-tests-template
+
       - run: &codecov-template
           name: codecov
           command: |
@@ -52,16 +52,12 @@ jobs:
 
   test-doctest:
     docker:
-      - image: circleci/python:3.7-stretch # as of march 2019 RTD uses 3.7
+      - image: cimg/python:3.7 # as of march 2019 RTD uses 3.7
 
     working_directory: ~/repo
 
     steps:
       - checkout
-
-      - restore_cache:
-          keys:
-          - v2-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "docs/requirements.txt" }}-{{ .Environment.CIRCLE_JOB }}
 
       - run:
           name: create virtual env and install dependencies
@@ -69,11 +65,6 @@ jobs:
             python -m venv env
             . env/bin/activate
             pip install -r requirements.txt -r docs/requirements.txt
-
-      - save_cache:
-          paths:
-            - ./env
-          key: v2-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "docs/requirements.txt" }}-{{ .Environment.CIRCLE_JOB }}
 
       - run:
           name: doctest
@@ -122,8 +113,6 @@ jobs:
             - ~/.pyenv
           key: pyenv-{{ .Environment.CIRCLE_JOB }}-xcode-13.2.0
 
-      - restore_cache: *restore-test-cache-template
-
       - run:
           name: create virtual env and install dependencies
           command: |
@@ -136,13 +125,12 @@ jobs:
             pip install .     # install dwave-system to break cycle created by dwave-drivers in requirements
             pip install -r requirements.txt -r tests/requirements.txt
 
-      - save_cache: *save-test-cache-template
       - run: *run-tests-template
       - run: *codecov-template
 
   deploy:
     docker:
-      - image: circleci/python:3.9
+      - image: cimg/python:3.9
 
     steps:
       - checkout
@@ -178,17 +166,11 @@ workflows:
   test:
     jobs:
       - test-linux:
-          name: test-linux-<< matrix.python-version >>-dimod<< matrix.dimod-version >>
+          name: test-linux-<< matrix.python-version >>
           matrix:
             parameters:
               python-version: &python-versions ["3.7.9", "3.8.9", "3.9.4", &latest-python "3.10.0"]
               integration-test-python-version: &integration-python-versions [*latest-python]
-              dimod-version: ["==0.10.0", "~=0.10.0", "~=0.11.0"]
-            exclude:
-              # py310 is supported in dimod>=0.10.8
-              - python-version: "3.10.0"
-                integration-test-python-version: *latest-python
-                dimod-version: "==0.10.0"
       - test-osx:
           name: test-osx-<< matrix.python-version >>
           matrix:

--- a/dwave/system/samplers/clique.py
+++ b/dwave/system/samplers/clique.py
@@ -22,13 +22,7 @@ import networkx as nx
 import dwave_networkx as dnx
 
 from minorminer.busclique import find_clique_embedding, busgraph_cache
-
-try:
-    from dwave.preprocessing import ScaleComposite
-except ImportError:
-    # fall back on dimod of dwave.preprocessing is not installed
-    from dimod import ScaleComposite
-
+from dwave.preprocessing import ScaleComposite
 from dwave.system.samplers.dwave_sampler import DWaveSampler
 from dwave.system.coupling_groups import coupling_groups
 

--- a/dwave/system/samplers/leap_hybrid_sampler.py
+++ b/dwave/system/samplers/leap_hybrid_sampler.py
@@ -25,18 +25,6 @@ from collections import abc
 
 import dimod
 
-try:
-    # dimod 0.10.x
-    from dimod.binary.binary_quadratic_model import BQM
-
-    bqm_to_file = BQM.to_file
-except ImportError:
-    # dimod 0.9.x
-    from dimod import AdjVectorBQM as BQM
-    from dimod.serialization.fileview import FileView
-
-    bqm_to_file = FileView
-
 from dwave.cloud import Client
 from dwave.system.utilities import classproperty, FeatureFlags
 
@@ -221,8 +209,8 @@ class LeapHybridSampler(dimod.Sampler):
             >>> sampleset = sampler.sample(bqm)           # doctest: +SKIP
 
         """
-        if not isinstance(bqm, BQM):
-            bqm = BQM(bqm)
+        if not isinstance(bqm, dimod.BQM):
+            bqm = dimod.BQM(bqm)
 
         num_vars = bqm.num_variables
 
@@ -246,7 +234,7 @@ class LeapHybridSampler(dimod.Sampler):
 
     def _sample(self, bqm, **kwargs):
         """Sample from the given BQM."""
-        with bqm_to_file(bqm, version=2) as fv:
+        with bqm.to_file(version=2) as fv:
             sapi_problem_id = self.solver.upload_bqm(fv).result()
 
         return self.solver.sample_bqm(sapi_problem_id, **kwargs).sampleset
@@ -255,7 +243,7 @@ class LeapHybridSampler(dimod.Sampler):
         """Sample from the unlabelled version of the BQM, then apply the
         labels to the returned sampleset.
         """
-        with bqm_to_file(bqm, version=2, ignore_labels=True) as fv:
+        with bqm.to_file(version=2, ignore_labels=True) as fv:
             sapi_problem_id = self.solver.upload_bqm(fv).result()
 
         sampleset = self.solver.sample_bqm(sapi_problem_id, **kwargs).sampleset

--- a/dwave/system/testing.py
+++ b/dwave/system/testing.py
@@ -19,13 +19,9 @@ from uuid import uuid4
 import numpy as np
 import dimod
 import dwave.cloud.computation
-from dwave.system import qpu_graph
 
-try:
-    #Simplest and efficient choice returning low energy states:
-    from greedy import SteepestDescentSampler as SubstituteSampler
-except ImportError:
-    from dimod import SimulatedAnnealingSampler as SubstituteSampler
+from dwave.samplers import SteepestDescentSampler as SubstituteSampler
+from dwave.system import qpu_graph
 
 
 class MockDWaveSampler(dimod.Sampler, dimod.Structured):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,15 @@
 --extra-index-url https://pypi.dwavesys.com/simple
 
-dimod==0.11.6
-dwave-preprocessing==0.4.0
-dwave-cloud-client==0.10.2
-dwave-networkx==0.8.12
+dimod==0.12.0
+dwave-preprocessing==0.5.0
+dwave-cloud-client==0.9.1
+dwave-networkx==0.8.10
 dwave-drivers==0.4.4
-dwave-greedy==0.2.5
+dwave-samplers==1.0.0
 homebase==1.0.1
 minorminer==0.2.9
-numpy==1.21.6
-scipy==1.7.3    # fix py310/win curve_fit import error in 1.9.3
 
+numpy==1.20.0;python_version<"3.10"  # oldest supported by dwave-preprocessing
+oldest-supported-numpy;python_version>="3.10"
+
+scipy==1.7.3

--- a/setup.py
+++ b/setup.py
@@ -25,16 +25,16 @@ os.chdir(setup_folder_loc)
 exec(open(os.path.join(".", "dwave", "system", "package_info.py")).read())
 
 
-install_requires = ['dimod>=0.10.0,<0.13.0',
+install_requires = ['dimod>=0.12.0,<0.14.0',
                     'dwave-cloud-client>=0.9.1,<0.11.0',
                     'dwave-networkx>=0.8.10',
-                    'dwave-preprocessing>=0.3',
+                    'dwave-preprocessing>=0.5.0',
                     'networkx>=2.0,<3.0',
                     'homebase>=1.0.0,<2.0.0',
                     'minorminer>=0.2.8,<0.3.0',
-                    'numpy>=1.17.3,<2.0.0',
-                    'dwave-greedy>=0.2.0',
-                    'scipy>=1.5.2,<2.0.0',
+                    'numpy>=1.20.0',
+                    'dwave-samplers>=1.0.0',
+                    'scipy>=1.7.3',
                     ]
 
 # NOTE: dwave-drivers can also be installed with `dwave install drivers`,

--- a/tests/qpu/test_leaphybridcqmsampler.py
+++ b/tests/qpu/test_leaphybridcqmsampler.py
@@ -54,7 +54,7 @@ class TestLeapHybridSampler(unittest.TestCase):
             with self.subTest(f"one constraint, vartype={vartype}"):
                 cqm = dimod.ConstrainedQuadraticModel()
                 cqm.set_objective(model)
-                cqm.add_constraint(model, rhs=1, sense='==')
+                cqm.add_constraint(model, rhs=0, sense='==')
                 sampleset = sampler.sample_cqm(cqm)
                 self.assertConsistent(cqm, sampleset)
 
@@ -86,7 +86,7 @@ class TestLeapHybridSampler(unittest.TestCase):
             with self.subTest(f"one constraint, vartype={vartype}"):
                 cqm = dimod.ConstrainedQuadraticModel()
                 cqm.set_objective(model)
-                cqm.add_constraint(model, rhs=1, sense='==')
+                cqm.add_constraint(model, rhs=0, sense='==')
                 sampleset = sampler.sample_cqm(cqm)
                 self.assertConsistent(cqm, sampleset)
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,4 @@
 parameterized==0.7.4
-networkx>=2.6
 
 coverage
 codecov

--- a/tests/test_mock_sampler.py
+++ b/tests/test_mock_sampler.py
@@ -65,7 +65,6 @@ class TestMockDWaveSampler(unittest.TestCase):
                                   answer_mode='raw', max_answers=2)
         self.assertEqual(len(ss.record.num_occurrences), 2)
 
-        # note: greedy should be available; it's a package/test requirement
         # disable exact ground state calc
         with mock.patch.object(sampler, 'exact_solver_cutoff', 0):
             #QPU format initial states:


### PR DESCRIPTION
This commit does a few things:
- Bumps the minimum dimod version to a modern version
- Use dwave-samplers rather than dwave-greedy
- Make the versions in requirements.txt match the oldest supported for each package
- Test with the minimum version and latest in CI
- Drop NetworkX from tests/requirements.txt in favour of letting dwave-networkx set the version. This makes our CI a bit simpler at the expense of a bit of explicitness.