### PR TITLE
Add Python 3.13 support and drop Python 3.8 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
         type: string
 
     docker:
-      - image: cimg/python:<< parameters.python-version >>
+      - image: python:<< parameters.python-version >>
 
     steps:
       - checkout
@@ -74,7 +74,7 @@ jobs:
 
   test-doctest:
     docker:
-      - image: cimg/python:3.9
+      - image: python:3.12
 
     steps:
       - checkout
@@ -106,7 +106,7 @@ jobs:
         type: string
       xcode:
         type: string
-        default: "14.3.0"
+        default: "16.0.0"
 
     macos:
       xcode: << parameters.xcode >>
@@ -189,7 +189,7 @@ jobs:
 
   deploy:
     docker:
-      - image: cimg/python:3.9
+      - image: python:3.12
 
     steps:
       - checkout
@@ -200,7 +200,7 @@ jobs:
             python -m virtualenv env
             . env/bin/activate
             pip install -r requirements.txt
-            pip install twine wheel
+            pip install twine wheel setuptools
 
       - run:
           name: verify version matches tag

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,7 +227,7 @@ workflows:
           name: test-linux-<< matrix.python-version >> | << matrix.dependency-specifiers >>
           matrix:
             parameters:
-              python-version: &python-versions ["3.8", "3.9", "3.10", "3.11", "3.12", &latest-python "3.13"]
+              python-version: &python-versions ["3.9", "3.10", "3.11", "3.12", &latest-python "3.13"]
               dependency-specifiers:
                 - "dwave-cloud-client~=0.12.0"
                 - "dwave-cloud-client~=0.13.0"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,11 +227,15 @@ workflows:
           name: test-linux-<< matrix.python-version >> | << matrix.dependency-specifiers >>
           matrix:
             parameters:
-              python-version: &python-versions ["3.8", "3.9", "3.10", "3.11", &latest-python "3.12"]
+              python-version: &python-versions ["3.8", "3.9", "3.10", "3.11", "3.12", &latest-python "3.13"]
               dependency-specifiers:
                 - "dwave-cloud-client~=0.12.0"
                 - "dwave-cloud-client~=0.13.0"
               integration-test-python-version: &integration-python-versions [*latest-python]
+            exclude:
+              - python-version: "3.13"
+                dependency-specifiers: "dwave-cloud-client~=0.12.0"
+                integration-test-python-version: "3.13"
 
       - test-osx:
           name: test-osx-<< matrix.python-version >>

--- a/dwave/embedding/transforms.py
+++ b/dwave/embedding/transforms.py
@@ -356,8 +356,8 @@ def embed_bqm(source_bqm, embedding=None, target_adjacency=None,
         >>> embedding = {'a': {0}, 'b': {1}, 'c': {2, 3}}
         >>> # Embed and show the chain strength
         >>> target_bqm = dwave.embedding.embed_bqm(bqm, embedding, target)
-        >>> target_bqm.quadratic[(2, 3)]
-        -1.9996979771955565
+        >>> print(target_bqm.quadratic[(2, 3)])
+        -1.999...
         >>> print(target_bqm.quadratic)  # doctest: +SKIP
         {(0, 1): 1.0, (0, 3): 1.0, (1, 2): 1.0, (2, 3): -1.9996979771955565}
 

--- a/dwave/system/composites/cutoffcomposite.py
+++ b/dwave/system/composites/cutoffcomposite.py
@@ -67,8 +67,9 @@ class CutOffComposite(dimod.ComposedSampler):
         ...                            {'ab': 0.8, 'ac': 0.7, 'bc': -1},
         ...                            0,
         ...                            dimod.SPIN)
-        >>> CutOffComposite(AutoEmbeddingComposite(sampler), 0.75).sample(bqm,
-        ...                 num_reads=1000).first.energy
+        >>> samples = CutOffComposite(
+        ...     AutoEmbeddingComposite(sampler), 0.75).sample(bqm, num_reads=1000)
+        >>> print(samples.first.energy)
         -5.5
 
     """
@@ -238,7 +239,8 @@ class PolyCutOffComposite(dimod.ComposedPolySampler):
         >>> import dimod
         >>> sampler = dimod.HigherOrderComposite(dimod.ExactSolver())
         >>> poly = dimod.BinaryPolynomial({'a': 3, 'abc':-4, 'ac': 0.2}, dimod.SPIN)
-        >>> PolyCutOffComposite(sampler, 1).sample_poly(poly).first.sample['a']
+        >>> samples = PolyCutOffComposite(sampler, 1).sample_poly(poly)
+        >>> print(samples.first.sample['a'])
         -1
 
     """

--- a/dwave/system/composites/embedding.py
+++ b/dwave/system/composites/embedding.py
@@ -30,7 +30,6 @@ from warnings import warn
 
 import dimod
 import minorminer
-import functools
 
 from dwave.embedding import (target_to_source, unembed_sampleset, embed_bqm,
                              chain_to_quadratic, EmbeddedStructure)

--- a/dwave/system/composites/embedding.py
+++ b/dwave/system/composites/embedding.py
@@ -81,7 +81,7 @@ class EmbeddingComposite(dimod.ComposedSampler):
        >>> h = {'a': -1., 'b': 2}
        >>> J = {('a', 'b'): 1.5}
        >>> sampleset = sampler.sample_ising(h, J, num_reads=100)
-       >>> sampleset.first.energy
+       >>> print(sampleset.first.energy)
        -4.5
 
 

--- a/dwave/system/composites/tiling.py
+++ b/dwave/system/composites/tiling.py
@@ -25,14 +25,10 @@ fully-yielded Advantage system.
 
 See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/stable/concepts/index.html>`_
 for explanations of technical terms in descriptions of Ocean tools.
-
 """
-
-from math import sqrt, ceil
 
 import dimod
 import dwave_networkx as dnx
-import numpy as np
 
 import dwave.embedding
 

--- a/dwave/system/samplers/dwave_sampler.py
+++ b/dwave/system/samplers/dwave_sampler.py
@@ -155,7 +155,7 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
         >>> sampleset = sampler.sample_ising({qubit_a: -1, qubit_b: 1},
         ...                                  {},
         ...                                  num_reads=100)
-        >>> sampleset.first.sample[qubit_a] == 1 and sampleset.first.sample[qubit_b] == -1
+        >>> print(sampleset.first.sample[qubit_a] == 1 and sampleset.first.sample[qubit_b] == -1)
         True
 
     See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/stable/concepts/index.html>`_
@@ -396,7 +396,7 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
             >>> sampleset = sampler.sample_ising({qubit_a: -1, qubit_b: 1},
             ...                                  {},
             ...                                  num_reads=100)
-            >>> sampleset.first.sample[qubit_a] == 1 and sampleset.first.sample[qubit_b] == -1
+            >>> print(sampleset.first.sample[qubit_a] == 1 and sampleset.first.sample[qubit_b] == -1)
             True
 
         See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/stable/concepts/index.html>`_

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,15 @@
-dimod==0.12.13
+dimod==0.12.17
 dwave-optimization==0.4.0
-dwave-preprocessing==0.6.4
+dwave-preprocessing==0.6.7
 dwave-cloud-client==0.12.0
-dwave-networkx==0.8.10
-dwave-samplers==1.2.0
+dwave-networkx==0.8.14
+dwave-samplers==1.4.0
 homebase==1.0.1
-minorminer==0.2.14
-networkx==2.8.8
+minorminer==0.2.16
+networkx~=3.0
 
 numpy==1.23.5;python_version<"3.11"  # for compatibility with scipy 1.9.3
-oldest-supported-numpy;python_version>="3.11"
+numpy==2.1.0;python_version>="3.13"
 
 scipy==1.9.3;python_version<"3.11"
-scipy==1.11.2;python_version>="3.11"
+scipy==1.14.1;python_version>="3.11"

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ classifiers = [
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ install_requires = ['dimod>=0.12.7,<0.14.0',
                     'scipy>=1.7.3',
                     ]
 
-python_requires = '>=3.8'
+python_requires = '>=3.9'
 
 packages = ['dwave',
             'dwave.embedding',
@@ -50,7 +50,6 @@ classifiers = [
     'Operating System :: OS Independent',
     'Development Status :: 3 - Alpha',
     'Programming Language :: Python :: 3 :: Only',
-    'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',


### PR DESCRIPTION
- [x] ~**Note**: `VirtualGraphComposite` tests are expected to fail on 3.13 until we either upgrade dwave-drivers to support numpy2 (required by py313), or we drop dwave-drivers (as they're already deprecated).~
- [x] ~Rebase after https://github.com/dwavesystems/dwave-system/pull/543 is merged.~