### PR TITLE
Fix DWaveCliqueSampler integration tests

### DIFF
--- a/dwave/system/samplers/clique.py
+++ b/dwave/system/samplers/clique.py
@@ -15,8 +15,6 @@
 from numbers import Number
 from typing import Tuple
 
-import warnings 
-
 import dimod
 import networkx as nx
 import dwave_networkx as dnx
@@ -96,11 +94,6 @@ class _QubitCouplingComposite(dimod.ComposedSampler):
             max_coupling_range = max(total_coupling_range.values())
 
             if (min_coupling_range < min_lim or max_coupling_range > max_lim):
-                warnings.warn(
-                    f'The {limit_name} is violated after scaling.'
-                    ' The problem is rescaled with respect to coupling range.'
-                    ' No variables, interactions, or offset are ignored.')
-
                 # scaling 
                 inv_scalar = max(min_coupling_range / min_lim, 
                                  max_coupling_range / max_lim)

--- a/tests/qpu/test_dwavecliquesampler.py
+++ b/tests/qpu/test_dwavecliquesampler.py
@@ -59,19 +59,5 @@ class TestDWaveCliqueSampler(unittest.TestCase):
         bqm = dimod.BinaryQuadraticModel({},
                 {(u, v): -2 for u in range(n) for v in range(u+1, n)}, 'SPIN')
 
-        with warnings.catch_warnings(record=True) as w:
-            sampler.sample(bqm, chain_strength=chain_strength).resolve()
-
-        if topology == 'Pegasus':
-            limit_name = 'per_qubit_coupling_range'
-        else:
-            limit_name = 'per_group_coupling_range'
-
-        if chain_strength is not None:
-            self.assertGreaterEqual(len(w), 1)
-            self.assertEqual(sum(f'{limit_name} is violated' in str(w[i].message)
-                                 for i in range(len(w))), 1)
-        else:
-            # this is not very robust, but does the job
-            self.assertEqual(sum(f'{limit_name} is violated' in str(w[i].message)
-                                 for i in range(len(w))), 0)
+        # if the range was not adjusted, this would raise an error.
+        sampler.sample(bqm, chain_strength=chain_strength).resolve()

--- a/tests/qpu/test_dwavecliquesampler.py
+++ b/tests/qpu/test_dwavecliquesampler.py
@@ -68,7 +68,10 @@ class TestDWaveCliqueSampler(unittest.TestCase):
             limit_name = 'per_group_coupling_range'
 
         if chain_strength is not None:
-            self.assertEqual(len(w), 1)
-            self.assertIn(f'{limit_name} is violated', str(w[0].message))
+            self.assertGreaterEqual(len(w), 1)
+            self.assertEqual(sum(f'{limit_name} is violated' in str(w[i].message)
+                                 for i in range(len(w))), 1)
         else:
-            self.assertEqual(w, [])
+            # this is not very robust, but does the job
+            self.assertEqual(sum(f'{limit_name} is violated' in str(w[i].message)
+                                 for i in range(len(w))), 0)


### PR DESCRIPTION
Previously the tests would fail if there were other warnings raised.