### PR TITLE
Support cloud-client 0.11.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,7 @@ jobs:
           command: |
             python -m venv env
             . env/bin/activate
+            pip install .     # install dwave-system to break cycle created by dwave-drivers in requirements
             pip install -r requirements.txt -r docs/requirements.txt
 
       - run:

--- a/dwave/system/samplers/dwave_sampler.py
+++ b/dwave/system/samplers/dwave_sampler.py
@@ -28,7 +28,6 @@ import dimod
 
 from dimod.exceptions import BinaryQuadraticModelStructureError
 from dwave.cloud.client import Client
-from dwave.cloud.solver import Solver
 from dwave.cloud.exceptions import (
     SolverError, SolverAuthenticationError, InvalidAPIResponseError,
     RequestTimeout, PollingTimeout, ProblemUploadError, ProblemStructureError,

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 
 dimod==0.12.7
 dwave-preprocessing==0.5.4
-dwave-cloud-client==0.10.6
+dwave-cloud-client==0.11.0.dev0
 dwave-networkx==0.8.10
 dwave-drivers==0.4.4
 dwave-samplers==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 
 dimod==0.12.7
 dwave-preprocessing==0.5.4
-dwave-cloud-client==0.11.0.dev0
+dwave-cloud-client==0.10.6
 dwave-networkx==0.8.10
 dwave-drivers==0.4.4
 dwave-samplers==1.0.0

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ exec(open(os.path.join(".", "dwave", "system", "package_info.py")).read())
 
 
 install_requires = ['dimod>=0.12.7,<0.14.0',
-                    'dwave-cloud-client>=0.10.6,<0.11.0',   # 0.10.6+ to avoid pydantic 2.0 backward compat break
+                    'dwave-cloud-client>=0.10.6,<0.12.0',   # 0.10.6+ to avoid pydantic 2.0 backward compat break
                     'dwave-networkx>=0.8.10',
                     'dwave-preprocessing>=0.5.0',
                     'networkx>=2.0,<3.0',


### PR DESCRIPTION
In this PR we:
- increase the cloud-client upper bound to 0.12.0
- test with 0.11.0.dev0
- fix docs build for edge case of running tests with a pre-release version of cloud-client that's not yet supported by dwave-system