### PR TITLE
Adapt `MockLeapHybridSolver` to work with cloud-client 0.11.3+

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 
 dimod==0.12.13
 dwave-preprocessing==0.6.4
-dwave-cloud-client==0.11.2
+dwave-cloud-client==0.11.4
 dwave-networkx==0.8.10
 dwave-drivers==0.4.4
 dwave-samplers==1.2.0


### PR DESCRIPTION
In cloud-client 0.11.3 we changed the meaning (and type) of a private variable, `Future._sampleset`, as part of garbage collection optimizations in https://github.com/dwavesystems/dwave-cloud-client/pull/602.
