### PR TITLE
Conversion from flux_biases (units of Phi0) to h (unitless) and vice-versa

### DIFF
--- a/docs/reference/utilities.rst
+++ b/docs/reference/utilities.rst
@@ -21,7 +21,7 @@ Utilities
    coupling_groups
 
 
-Temperature and Unit Conversion Utilities
+Temperature and Unit-Conversion Utilities
 -----------------------------------------
 
 .. automodule:: dwave.system.temperatures
@@ -32,9 +32,9 @@ Temperature and Unit Conversion Utilities
    :toctree: generated/
 
    effective_field
-   maximum_pseudolikelihood_temperature
-   freezeout_effective_temperature
    fast_effective_temperature
-   Ip_in_units_of_B
-   h_to_fluxbias
    fluxbias_to_h
+   freezeout_effective_temperature
+   h_to_fluxbias
+   Ip_in_units_of_B
+   maximum_pseudolikelihood_temperature

--- a/docs/reference/utilities.rst
+++ b/docs/reference/utilities.rst
@@ -20,8 +20,9 @@ Utilities
 
    coupling_groups
 
-Temperature Utilities
----------------------
+
+Temperature and Unit Conversion Utilities
+-----------------------------------------
 
 .. automodule:: dwave.system.temperatures
 
@@ -34,3 +35,6 @@ Temperature Utilities
    maximum_pseudolikelihood_temperature
    freezeout_effective_temperature
    fast_effective_temperature
+   Ip_in_units_of_B
+   h_to_fluxbias
+   fluxbias_to_h

--- a/dwave/system/temperatures.py
+++ b/dwave/system/temperatures.py
@@ -34,10 +34,11 @@ import warnings
 import numpy as np
 import dimod
 from scipy import optimize
-from typing import Tuple, Union
+from typing import Tuple, Union, Optional
 
 __all__ = ['effective_field', 'maximum_pseudolikelihood_temperature',
-           'freezeout_effective_temperature', 'fast_effective_temperature']
+           'freezeout_effective_temperature', 'fast_effective_temperature',
+           'Ip_in_units_of_B', 'h_to_fluxbias', 'fluxbias_to_h']
 
 def effective_field(bqm,
                     samples=None,
@@ -355,10 +356,12 @@ def maximum_pseudolikelihood_temperature(bqm=None,
     
     return T_estimate, T_bootstrap_estimates
 
-def Ip_in_units_of_B(Ip: Optional[float, np.ndarray]=None,
-                     B: Optional[float, np.ndarray]=1.391, MAFM: Optional[float]=6.4,
+def Ip_in_units_of_B(Ip: Union[None, float, np.ndarray]=None,
+                     B: Union[None, float, np.ndarray]=1.391,
+                     MAFM: Optional[float]=6.4,
                      units_Ip: Optional[str]='uA',
-                     units_B : str='GHz', units_MAFM : Optional[str]='pH') -> Union[float, np.ndarray]:
+                     units_B : str='GHz',
+                     units_MAFM : Optional[str]='pH') -> Union[float, np.ndarray]:
     """Estimates Ip(s) with units matching B(s) (the standard Transverse Field Ising Model schedule)
 
     Args:
@@ -369,11 +372,11 @@ def Ip_in_units_of_B(Ip: Optional[float, np.ndarray]=None,
         B:
             :math:`B(s)`, the annealing schedule field associated to the 
             problem Hamiltonian. See QPU documentation and device specific
-            characteristics.
+            characteristics. The B value is ignored when Ip is specified.
         
         MAFM:
             The Mutual inductance, see QPU documentation and device specific
-            characteristics.
+            characteristics. MAFM is ignored when Ip is specified.
 
         units_Ip:
             Units in which the persistent current is specified. Allowed values:
@@ -419,7 +422,7 @@ def Ip_in_units_of_B(Ip: Optional[float, np.ndarray]=None,
         B = B*B_multiplier # To Joules
         if units_MAFM == 'pH':
             MAFM = MAFM*1e-12  # D-Wave convention
-        elif units_MAFM = 'H':
+        elif units_MAFM == 'H':
             pass
         else:
             raise ValueError('MAFM must be in pH or H, ' 
@@ -441,7 +444,8 @@ def h_to_fluxbias(h: Union[float, np.ndarray]=1,
                   Ip: Optional[float]=None,
                   B: float=1.391, MAFM: Optional[float]=6.4,
                   units_Ip: Optional[str]='uA',
-                  units_B : str='GHz', units_MAFM : Optional[str]='pH') -> Union[float, np.ndarray]:
+                  units_B : str='GHz',
+                  units_MAFM : Optional[str]='pH') -> Union[float, np.ndarray]:
     """Converts problem Hamiltonian unitless fields h to equivalent flux biases (units Phi0)
 
     Args:
@@ -480,7 +484,8 @@ def h_to_fluxbias(h: Union[float, np.ndarray]=1,
     Defaults are based on the published physical properties of the  
     Advantage_system4.1 solver at single-qubit freezeout (s=0.612).
     """
-    Ip = Ip_in_units_of_B(Ip, B, MAFM, units_B, units_MAFM)  # Convert/Create Ip in units of B, scalar
+    Ip = Ip_in_units_of_B(Ip, B, MAFM,
+                          units_Ip, units_B, units_MAFM)  # Convert/Create Ip in units of B, scalar
     # B(s)/2 h_i = Ip(s) phi_i 
     return B/2/Ip*h
 
@@ -531,7 +536,8 @@ def fluxbias_to_h(fluxbias: Union[float, np.ndarray]=1,
     Advantage_system4.1 solver at single-qubit freezeout (s=0.612).
     
     """
-    Ip = Ip_in_units_of_B(Ip, B, MAFM, units_B, units_MAFM)  # Convert/Create Ip in units of B, scalar
+    Ip = Ip_in_units_of_B(Ip, B, MAFM,
+                          units_Ip, units_B, units_MAFM)  # Convert/Create Ip in units of B, scalar
     # B(s)/2 h_i = Ip(s) phi_i 
     return 2*Ip/B*fluxbias
 

--- a/dwave/system/temperatures.py
+++ b/dwave/system/temperatures.py
@@ -28,7 +28,7 @@
   Necessary device-specific properties are published for online solvers:
   https://docs.dwavesys.com/docs/latest/doc_physical_properties.html
 
-- The biases (h) equivalent to application of flux_bias, or vice-versa,
+- The biases (h) equivalent to application of flux bias, or vice-versa,
   can be inferred as a function of the anneal progress s=t/t_a by
   device-specific unit conversion. The necessary parameters for estimation
   [Mafm, B(s)] are published for online solvers:

--- a/dwave/system/temperatures.py
+++ b/dwave/system/temperatures.py
@@ -12,7 +12,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-"""The following effective temperature estimators are provided:
+"""The following effective temperature and bias estimators are provided:
 
 - Maximum pseudo-likelihood is an efficient estimator for the temperature 
   describing a classical Boltzmann distribution P(x) = \exp(-H(x)/T)/Z(T) 
@@ -28,6 +28,11 @@
   Necessary device-specific properties are published for online solvers:
   https://docs.dwavesys.com/docs/latest/doc_physical_properties.html
 
+- The biases (h) equivalent to application of flux_bias, or vice-versa,
+  can be inferred as a function of the anneal progress s=t/t_a by
+  device-specific unit conversion. The necessary parameters for estimation
+  [Mafm, B(s)] are published for online solvers:
+  https://docs.dwavesys.com/docs/latest/doc_physical_properties.html
 """ 
 
 import warnings

--- a/dwave/system/temperatures.py
+++ b/dwave/system/temperatures.py
@@ -360,7 +360,7 @@ def Ip_in_units_of_B(Ip: Union[None, float, np.ndarray]=None,
                      B: Union[None, float, np.ndarray]=1.391,
                      MAFM: Optional[float]=6.4,
                      units_Ip: Optional[str]='uA',
-                     units_B : str='GHz',
+                     units_B: typing.Literal['GHz', 'J'] = 'GHz',
                      units_MAFM : Optional[str]='pH') -> Union[float, np.ndarray]:
     """Estimates Ip(s) with units matching B(s) (the standard Transverse Field Ising Model schedule)
 

--- a/dwave/system/temperatures.py
+++ b/dwave/system/temperatures.py
@@ -34,7 +34,7 @@ import warnings
 import numpy as np
 import dimod
 from scipy import optimize
-from typing import Tuple, Union, Optional
+from typing import Tuple, Union, Optional, Literal
 
 __all__ = ['effective_field', 'maximum_pseudolikelihood_temperature',
            'freezeout_effective_temperature', 'fast_effective_temperature',
@@ -358,9 +358,9 @@ def maximum_pseudolikelihood_temperature(bqm=None,
 
 def Ip_in_units_of_B(Ip: Union[None, float, np.ndarray]=None,
                      B: Union[None, float, np.ndarray]=1.391,
-                     MAFM: Optional[float]=6.4,
+                     MAFM: Optional[float]=1.647,
                      units_Ip: Optional[str]='uA',
-                     units_B: typing.Literal['GHz', 'J'] = 'GHz',
+                     units_B: Literal['GHz', 'J'] = 'GHz',
                      units_MAFM : Optional[str]='pH') -> Union[float, np.ndarray]:
     """Estimates Ip(s) with units matching B(s) (the standard Transverse Field Ising Model schedule)
 
@@ -442,7 +442,7 @@ def Ip_in_units_of_B(Ip: Union[None, float, np.ndarray]=None,
 
 def h_to_fluxbias(h: Union[float, np.ndarray]=1,
                   Ip: Optional[float]=None,
-                  B: float=1.391, MAFM: Optional[float]=6.4,
+                  B: float=1.391, MAFM: Optional[float]=1.647,
                   units_Ip: Optional[str]='uA',
                   units_B : str='GHz',
                   units_MAFM : Optional[str]='pH') -> Union[float, np.ndarray]:
@@ -476,7 +476,7 @@ def h_to_fluxbias(h: Union[float, np.ndarray]=1,
 
     
     Returns:
-        Ip(s) with units matching the Hamiltonian B(s).
+        h values producing equivalent longitudinal fields to the fluxbiases
     
     Note that dynamics of h and fluxbias differ, see Ip_in_units_of_B.
     Equivalence at a specific point in the anneal is valid under a 
@@ -491,7 +491,7 @@ def h_to_fluxbias(h: Union[float, np.ndarray]=1,
 
 def fluxbias_to_h(fluxbias: Union[float, np.ndarray]=1,
                   Ip: Optional[float]=None,
-                  B: float=1.391, MAFM: Optional[float]=6.4, 
+                  B: float=1.391, MAFM: Optional[float]=1.647, 
                   units_Ip: Optional[str]='uA',
                   units_B : str='GHz', units_MAFM : Optional[str]='pH') -> Union[float, np.ndarray]:
     """Converts flux biases (units Phi0) to equivalent problem Hamiltonian unitless fields
@@ -527,7 +527,7 @@ def fluxbias_to_h(fluxbias: Union[float, np.ndarray]=1,
 
     
     Returns:
-        An equivalent unitless h value.
+        flux_biases values producing equivalent longitudinal fields to h
     
     Note that dynamics of h and fluxbias differ, see Ip_in_units_of_B.
     Equivalence at a specific point in the anneal is valid under a 

--- a/dwave/system/temperatures.py
+++ b/dwave/system/temperatures.py
@@ -397,7 +397,7 @@ def Ip_in_units_of_B(Ip: Union[None, float, np.ndarray]=None,
     Assume a Hamiltonian in our documented form with an additional flux_bias dependent component
     H(s) -> H(s) - H_F(s) sum_i phi_i sigma^z_i,
     phi_i are flux_biases (in units of Phi_0), sigma^z_i is the Pauli-z operator,
-    and H_F(s) = Ip(s) Phi_0. Standard documentation presents the schedules in Joules or GHz
+    and H_F(s) = Ip(s) Phi_0. Standard documentation presents the schedules in J or GHz
 
     Ip(s) can be provided in units of amps or micro-amps,
     or inferred from B(s) and MAFM (documented per solver) as follows:
@@ -413,10 +413,10 @@ def Ip_in_units_of_B(Ip: Union[None, float, np.ndarray]=None,
     
     if units_B == 'GHz':
         B_multiplier = 1e9*h  # D-Wave convention
-    elif units_B == 'Joules':
+    elif units_B == 'J':
         B_multiplier = 1
     else:
-        raise ValueError('B (the schedule) must be in GHz or Joules, ' 
+        raise ValueError('B (the schedule) must be in GHz or J, ' 
                          f'but your units are {units_B}')
     if Ip is None:
         B = B*B_multiplier # To Joules

--- a/tests/test_temperatures.py
+++ b/tests/test_temperatures.py
@@ -29,7 +29,7 @@ from dwave.system.testing import MockDWaveSampler
 
 class TestTemperatures(unittest.TestCase):
     def test_Ip_in_units_of_B(self):
-        uBs = ['Joules', 'GHz']
+        uBs = ['J', 'GHz']
         uIps = ['A', 'uA']
         uMAFMs = ['H', 'pH']
         for uIp, uB, uMAFM in product(uIps, uBs, uMAFMs):

--- a/tests/test_temperatures.py
+++ b/tests/test_temperatures.py
@@ -15,16 +15,38 @@
 import unittest
 import numpy as np
 import dimod
+from itertools import product
 
 from dwave.system.temperatures import (maximum_pseudolikelihood_temperature,
                                        effective_field,
                                        freezeout_effective_temperature,
-                                       fast_effective_temperature)
+                                       fast_effective_temperature,
+                                       Ip_in_units_of_B,
+                                       h_to_fluxbias,
+                                       fluxbias_to_h)
 
 from dwave.system.testing import MockDWaveSampler
 
 class TestTemperatures(unittest.TestCase):
-    
+    def test_Ip_in_units_of_B(self):
+        uBs = ['Joules', 'GHz']
+        uIps = ['A', 'uA']
+        uMAFMs = ['H', 'pH']
+        for uIp, uB, uMAFM in product(uIps, uBs, uMAFMs):
+            _ = Ip_in_units_of_B(units_Ip=uIp,
+                                 units_B=uB,
+                                 units_MAFM=uMAFM)
+
+    def test_fluxbias_h(self):
+        phi = np.random.random()
+        h = fluxbias_to_h(phi)
+        phi2 = h_to_fluxbias(h)
+        self.assertLess(abs(phi-phi2), 1e-15)
+        phi = np.random.random(10)
+        h = fluxbias_to_h(phi)
+        phi2 = h_to_fluxbias(h)
+        self.assertTrue(np.all(np.abs(phi-phi2) < 1e-15))
+
     def test_effective_field(self):
         # For a simple model of independent spins H = sum_i s_i
         # The effective field is 1 (setting a spin to 1, costs 1 unit of energy,


### PR DESCRIPTION
Both flux_biases and h apply time dependent longitudinal fields (fields conjugate to sigma^z in the Hamiltonian description, see documentation).
At given point in the anneal s=t/t_a, h and flux_biases can apply equal longitudinal fields subject to rescaling. If a freeze-out phenomena is assumed at a given s, as relevant to quantum Boltzmann or Boltzmann sampling,  flux_biases can be replaced by h or vice-versa.
'h' is typically unitless, whereas flux has units of Phi0, the conversion is a function of published QPU properties B(s) and M_AFM. This pull request adds code for this conversion. 
