### PR TITLE
Use default resource class for macos builds on CircleCi

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 parameters:
   cache-generation:
     type: integer
-    default: 1
+    default: 2
 
 orbs:
   win: circleci/windows@5.0
@@ -99,7 +99,7 @@ jobs:
         type: string
         default: "14.3.0"
 
-    resource_class: macos.x86.medium.gen2   
+    resource_class: macos.m1.medium.gen1
 
     macos:
       xcode: << parameters.xcode >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,23 +107,24 @@ jobs:
     steps:
       - checkout
 
+      - restore_cache: &restore-cache-pyenv
+          key: &brew-pyenv-cache-key v<< pipeline.parameters.cache-generation >>-pyenv-{{ .Environment.CIRCLE_JOB }}-xcode-<< parameters.xcode >>
+
       - run:
           name: install pyenv
           command: |
             brew install pyenv
-
-      - restore_cache:
-          keys:
-            - v<< pipeline.parameters.cache-generation >>-pyenv-{{ .Environment.CIRCLE_JOB }}-xcode-<< parameters.xcode >>
 
       - run:
           name: install python
           command: |
             pyenv install << parameters.python-version>> -s
 
-      - save_cache:
-          key: v<< pipeline.parameters.cache-generation >>-pyenv-{{ .Environment.CIRCLE_JOB }}-xcode-<< parameters.xcode >>
+      - save_cache: &save-cache-pyenv
+          key: *brew-pyenv-cache-key
           paths:
+            - /Users/distiller/Library/Caches/Homebrew
+            - /usr/local/Homebrew
             - ~/.pyenv
 
       - run:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ dwave-networkx==0.8.10
 dwave-drivers==0.4.4
 dwave-samplers==1.2.0
 homebase==1.0.1
-minorminer==0.2.13
+minorminer==0.2.14
 networkx==2.8.8
 
 numpy==1.21.6;python_version<"3.10"  # oldest supported by minorminer

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,8 +11,8 @@ homebase==1.0.1
 minorminer==0.2.14
 networkx==2.8.8
 
-numpy==1.21.6;python_version<"3.10"  # oldest supported by minorminer
-oldest-supported-numpy;python_version>="3.10"
+numpy==1.23.5;python_version<"3.11"  # for compatibility with scipy 1.9.3
+oldest-supported-numpy;python_version>="3.11"
 
 scipy==1.9.3;python_version<"3.11"
 scipy==1.11.2;python_version>="3.11"

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,5 @@ networkx==2.8.8
 numpy==1.21.6;python_version<"3.10"  # oldest supported by minorminer
 oldest-supported-numpy;python_version>="3.10"
 
-scipy==1.7.3;python_version<"3.11"
+scipy==1.9.3;python_version<"3.11"
 scipy==1.11.2;python_version>="3.11"


### PR DESCRIPTION
Support for `macos.x86.medium.gen2` is soon to be dropped.

See: https://discuss.circleci.com/t/macos-intel-support-deprecation-in-january-2024/48718