### PR TITLE
Release 1.28.0

### DIFF
--- a/dwave/system/package_info.py
+++ b/dwave/system/package_info.py
@@ -14,7 +14,7 @@
 
 __all__ = ['__version__', '__author__', '__authoremail__', '__description__']
 
-__version__ = '1.27.0'
+__version__ = '1.28.0'
 __author__ = 'D-Wave Systems Inc.'
 __authoremail__ = 'tools@dwavesys.com'
 __description__ = 'All things D-Wave System.'


### PR DESCRIPTION
### New Features
- Add option to specify sampler used in `MockDWaveSampler` (new default is now `SteepestDescentSampler`). See https://github.com/dwavesystems/dwave-system/pull/537.

- Add support for Python 3.13. See https://github.com/dwavesystems/dwave-system/pull/541.

- Add `LinearAncillaComposite`. See https://github.com/dwavesystems/dwave-system/pull/530.

### Fixes
- Fix inconsistent sampleset interface across hybrid samplers - we make sure every `SampleSet` returned now has a working `wait_id()` method. See https://github.com/dwavesystems/dwave-system/pull/544.

### Upgrade Notes
- Drop support for Python 3.8. See https://github.com/dwavesystems/dwave-system/pull/541.

- Soft-remove `VirtualGraphComposite` and its dependencies. Namely, `VirtualGraphComposite` is now just an identity wrapper around `FixedEmbeddingComposite`, `dwave-drivers` is not used anymore, and `dwave.system.cache.*` is completely removed. See https://github.com/dwavesystems/dwave-system/pull/543.