### PR TITLE
Fix inconsistent sampleset interface across hybrid samplers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-dimod==0.12.17
+dimod==0.12.18
 dwave-optimization==0.4.0
 dwave-preprocessing==0.6.7
 dwave-cloud-client==0.12.0

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ os.chdir(setup_folder_loc)
 exec(open(os.path.join(".", "dwave", "system", "package_info.py")).read())
 
 
-install_requires = ['dimod>=0.12.7,<0.14.0',
+install_requires = ['dimod>=0.12.18,<0.14.0',
                     'dwave-optimization>=0.1.0,<0.6',
                     'dwave-cloud-client>=0.12.0,<0.14.0',
                     'dwave-networkx>=0.8.10',


### PR DESCRIPTION
Make sure sampleset returned always has a working `wait_id()` method.

The fix was actually implemented in https://github.com/dwavesystems/dimod/pull/1393 (released in dimod 0.12.18), and supported with https://github.com/dwavesystems/dwave-cloud-client/pull/674 in cloud-client.

On the dwave-system level, it's enough to require the latest dimod.

Fix #540.