### PR TITLE
Deprecate `VirtualGraphComposite`

### DIFF
--- a/dwave/system/composites/virtual_graph.py
+++ b/dwave/system/composites/virtual_graph.py
@@ -32,12 +32,12 @@ See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/stable/concepts/index.ht
 for explanations of technical terms in descriptions of Ocean tools.
 """
 
+import warnings
+
 import dimod
 
 from dwave.system.composites.embedding import FixedEmbeddingComposite
 from dwave.system.flux_bias_offsets import get_flux_biases
-
-from warnings import warn
 
 FLUX_BIAS_KWARG = 'flux_biases'
 
@@ -47,9 +47,11 @@ __all__ = ['VirtualGraphComposite']
 class VirtualGraphComposite(FixedEmbeddingComposite):
     """Deprecated. Composite to use the D-Wave virtual graph feature for minor-embedding.
 
-    This class is deprecated due to improved calibration of newer QPUs; to 
-    calibrate chains for residual biases, follow the instructions in the 
-    `shimming tutorial <https://github.com/dwavesystems/shimming-tutorial>`_.
+    .. deprecated:: 1.25.0
+        This class is deprecated due to improved calibration of newer QPUs and
+        will be removed in 1.27.0; to calibrate chains for residual biases, 
+        follow the instructions in the 
+        `shimming tutorial <https://github.com/dwavesystems/shimming-tutorial>`_.
 
     Calibrates qubits in chains to compensate for the effects of biases and enables easy
     creation, optimization, use, and reuse of an embedding for a given working graph.
@@ -137,12 +139,12 @@ class VirtualGraphComposite(FixedEmbeddingComposite):
                  flux_bias_max_age=3600):
 
         super(VirtualGraphComposite, self).__init__(sampler, embedding)
-        warn(
+        warnings.warn(
                 "'VirtualGraphComposite' is deprecated due to improved calibration "
                 "of newer QPUs and in future will raise an exception; if needed, "
                 "follow the instructions in the shimming tutorial at "
                 "https://github.com/dwavesystems/shimming-tutorial instead. ",
-                DeprecationWarning
+                DeprecationWarning, stacklevel=2
             )
         self.parameters.update(apply_flux_bias_offsets=[])
 

--- a/dwave/system/composites/virtual_graph.py
+++ b/dwave/system/composites/virtual_graph.py
@@ -13,6 +13,11 @@
 #    limitations under the License.
 
 """
+Deprecated. 
+Virtual graphs are deprecated due to improved calibration of newer QPUs; to 
+calibrate chains for residual biases, follow the instructions in the 
+`shimming tutorial <https://github.com/dwavesystems/shimming-tutorial>`_.
+
 A :std:doc:`dimod composite <oceandocs:docs_dimod/reference/samplers>` that 
 uses the D-Wave virtual graph feature for improved 
 :std:doc:`minor-embedding <oceandocs:docs_system/intro>`.
@@ -32,6 +37,7 @@ import dimod
 from dwave.system.composites.embedding import FixedEmbeddingComposite
 from dwave.system.flux_bias_offsets import get_flux_biases
 
+from warnings import warn
 
 FLUX_BIAS_KWARG = 'flux_biases'
 
@@ -39,7 +45,11 @@ __all__ = ['VirtualGraphComposite']
 
 
 class VirtualGraphComposite(FixedEmbeddingComposite):
-    """Composite to use the D-Wave virtual graph feature for minor-embedding.
+    """Deprecated. Composite to use the D-Wave virtual graph feature for minor-embedding.
+
+    This class is deprecated due to improved calibration of newer QPUs; to 
+    calibrate chains for residual biases, follow the instructions in the 
+    `shimming tutorial <https://github.com/dwavesystems/shimming-tutorial>`_.
 
     Calibrates qubits in chains to compensate for the effects of biases and enables easy
     creation, optimization, use, and reuse of an embedding for a given working graph.
@@ -127,6 +137,13 @@ class VirtualGraphComposite(FixedEmbeddingComposite):
                  flux_bias_max_age=3600):
 
         super(VirtualGraphComposite, self).__init__(sampler, embedding)
+        warn(
+                "'VirtualGraphComposite' is deprecated due to improved calibration "
+                "of newer QPUs and in future will raise an exception; if needed, "
+                "follow the instructions in the shimming tutorial at "
+                "https://github.com/dwavesystems/shimming-tutorial instead. ",
+                DeprecationWarning
+            )
         self.parameters.update(apply_flux_bias_offsets=[])
 
         # Validate the chain strength, or obtain it from J-range if chain strength is not provided.

--- a/tests/test_virtual_graph_composite.py
+++ b/tests/test_virtual_graph_composite.py
@@ -28,7 +28,8 @@ class TestVirtualGraphWithMockDWaveSampler(unittest.TestCase):
 
     def test_smoke(self):
         child_sampler = MockDWaveSampler()
-        sampler = VirtualGraphComposite(child_sampler, {'a': [0]}, flux_bias_num_reads=1)
+        with self.assertWarns(DeprecationWarning):
+            sampler = VirtualGraphComposite(child_sampler, {'a': [0]}, flux_bias_num_reads=1)
 
         # depending on how recenlty flux bias data was gathered, this may be true
         child_sampler.flux_biases_flag = False
@@ -38,10 +39,11 @@ class TestVirtualGraphWithMockDWaveSampler(unittest.TestCase):
             self.assertTrue(child_sampler.flux_biases_flag)  # true when some have been provided to sample_ising
 
     def test_structure_keyword_setting(self):
-        sampler = VirtualGraphComposite(self.sampler, embedding={'a': set(range(8)),
-                                                                 'b': set(range(8, 16)),
-                                                                 'c': set(range(16, 24))},
-                                        flux_biases=False)
+        with self.assertWarns(DeprecationWarning):
+            sampler = VirtualGraphComposite(self.sampler, embedding={'a': set(range(8)),
+                                                                     'b': set(range(8, 16)),
+                                                                     'c': set(range(16, 24))},
+                                            flux_biases=False)
 
         nodelist, edgelist, adj = sampler.structure
         self.assertEqual(nodelist, ['a', 'b', 'c'])
@@ -49,10 +51,11 @@ class TestVirtualGraphWithMockDWaveSampler(unittest.TestCase):
         self.assertEqual(adj, {'a': {'b'}, 'b': {'a', 'c'}, 'c': {'b'}})
 
         # unlike variable names
-        sampler = VirtualGraphComposite(self.sampler, embedding={'a': set(range(8)),
-                                                                 1: set(range(8, 16)),
-                                                                 'c': set(range(16, 24))},
-                                        flux_biases=False)
+        with self.assertWarns(DeprecationWarning):
+            sampler = VirtualGraphComposite(self.sampler, embedding={'a': set(range(8)),
+                                                                     1: set(range(8, 16)),
+                                                                     'c': set(range(16, 24))},
+                                            flux_biases=False)
         nodelist, edgelist, adj = sampler.structure
         self.assertEqual(set(nodelist), {'a', 1, 'c'})
         self.assertEqual(adj, {'a': {1}, 1: {'a', 'c'}, 'c': {1}})
@@ -75,18 +78,20 @@ class TestVirtualGraphWithMockDWaveSampler(unittest.TestCase):
         __, __, adj = sampler.structure
         embedding = {v: (v,) for v in adj}
 
-        sampler = VirtualGraphComposite(sampler, embedding=embedding, flux_biases=False)
+        with self.assertWarns(DeprecationWarning):
+            sampler = VirtualGraphComposite(sampler, embedding=embedding, flux_biases=False)
 
         self.assertEqual(sampler.embedding, embedding)
 
     def test_simple_complete_graph_sample_ising(self):
         """sample_ising on a K4."""
 
-        K4 = VirtualGraphComposite(self.sampler, embedding={0: {0, 4},
-                                                            1: {1, 5},
-                                                            2: {2, 6},
-                                                            3: {3, 7}},
-                                   flux_biases=False)
+        with self.assertWarns(DeprecationWarning):
+            K4 = VirtualGraphComposite(self.sampler, embedding={0: {0, 4},
+                                                                1: {1, 5},
+                                                                2: {2, 6},
+                                                                3: {3, 7}},
+                                       flux_biases=False)
 
         K4.sample_ising({0: .1, 1: .2}, {(0, 1): 1.5})
 


### PR DESCRIPTION
Closes https://github.com/dwavesystems/dwave-system/issues/531 and https://github.com/dwavesystems/dwave-system/issues/54 