### PR TITLE
Another parameter that should be ignored in `MockDWaveSampler`

### DIFF
--- a/dwave/system/testing.py
+++ b/dwave/system/testing.py
@@ -216,6 +216,7 @@ class MockDWaveSampler(dimod.Sampler, dimod.Structured):
             'readout_thermalization': ['parameters'],
             'reduce_intersample_correlation': ['parameters'],
             'reinitialize_state': ['parameters'],
+            'x_simple_anneal_time': ['parameters'],
             'warnings': [],
             'label': [],
         }


### PR DESCRIPTION
Apparently, `DWaveSampler` accepts `x_simple_anneal_time`, but `MockDWaveSampler` does not. This PR just adds this argument to the list of arguments that should be ignored when passed to `MockDWaveSampler`.