### PR TITLE
Use dimod 0.12.7 in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 --extra-index-url https://pypi.dwavesys.com/simple
 
-dimod==0.12.2
+dimod==0.12.7
 dwave-preprocessing==0.5.4
 dwave-cloud-client==0.9.1
 dwave-networkx==0.8.10

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ os.chdir(setup_folder_loc)
 exec(open(os.path.join(".", "dwave", "system", "package_info.py")).read())
 
 
-install_requires = ['dimod>=0.12.0,<0.14.0',
+install_requires = ['dimod>=0.12.7,<0.14.0',
                     'dwave-cloud-client>=0.9.1,<0.11.0',
                     'dwave-networkx>=0.8.10',
                     'dwave-preprocessing>=0.5.0',

--- a/tests/qpu/test_leaphybriddqmsampler.py
+++ b/tests/qpu/test_leaphybriddqmsampler.py
@@ -49,6 +49,9 @@ class TestLeapHybridSampler(unittest.TestCase):
         np.testing.assert_array_almost_equal(dqm.energies(sampleset),
                                              sampleset.record.energy)
 
+    @unittest.skipIf(tuple(map(int, dimod.__version__.split(".")[:3])) < (0, 12, 7),
+                     "Skipping for dimod version < 0.12.7, "
+                     "see https://github.com/dwavesystems/dimod/pull/1332")
     def test_smoke_case_label(self):
         try:
             from dimod import CaseLabelDQM

--- a/tests/qpu/test_leaphybriddqmsampler.py
+++ b/tests/qpu/test_leaphybriddqmsampler.py
@@ -49,9 +49,6 @@ class TestLeapHybridSampler(unittest.TestCase):
         np.testing.assert_array_almost_equal(dqm.energies(sampleset),
                                              sampleset.record.energy)
 
-    @unittest.skipIf(tuple(map(int, dimod.__version__.split(".")[:3])) < (0, 12, 7),
-                     "Skipping for dimod version < 0.12.7, "
-                     "see https://github.com/dwavesystems/dimod/pull/1332")
     def test_smoke_case_label(self):
         try:
             from dimod import CaseLabelDQM


### PR DESCRIPTION
Use a more modern version of dimod to get the benefit of https://github.com/dwavesystems/dimod/pull/1332 and thereby fix the current CI errors in the integration tests on the main branch.

~We could also bump the minimum version in setup.py, but because dimod.CaseLabelDQM is only rarely used, I think it makes sense to be more permissive.~ Ended up requiring `dimod >= 0.12.7`