### PR TITLE
Add zephyr to embedding namespace

### DIFF
--- a/dwave/embedding/__init__.py
+++ b/dwave/embedding/__init__.py
@@ -14,8 +14,9 @@
 
 import minorminer  # into this namespace
 import dwave.embedding.chimera
-import dwave.embedding.drawing
 import dwave.embedding.pegasus
+import dwave.embedding.zephyr
+import dwave.embedding.drawing
 import dwave.embedding.exceptions
 
 from dwave.embedding.diagnostic import diagnose_embedding, is_valid_embedding, verify_embedding


### PR DESCRIPTION
We document [dwave.embedding.zephyr.find_clique_embedding](https://docs.ocean.dwavesys.com/en/stable/docs_system/reference/generated/dwave.embedding.zephyr.find_clique_embedding.html) but it's not there now:

```
>>> import dwave.embedding
>>> dwave.embedding.zephyr.find_clique_embedding(2, 3)
AttributeError                            Traceback (most recent call last)
Cell In[2], line 1
----> 1 dwave.embedding.zephyr.find_clique_embedding(2, 3)
AttributeError: module 'dwave.embedding' has no attribute 'zephyr'
```