### PR TITLE
Remove ambiguous xrefs to reduce build warnings

### DIFF
--- a/docs/reference/composites.rst
+++ b/docs/reference/composites.rst
@@ -149,6 +149,7 @@ FixedEmbeddingComposite
 -----------------------
 
 .. autoclass:: FixedEmbeddingComposite
+   :show-inheritance:
 
 Properties
 ~~~~~~~~~~

--- a/docs/reference/samplers.rst
+++ b/docs/reference/samplers.rst
@@ -29,6 +29,7 @@ DWaveSampler
 ============
 
 .. autoclass:: DWaveSampler
+   :show-inheritance: 
 
 Properties
 ----------

--- a/docs/reference/warnings.rst
+++ b/docs/reference/warnings.rst
@@ -5,7 +5,7 @@ Warnings
 ========
 
 Settings for raising warnings may be configured by tools such as composites or
-:doc:`docs_inspector/sdk_index`.
+:doc:`oceandocs:docs_inspector/sdk_index`.
 
 This example configures warnings for an instance of the
 :class:`~dwave.system.composites.EmbeddingComposite()` class used on a sampler

--- a/dwave/embedding/transforms.py
+++ b/dwave/embedding/transforms.py
@@ -548,7 +548,7 @@ def unembed_sampleset(target_sampleset, embedding, source_bqm,
             already exists in the sample set then it is overwritten.
 
     Returns:
-        :obj:`.SampleSet`: Sample set in the source BQM.
+        :obj:`~dimod.SampleSet`: Sample set in the source BQM.
 
     Examples:
        This example unembeds from a square target graph samples of a triangular

--- a/dwave/system/composites/cutoffcomposite.py
+++ b/dwave/system/composites/cutoffcomposite.py
@@ -26,7 +26,7 @@ __all__ = 'CutOffComposite', 'PolyCutOffComposite'
 
 
 class CutOffComposite(dimod.ComposedSampler):
-    """Composite to remove interactions below a specified cutoff value.
+    r"""Composite to remove interactions below a specified cutoff value.
 
     Prunes the binary quadratic model (BQM) submitted to the child sampler by
     retaining only interactions with values commensurate with the sampler's
@@ -89,7 +89,7 @@ class CutOffComposite(dimod.ComposedSampler):
     @property
     def parameters(self):
         """A dict where keys are the keyword parameters accepted by the sampler methods
-        and values are lists of the properties relevent to each parameter."""
+        and values are lists of the properties relevant to each parameter."""
         return self.child.parameters.copy()
 
     @property
@@ -108,14 +108,14 @@ class CutOffComposite(dimod.ComposedSampler):
         that minimize the original BQM's energy for the returned samples.
 
         Args:
-            bqm (:obj:`dimod.BinaryQuadraticModel`):
+            bqm (:obj:`~dimod.BinaryQuadraticModel`):
                 Binary quadratic model to be sampled from.
 
             **parameters:
                 Parameters for the sampling method, specified by the child sampler.
 
         Returns:
-            :obj:`dimod.SampleSet`
+            :obj:`~dimod.SampleSet`
 
         Examples:
             See the example in :class:`CutOffComposite`.
@@ -285,7 +285,7 @@ class PolyCutOffComposite(dimod.ComposedPolySampler):
                 Parameters for the sampling method, specified by the child sampler.
 
         Returns:
-            :obj:`dimod.SampleSet`
+            :obj:`~dimod.SampleSet`
 
         Examples:
             See the example in :class:`PolyCutOffComposite`.

--- a/dwave/system/composites/embedding.py
+++ b/dwave/system/composites/embedding.py
@@ -48,12 +48,12 @@ class EmbeddingComposite(dimod.ComposedSampler):
     """Maps problems to a structured sampler.
 
     Automatically minor-embeds a problem into a structured sampler such as a
-    D-Wave system. A new minor-embedding is calculated each time one of its
-    sampling methods is called.
+    D-Wave quantum computer. A new minor-embedding is calculated each time one 
+    of its sampling methods is called.
 
     Args:
         child_sampler (:class:`dimod.Sampler`):
-            A dimod sampler, such as a :obj:`.DWaveSampler`, that accepts
+            A dimod sampler, such as a :obj:`DWaveSampler`, that accepts
             only binary quadratic models of a particular structure.
 
         find_embedding (function, optional):
@@ -66,12 +66,12 @@ class EmbeddingComposite(dimod.ComposedSampler):
             keyword arguments.
 
         scale_aware (bool, optional, default=False):
-            Pass chain interactions to child samplers that accept an `ignored_interactions`
-            parameter.
+            Pass chain interactions to child samplers that accept an 
+            ``ignored_interactions`` parameter.
 
         child_structure_search (function, optional):
-            A function `child_structure_search(sampler)` that accepts a sampler
-            and returns the :attr:`dimod.Structured.structure`.
+            A function that accepts a sampler and returns the 
+            :attr:`~dimod.Structured.structure` attribute.
             Defaults to :func:`dimod.child_structure_dfs`.
 
     Examples:
@@ -138,12 +138,17 @@ class EmbeddingComposite(dimod.ComposedSampler):
     """
 
     return_embedding_default = False
-    """Defines the default behaviour for :meth:`.sample`'s `return_embedding`
-    kwarg.
+    """Defines the default behavior for returning embeddings. 
+    
+    Sets the default for the :meth:`.sample` method's 
+    ``return_embedding`` optional parameter (``kwarg``).
     """
 
     warnings_default = WarningAction.IGNORE
-    """Defines the default behavior for :meth:`.sample`'s `warnings` kwarg.
+    """Defines the default behavior for warnings. 
+    
+    Sets the default for the :meth:`.sample` method's 
+    ``warnings`` optional parameter (``kwarg``).
     """
 
     def sample(self, bqm, chain_strength=None,
@@ -156,7 +161,7 @@ class EmbeddingComposite(dimod.ComposedSampler):
         """Sample from the provided binary quadratic model.
 
         Args:
-            bqm (:obj:`dimod.BinaryQuadraticModel`):
+            bqm (:obj:`~dimod.BinaryQuadraticModel`):
                 Binary quadratic model to be sampled from.
 
             chain_strength (float/mapping/callable, optional):
@@ -164,37 +169,37 @@ class EmbeddingComposite(dimod.ComposedSampler):
                 that form a :term:`chain`. Mappings should specify the required 
                 chain strength for each variable. Callables should accept the BQM 
                 and embedding and return a float or mapping. By default, 
-                `chain_strength` is calculated with
+                ``chain_strength`` is calculated with
                 :func:`~dwave.embedding.chain_strength.uniform_torque_compensation`.
 
             chain_break_method (function/list, optional):
                 Method or methods used to resolve chain breaks. If multiple
                 methods are given, the results are concatenated and a new field
-                called "chain_break_method" specifying the index of the method
+                called ``chain_break_method`` specifying the index of the method
                 is appended to the sample set.
                 See :func:`~dwave.embedding.unembed_sampleset` and
-                :mod:`dwave.embedding.chain_breaks`.
+                :mod:`~dwave.embedding.chain_breaks`.
 
             chain_break_fraction (bool, optional, default=True):
-                Add a `chain_break_fraction` field to the unembedded response with
-                the fraction of chains broken before unembedding.
+                Add a ``chain_break_fraction`` field to the unembedded response 
+                with the fraction of chains broken before unembedding.
 
             embedding_parameters (dict, optional):
                 If provided, parameters are passed to the embedding method as
-                keyword arguments. Overrides any `embedding_parameters` passed
+                keyword arguments. Overrides any embedding parameters passed
                 to the constructor.
 
             return_embedding (bool, optional):
                 If True, the embedding, chain strength, chain break method and
-                embedding parameters are added to :attr:`dimod.SampleSet.info`
-                of the returned sample set. The default behaviour is defined
-                by :attr:`return_embedding_default`, which itself defaults to
-                False.
+                embedding parameters are added to the :attr:`~dimod.SampleSet.info`
+                field of the returned sample set. The default behavior is defined
+                by the :attr:`return_embedding_default` attribute, which by default 
+                is False.
 
             warnings (:class:`~dwave.system.warnings.WarningAction`, optional):
-                Defines what warning action to take, if any. See
-                :mod:`~dwave.system.warnings`. The default behaviour is defined
-                by :attr:`warnings_default`, which itself defaults to
+                Defines what warning action to take, if any (see the
+                :ref:`warnings_system` section). The default behavior is defined
+                by the :attr:`warnings_default` attribute, which by default is
                 :class:`~dwave.system.warnings.IGNORE`
 
             **parameters:
@@ -202,10 +207,10 @@ class EmbeddingComposite(dimod.ComposedSampler):
                 sampler.
 
         Returns:
-            :obj:`dimod.SampleSet`
+            :obj:`~dimod.SampleSet`
 
         Examples:
-            See the example in :class:`EmbeddingComposite`.
+            See the example in :class:`.EmbeddingComposite`.
 
         """
         if return_embedding is None:
@@ -318,7 +323,7 @@ class LazyFixedEmbeddingComposite(EmbeddingComposite, dimod.Structured):
             Structured dimod sampler.
 
         find_embedding (function, default=:func:`minorminer.find_embedding`):
-            A function `find_embedding(S, T, **kwargs)` where `S` and `T`
+            A function ``find_embedding(S, T, **kwargs)`` where ``S`` and ``T``
             are edgelists. The function can accept additional keyword arguments.
             The function is used to find the embedding for the first problem
             solved.
@@ -339,7 +344,7 @@ class LazyFixedEmbeddingComposite(EmbeddingComposite, dimod.Structured):
         ['a', 'b']
 
     """
-
+        
     @property
     def nodelist(self):
         """list: Nodes available to the composed sampler."""
@@ -442,7 +447,7 @@ class LazyFixedEmbeddingComposite(EmbeddingComposite, dimod.Structured):
         sampling methods reuse this embedding.
 
         Args:
-            bqm (:obj:`dimod.BinaryQuadraticModel`):
+            bqm (:obj:`~dimod.BinaryQuadraticModel`):
                 Binary quadratic model to be sampled from.
 
             chain_strength (float/mapping/callable, optional):
@@ -450,7 +455,7 @@ class LazyFixedEmbeddingComposite(EmbeddingComposite, dimod.Structured):
                 that form a :term:`chain`. Mappings should specify the required 
                 chain strength for each variable. Callables should accept the BQM 
                 and embedding and return a float or mapping. By default, 
-                `chain_strength` is calculated with
+                ``chain_strength`` is calculated with
                 :func:`~dwave.embedding.chain_strength.uniform_torque_compensation`.
 
             chain_break_method (function, optional):
@@ -458,12 +463,12 @@ class LazyFixedEmbeddingComposite(EmbeddingComposite, dimod.Structured):
                 See :func:`~dwave.embedding.unembed_sampleset`.
 
             chain_break_fraction (bool, optional, default=True):
-                Add a ‘chain_break_fraction’ field to the unembedded response with
+                Add a ``chain_break_fraction`` field to the unembedded response with
                 the fraction of chains broken before unembedding.
 
             embedding_parameters (dict, optional):
                 If provided, parameters are passed to the embedding method as
-                keyword arguments. Overrides any `embedding_parameters` passed
+                keyword arguments. Overrides any embedding parameters passed
                 to the constructor. Only used on the first call.
 
             **parameters:
@@ -471,7 +476,7 @@ class LazyFixedEmbeddingComposite(EmbeddingComposite, dimod.Structured):
                 sampler.
 
         Returns:
-            :obj:`dimod.SampleSet`
+            :obj:`~dimod.SampleSet`
 
         """
         if self.embedding is None:
@@ -504,15 +509,15 @@ class FixedEmbeddingComposite(LazyFixedEmbeddingComposite):
 
     Args:
         child_sampler (dimod.Sampler):
-            Structured dimod sampler such as a D-Wave system.
+            Structured dimod sampler such as a D-Wave quantum computer.
 
         embedding (dict[hashable, iterable], optional):
-            Mapping from a source graph to the specified sampler’s graph (the
+            Mapping from a source graph to the specified sampler's graph (the
             target graph).
 
         source_adjacency (dict[hashable, iterable]):
-            Deprecated. Dictionary to describe source graph as `{node:
-            {node neighbours}}`.
+            Deprecated. Dictionary to describe source graph as ``{node:
+            {node neighbours}}``.
 
         kwargs:
             See the :class:`EmbeddingComposite` class for additional keyword
@@ -579,7 +584,8 @@ class AutoEmbeddingComposite(EmbeddingComposite):
 
     This composite first tries to submit the binary quadratic model directly
     to the child sampler and only embeds if a
-    :exc:`dimod.exceptions.BinaryQuadraticModelStructureError` is raised.
+    :exc:`~dimod.exceptions.BinaryQuadraticModelStructureError` exception is 
+    raised.
 
     Args:
         child_sampler (:class:`dimod.Sampler`):
@@ -587,7 +593,7 @@ class AutoEmbeddingComposite(EmbeddingComposite):
             :obj:`~dwave.system.samplers.DWaveSampler()`.
 
         find_embedding (function, optional):
-            A function `find_embedding(S, T, **kwargs)` where `S` and `T`
+            A function ``find_embedding(S, T, **kwargs)`` where ``S`` and ``T``
             are edgelists. The function can accept additional keyword arguments.
             Defaults to :func:`minorminer.find_embedding`.
 

--- a/dwave/system/composites/reversecomposite.py
+++ b/dwave/system/composites/reversecomposite.py
@@ -25,8 +25,7 @@ __all__ = ['ReverseAdvanceComposite', 'ReverseBatchStatesComposite']
 
 
 class ReverseAdvanceComposite(dimod.ComposedSampler):
-    """
-    Composite that reverse anneals an initial sample through a sequence of anneal
+    r"""Composite that reverse anneals an initial sample through a sequence of anneal
     schedules.
 
     If you do not specify an initial sample, a random sample is used for the first
@@ -43,7 +42,7 @@ class ReverseAdvanceComposite(dimod.ComposedSampler):
        This example runs 100 reverse anneals each for three schedules on a problem
        constructed by setting random :math:`\pm 1` values on a clique (complete
        graph) of 15 nodes, minor-embedded on a D-Wave system using the
-       :class:`.DWaveCliqueSampler` sampler.
+       :class:`DWaveCliqueSampler` sampler.
 
        >>> import dimod
        >>> from dwave.system import DWaveCliqueSampler, ReverseAdvanceComposite
@@ -80,11 +79,11 @@ class ReverseAdvanceComposite(dimod.ComposedSampler):
         return {'child_properties': self.child.properties.copy()}
 
     def sample(self, bqm, anneal_schedules=None, **parameters):
-        """Sample the binary quadratic model using reverse annealing along a given set 
+        r"""Sample the binary quadratic model using reverse annealing along a given set 
         of anneal schedules.
 
         Args:
-            bqm (:obj:`dimod.BinaryQuadraticModel`):
+            bqm (:obj:`~dimod.BinaryQuadraticModel`):
                 Binary quadratic model to be sampled from.
 
             anneal_schedules (list of lists, optional, default=[[[0, 1], [1, 0.35], [9, 0.35], [10, 1]]]): 
@@ -100,7 +99,8 @@ class ReverseAdvanceComposite(dimod.ComposedSampler):
                 Parameters for the sampling method, specified by the child sampler.
 
         Returns:
-            :obj:`dimod.SampleSet` that has initial_state and schedule_index fields.
+            :obj:`~dimod.SampleSet` that has ``initial_state`` and ``schedule_index`` 
+            fields.
 
         Examples:
            This example runs 100 reverse anneals each for three schedules on a problem
@@ -194,18 +194,19 @@ class ReverseAdvanceComposite(dimod.ComposedSampler):
 
 
 class ReverseBatchStatesComposite(dimod.ComposedSampler, dimod.Initialized):
-    r"""Composite that reverse anneals from multiple initial samples. Each submission is independent
-    from one another.
+    r"""Composite that reverse anneals from multiple initial samples. 
+    
+    Each submission is independent from one another.
 
     Args:
-       sampler (:obj:`dimod.Sampler`):
+       sampler (:obj:`~dimod.Sampler`):
             A dimod sampler.
 
     Examples:
        This example runs three reverse anneals from two configured and one 
        randomly generated initial states on a problem constructed by setting 
        random :math:`\pm 1` values on a clique (complete graph) of 15 nodes, 
-       minor-embedded on a D-Wave system using the :class:`.DWaveCliqueSampler` 
+       minor-embedded on a D-Wave system using the :class:`DWaveCliqueSampler` 
        sampler. 
 
        >>> import dimod
@@ -247,7 +248,7 @@ class ReverseBatchStatesComposite(dimod.ComposedSampler, dimod.Initialized):
         r"""Sample the binary quadratic model using reverse annealing from multiple initial states.
 
         Args:
-            bqm (:obj:`dimod.BinaryQuadraticModel`):
+            bqm (:obj:`~dimod.BinaryQuadraticModel`):
                 Binary quadratic model to be sampled from.
 
             initial_states (samples-like, optional, default=None):
@@ -287,13 +288,13 @@ class ReverseBatchStatesComposite(dimod.ComposedSampler, dimod.Initialized):
                 Parameters for the sampling method, specified by the child sampler.
 
         Returns:
-            :obj:`dimod.SampleSet` that has initial_state field.
+            :obj:`~dimod.SampleSet` that has an ``initial_state`` field.
 
         Examples:
            This example runs three reverse anneals from two configured and one 
            randomly generated initial states on a problem constructed by setting
            random :math:`\pm 1` values on a clique (complete graph) of 15 nodes, 
-           minor-embedded on a D-Wave system using the :class:`.DWaveCliqueSampler` 
+           minor-embedded on a D-Wave system using the :class:`DWaveCliqueSampler` 
            sampler.
            
            >>> import dimod

--- a/dwave/system/composites/tiling.py
+++ b/dwave/system/composites/tiling.py
@@ -50,17 +50,17 @@ class TilingComposite(dimod.Sampler, dimod.Composite, dimod.Structured):
     Notation *PN* referes to a Pegasus graph consisting of a 3x(N-1)x(N-1) grid
     of cells, where each unit cell is a bipartite graph with shore of size t,
     supplemented with odd couplers (see ``nice_coordinate`` definition in
-    the :func:`dwave_networkx.pegasus_graph` function). The
+    the :func:`~dwave_networkx.pegasus_graph` function). The
     Advantage QPU supports a P16 Pegasus graph: its qubits may be mapped to a
     3x15x15 matrix of unit cells, each of 8 qubits. This code supports tiling of
     Chimera-structured problems, with an option of additional odd-couplers,
-    onto Pegasus. See also the :func:`dwave_networkx.pegasus_graph` function.
+    onto Pegasus. See also the :func:`~dwave_networkx.pegasus_graph` function.
 
     Notation *CN* refers to a Chimera graph consisting of an NxN grid of unit
     cells, where each unit cell is a bipartite graph with shores of size t.
     (An earlier quantum computer, the D-Wave 2000Q, supported a C16 Chimera 
     graph: its 2048 qubits were logically mapped into a 16x16 matrix of unit 
-    cells of 8 qubits (t=4). See also the :func:`dwave_networkx.chimera_graph` 
+    cells of 8 qubits (t=4). See also the :func:`~dwave_networkx.chimera_graph` 
     function.)
 
     A problem that can be minor-embedded in a single chimera unit cell, for
@@ -70,8 +70,8 @@ class TilingComposite(dimod.Sampler, dimod.Composite, dimod.Structured):
     D-Wave 2000Q) parallel samples per read.
 
     Args:
-       sampler (:class:`dimod.Sampler`): Structured dimod sampler such as a
-           :class:`~dwave.system.samplers.DWaveSampler()`.
+       sampler (:class:`~dimod.Sampler`): Structured dimod sampler such as a
+           :class:`~dwave.system.samplers.DWaveSampler`.
        sub_m (int): Minimum number of Chimera unit cell rows required for
            minor-embedding a single instance of the problem.
        sub_n (int): Minimum number of Chimera unit cell columns required for
@@ -264,14 +264,14 @@ class TilingComposite(dimod.Sampler, dimod.Composite, dimod.Structured):
         """Sample from the specified binary quadratic model.
 
         Args:
-            bqm (:obj:`dimod.BinaryQuadraticModel`):
+            bqm (:obj:`~dimod.BinaryQuadraticModel`):
                 Binary quadratic model to be sampled from.
 
             **kwargs:
                 Optional keyword arguments for the sampling method, specified per solver.
 
         Returns:
-            :class:`dimod.SampleSet`
+            :class:`~dimod.SampleSet`
 
         Examples:
             This example submits a simple Ising problem of just two variables on a

--- a/dwave/system/composites/virtual_graph.py
+++ b/dwave/system/composites/virtual_graph.py
@@ -13,14 +13,15 @@
 #    limitations under the License.
 
 """
-A :std:doc:`dimod composite <oceandocs:docs_dimod/reference/samplers>` that uses the D-Wave virtual
-graph feature for improved :std:doc:`minor-embedding <oceandocs:docs_system/intro>`.
+A :std:doc:`dimod composite <oceandocs:docs_dimod/reference/samplers>` that 
+uses the D-Wave virtual graph feature for improved 
+:std:doc:`minor-embedding <oceandocs:docs_system/intro>`.
 
-D-Wave *virtual graphs* simplify the process of minor-embedding by enabling you to more
-easily create, optimize, use, and reuse an embedding for a given working graph. When you submit an
-embedding and specify a chain strength using these tools, they automatically calibrate the qubits
-in a chain to compensate for the effects of biases that may be introduced as a result of strong
-couplings.
+D-Wave *virtual graphs* simplify the process of minor-embedding by enabling you 
+to more easily create, optimize, use, and reuse an embedding for a given working 
+graph. When you submit an embedding and specify a chain strength using these 
+tools, they automatically calibrate the qubits in a chain to compensate for the 
+effects of biases that may be introduced as a result of strong couplings.
 
 See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/stable/concepts/index.html>`_
 for explanations of technical terms in descriptions of Ocean tools.
@@ -43,42 +44,45 @@ class VirtualGraphComposite(FixedEmbeddingComposite):
     Calibrates qubits in chains to compensate for the effects of biases and enables easy
     creation, optimization, use, and reuse of an embedding for a given working graph.
 
-    Inherits from :class:`dimod.ComposedSampler` and :class:`dimod.Structured`.
+    Inherits from :class:`~dimod.ComposedSampler` and :class:`~dimod.Structured`.
 
     Args:
-        sampler (:class:`.DWaveSampler`):
-            A dimod :class:`dimod.Sampler`. Typically a :obj:`.DWaveSampler` or
-            derived composite sampler; other samplers may not work or make sense with
-            this composite layer.
+        sampler (:class:`DWaveSampler`):
+            A dimod :class:`~dimod.Sampler`. Typically a :obj:`DWaveSampler` or
+            derived composite sampler; other samplers may not work or make sense 
+            with this composite layer.
 
         embedding (dict[hashable, iterable]):
-            Mapping from a source graph to the specified sampler's graph (the target graph).
+            Mapping from a source graph to the specified sampler's graph (the 
+            target graph).
 
         chain_strength (float, optional, default=None):
-            Desired chain coupling strength. This is the magnitude of couplings between qubits
-            in a chain. If None, uses the maximum available as returned by a SAPI query
-            to the D-Wave solver.
+            Desired chain coupling strength. This is the magnitude of couplings 
+            between qubits in a chain. If None, uses the maximum available as 
+            returned by a SAPI query to the D-Wave solver.
 
         flux_biases (list/False/None, optional, default=None):
-            Per-qubit flux bias offsets in the form of a list of lists, where each sublist
-            is of length 2 and specifies a variable and the flux bias offset associated with
-            that variable. Qubits in a chain with strong negative J values experience a
-            J-induced bias; this parameter compensates by recalibrating to remove that bias.
-            If False, no flux bias is applied or calculated.
-            If None, flux biases are pulled from the database or calculated empirically.
+            Per-qubit flux bias offsets in the form of a list of lists, where 
+            each sublist is of length 2 and specifies a variable and the flux 
+            bias offset associated with that variable. Qubits in a chain with 
+            strong negative J values experience a J-induced bias; this parameter 
+            compensates by recalibrating to remove that bias. If False, no flux 
+            bias is applied or calculated. If None, flux biases are pulled from 
+            the database or calculated empirically.
 
         flux_bias_num_reads (int, optional, default=1000):
-            Number of samples to collect per flux bias value to calculate calibration
-            information.
+            Number of samples to collect per flux bias value to calculate 
+            calibration information.
 
         flux_bias_max_age (int, optional, default=3600):
-            Maximum age (in seconds) allowed for a previously calculated flux bias offset to
-            be considered valid.
+            Maximum age (in seconds) allowed for a previously calculated flux 
+            bias offset to be considered valid.
 
     .. attention::
-        D-Wave's *virtual graphs* feature can require many seconds of D-Wave system time to calibrate
-        qubits to compensate for the effects of biases. If your account has limited
-        D-Wave system access, consider using :class:`.FixedEmbeddingComposite` instead.
+        D-Wave's *virtual graphs* feature can require many seconds of D-Wave 
+        quantum computer time to calibrate qubits to compensate for the effects 
+        of biases. If your account has limited D-Wave system access, consider 
+        using :class:`FixedEmbeddingComposite` instead.
 
     Examples:
         This example uses :class:`.VirtualGraphComposite` to instantiate a 
@@ -180,13 +184,16 @@ class VirtualGraphComposite(FixedEmbeddingComposite):
 
 
 def _validate_chain_strength(sampler, chain_strength):
-    """Validate the provided chain strength, checking J-ranges of the sampler's children.
+    """Validate the provided chain strength, checking J-ranges of the sampler's 
+    children.
 
     Args:
-        chain_strength (float) The provided chain strength.  Use None to use J-range.
+        chain_strength (float): The provided chain strength.  Use None to use 
+            J-range.
 
     Returns (float):
-        A valid chain strength, either provided or based on available J-range.  Positive finite float.
+        A valid chain strength, either provided or based on available J-range.  
+        Positive finite float.
 
     """
     properties = sampler.properties

--- a/dwave/system/samplers/clique.py
+++ b/dwave/system/samplers/clique.py
@@ -34,7 +34,7 @@ class _QubitCouplingComposite(dimod.ComposedSampler):
     model (BQM) and modifies linear and quadratic terms accordingly.
 
     Args:
-       sampler (:obj:`dimod.ComposedSampler`):
+       sampler (:obj:`~dimod.ComposedSampler`):
             A dimod sampler.
     """
     def __init__(self, child_sampler):
@@ -61,7 +61,7 @@ class _QubitCouplingComposite(dimod.ComposedSampler):
         that range is exceeded. 
 
         Args:
-            bqm (:obj:`dimod.BinaryQuadraticModel`):
+            bqm (:obj:`~dimod.BinaryQuadraticModel`):
                 Binary quadratic model to be sampled from.
 
             **parameters:
@@ -69,7 +69,7 @@ class _QubitCouplingComposite(dimod.ComposedSampler):
                 sampler.
 
         Returns:
-            :obj:`dimod.SampleSet`
+            :obj:`~dimod.SampleSet`
         """
         if any(('per_qubit_coupling_range' in self.child.properties.keys(),
                 'per_group_coupling_range' in self.child.properties.keys())):
@@ -117,7 +117,7 @@ class _QubitCouplingComposite(dimod.ComposedSampler):
         yield sampleset 
 
 class DWaveCliqueSampler(dimod.Sampler):
-    """A sampler for solving clique binary quadratic models on the D-Wave system.
+    r"""A sampler for solving clique binary quadratic models on the D-Wave system.
 
     This sampler wraps
     :func:`~minorminer.busclique.find_clique_embedding` to generate embeddings
@@ -138,8 +138,9 @@ class DWaveCliqueSampler(dimod.Sampler):
             Actual failover, i.e. selection of a new solver, has to be handled
             by the user. A convenience method :meth:`.trigger_failover` is available
             for this. Note that hardware graphs vary between QPUs, so triggering
-            failover results in regenerated :attr:`.nodelist`, :attr:`.edgelist`,
-            :attr:`.properties` and :attr:`.parameters`.
+            failover results in regenerated :attr:`~dimod.Structured.nodelist`, 
+            :attr:`~dimod.Structured.edgelist`, :attr:`.properties` and 
+            :attr:`.parameters`.
 
             .. versionchanged:: 1.16.0
 
@@ -330,7 +331,7 @@ class DWaveCliqueSampler(dimod.Sampler):
                 that form a :term:`chain`. Mappings should specify the required
                 chain strength for each variable. Callables should accept the BQM
                 and embedding and return a float or mapping. By default,
-                `chain_strength` is calculated with
+                ``chain_strength`` is calculated with
                 :func:`~dwave.embedding.chain_strength.uniform_torque_compensation`.
 
             **kwargs:
@@ -339,7 +340,7 @@ class DWaveCliqueSampler(dimod.Sampler):
                 D-Wave System Documentation's
                 `solver guide <https://docs.dwavesys.com/docs/latest/doc_solver_ref.html>`_
                 describes the parameters and properties supported on the D-Wave
-                system. Note that `auto_scale` is not supported by this
+                system. Note that ``auto_scale`` is not supported by this
                 sampler, because it scales the problem as part of the embedding
                 process.
 

--- a/dwave/system/samplers/dwave_sampler.py
+++ b/dwave/system/samplers/dwave_sampler.py
@@ -13,7 +13,8 @@
 #    limitations under the License.
 
 """
-A :std:doc:`dimod sampler <oceandocs:docs_dimod/reference/samplers>` for the D-Wave system.
+A :std:doc:`dimod sampler <oceandocs:docs_dimod/reference/samplers>` 
+for D-Wave quantum computers.
 
 See :std:doc:`Ocean Glossary <oceandocs:glossary>`
 for explanations of technical terms in descriptions of Ocean tools.
@@ -88,7 +89,7 @@ def qpu_graph(topology_type, topology_shape, nodelist, edgelist):
 
 
 class DWaveSampler(dimod.Sampler, dimod.Structured):
-    """A class for using the D-Wave system as a sampler for binary quadratic models.
+    """A class for using D-Wave quantum computers as samplers for binary quadratic models.
 
     You can configure your :term:`solver` selection and usage by setting parameters,
     hierarchically, in a configuration file, as environment variables, or
@@ -96,8 +97,6 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
     `D-Wave Cloud Client <https://docs.ocean.dwavesys.com/en/stable/docs_cloud/sdk_index.html>`_
     :meth:`~dwave.cloud.client.Client.get_solvers`. By default, online
     D-Wave systems are returned ordered by highest number of qubits.
-
-    Inherits from :class:`dimod.Sampler` and :class:`dimod.Structured`.
 
     Args:
         failover (bool, optional, default=False):
@@ -109,14 +108,14 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
             Actual failover, i.e. selection of a new solver, has to be handled
             by the user. A convenience method :meth:`.trigger_failover` is available
             for this. Note that hardware graphs vary between QPUs, so triggering
-            failover results in regenerated :attr:`.nodelist`, :attr:`.edgelist`,
+            failover results in regenerated :attr:`.nodelist`,  :attr:`.edgelist`, 
             :attr:`.properties` and :attr:`.parameters`.
 
             .. versionchanged:: 1.16.0
 
                In the past, the :meth:`.sample` method was blocking and
                ``failover=True`` caused a solver failover and sampling retry.
-               However, this failover implementation broke when :meth:`sample`
+               However, this failover implementation broke when :meth:`.sample`
                became non-blocking (asynchronous), Setting ``failover=True`` had
                no effect.
 
@@ -244,7 +243,7 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
     def parameters(self):
         """dict[str, list]: D-Wave solver parameters in the form of a dict, where keys are
         keyword parameters accepted by a SAPI query and values are lists of properties in
-        :attr:`.properties` for each key.
+        :attr:`~DWaveSampler.properties` for each key.
 
         Solver parameters are dependent on the selected D-Wave solver and subject to change;
         for example, new released features may add parameters.
@@ -360,12 +359,12 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
 
         Args:
             bqm (:class:`~dimod.BinaryQuadraticModel`):
-                The binary quadratic model. Must match :attr:`.nodelist` and
-                :attr:`.edgelist`.
+                The binary quadratic model. Must match 
+                :attr:`~DWaveSampler.nodelist` and :attr:`~DWaveSampler.edgelist`.
 
             warnings (:class:`~dwave.system.warnings.WarningAction`, optional):
-                Defines what warning action to take, if any. See
-                :ref:`warnings_system`. The default behaviour is to
+                Defines what warning action to take, if any (see the
+                :ref:`warnings_system` section). The default behavior is to
                 ignore warnings.
 
             **kwargs:
@@ -570,11 +569,8 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
         max_slope = 1.0 / min_anneal_time
         for (t0, s0), (t1, s1) in zip(anneal_schedule, anneal_schedule[1:]):
             if round(abs((s0 - s1) / (t0 - t1)),10) > max_slope:
-                raise ValueError("the maximum slope cannot exceed {}".format(max_slope))
-
-    
+                raise ValueError("the maximum slope cannot exceed {}".format(max_slope))  
         
-    
     def to_networkx_graph(self):
         """Converts DWaveSampler's structure to a Chimera, Pegasus or Zephyr NetworkX graph.
 

--- a/dwave/system/temperatures.py
+++ b/dwave/system/temperatures.py
@@ -80,7 +80,7 @@ def effective_field(bqm,
     Args:
         bqm (:obj:`dimod.BinaryQuadraticModel`): 
             Binary quadratic model.
-        samples (samples_like or :obj:`.SampleSet`,optional):
+        samples (samples_like or :obj:`~dimod.SampleSet`,optional):
             A collection of raw samples. `samples_like` is an extension of
             NumPy's array like structure. See :func:`dimod.sampleset.as_samples`.
             By default, a single sample with all +1 assignments is used. 
@@ -186,7 +186,7 @@ def maximum_pseudolikelihood_temperature(bqm=None,
             If ``bqm`` and ``site_energy`` are both None, then by default 
             100 samples are drawn using :class:`~dwave.system.samplers.DWaveSampler`, 
             with ``bqm`` defaulted as described.
-        sampleset (:class:`dimod.SampleSet`, optional):
+        sampleset (:class:`~dimod.SampleSet`, optional):
             A set of samples, assumed to be fairly sampled from
             a Boltzmann distribution characterized by ``bqm``.
         site_energy (samples_like, optional):

--- a/dwave/system/temperatures.py
+++ b/dwave/system/temperatures.py
@@ -641,9 +641,9 @@ def freezeout_effective_temperature(freezeout_B, temperature, units_B = 'GHz', u
     Examples:
 
        This example uses the 
-       published parameters <https://docs.dwavesys.com/docs/latest/doc_physical_properties.html>
+       `published parameters <https://docs.dwavesys.com/docs/latest/doc_physical_properties.html>`_
        for the Advantage_system4.1 QPU solver as of November 22nd 2021: 
-       :math:`B(s=0.612) = 3.91` GHz , :math:`T = 15.4`mK.
+       :math:`B(s=0.612) = 3.91` GHz , :math:`T = 15.4` mK.
        
        >>> from dwave.system.temperatures import freezeout_effective_temperature
        >>> T = freezeout_effective_temperature(freezeout_B = 3.91, temperature = 15.4)


### PR DESCRIPTION
Part of [sdk](https://github.com/dwavesystems/dwave-ocean-sdk/pull/300), [dimod](https://github.com/dwavesystems/dimod/pull/1372), [dwave-cloud-client](https://github.com/dwavesystems/dwave-cloud-client/pull/633), and [dwave-hybrid](https://github.com/dwavesystems/dwave-hybrid/pull/294) PRs to reduce build warnings