### PR TITLE
Add `close()` to all QPU and hybrid samplers

### DIFF
--- a/docs/reference/samplers.rst
+++ b/docs/reference/samplers.rst
@@ -58,6 +58,7 @@ Methods
    DWaveSampler.sample_qubo
    DWaveSampler.validate_anneal_schedule
    DWaveSampler.to_networkx_graph
+   DWaveSampler.close
 
 DWaveCliqueSampler
 ==================
@@ -88,6 +89,7 @@ Methods
    DWaveCliqueSampler.sample
    DWaveCliqueSampler.sample_ising
    DWaveCliqueSampler.sample_qubo
+   DWaveCliqueSampler.close
 
 
 LeapHybridSampler
@@ -116,6 +118,7 @@ Methods
    LeapHybridSampler.sample_ising
    LeapHybridSampler.sample_qubo
    LeapHybridSampler.min_time_limit
+   LeapHybridSampler.close
 
 LeapHybridCQMSampler
 ====================
@@ -140,6 +143,7 @@ Methods
 
    LeapHybridCQMSampler.sample_cqm
    LeapHybridCQMSampler.min_time_limit
+   LeapHybridCQMSampler.close
 
 LeapHybridNLSampler
 ====================
@@ -164,6 +168,7 @@ Methods
 
    LeapHybridNLSampler.sample
    LeapHybridNLSampler.estimated_min_time_limit
+   LeapHybridNLSampler.close
 
 LeapHybridDQMSampler
 ====================
@@ -189,3 +194,4 @@ Methods
 
    LeapHybridDQMSampler.sample_dqm
    LeapHybridDQMSampler.min_time_limit
+   LeapHybridDQMSampler.close

--- a/dwave/system/samplers/clique.py
+++ b/dwave/system/samplers/clique.py
@@ -176,6 +176,7 @@ class DWaveCliqueSampler(dimod.Sampler):
         >>> sampler.largest_clique_size > 5  # doctest: +SKIP
         True
         >>> sampleset = sampler.sample(bqm, num_reads=100)   # doctest: +SKIP
+        >>> sampler.close()     # doctest: +SKIP
 
     """
     def __init__(self, *,
@@ -183,6 +184,18 @@ class DWaveCliqueSampler(dimod.Sampler):
                  **config):
         self.child = DWaveSampler(
             failover=failover, retry_interval=retry_interval, **config)
+
+    def close(self):
+        """Close the child sampler in order to release system resources like threads.
+
+        .. note::
+
+            The method blocks for all the currently scheduled work (sampling
+            requests) to finish.
+
+        See: :meth:`~dwave.system.samplers.dwave_sampler.DWaveSampler.close`.
+        """
+        self.child.close()
 
     @property
     def parameters(self) -> dict:

--- a/dwave/system/samplers/clique.py
+++ b/dwave/system/samplers/clique.py
@@ -186,7 +186,7 @@ class DWaveCliqueSampler(dimod.Sampler):
             failover=failover, retry_interval=retry_interval, **config)
 
     def close(self):
-        """Close the child sampler in order to release system resources like threads.
+        """Close the child sampler to release system resources such as threads.
 
         .. note::
 

--- a/dwave/system/samplers/dwave_sampler.py
+++ b/dwave/system/samplers/dwave_sampler.py
@@ -157,7 +157,6 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
         ...                                  num_reads=100)
         >>> print(sampleset.first.sample[qubit_a] == 1 and sampleset.first.sample[qubit_b] == -1)
         True
-        ...
         >>> sampler.close()
 
     See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/stable/concepts/index.html>`_

--- a/dwave/system/samplers/dwave_sampler.py
+++ b/dwave/system/samplers/dwave_sampler.py
@@ -182,15 +182,15 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
         self.solver = self._get_solver(penalty=self._solver_penalty)
 
     def close(self):
-        """Close the underlying cloud-client in order to release system
-        resources like threads.
+        """Close the underlying cloud client to release system resources such as
+        threads.
 
         .. note::
 
             The method blocks for all the currently scheduled work (sampling
             requests) to finish.
 
-        See: :meth:`~dwave.cloud.client.base.Client.close`.
+        See: :meth:`~dwave.cloud.client.Client.close`.
         """
         self.client.close()
 

--- a/dwave/system/samplers/dwave_sampler.py
+++ b/dwave/system/samplers/dwave_sampler.py
@@ -180,6 +180,19 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
         self.client = Client.from_config(**config)
         self.solver = self._get_solver(penalty=self._solver_penalty)
 
+    def close(self):
+        """Close the underlying cloud-client in order to release system
+        resources like threads.
+
+        .. note::
+
+            The method blocks for all the currently scheduled work (sampling
+            requests) to finish.
+
+        See: :meth:`~dwave.cloud.client.base.Client.close`.
+        """
+        self.client.close()
+
     def _get_solver(self, *, refresh: bool = False, penalty: Optional[Dict[str, int]] = None):
         """Get the least penalized solver from the list of solvers filtered and
         ordered according to user config.

--- a/dwave/system/samplers/dwave_sampler.py
+++ b/dwave/system/samplers/dwave_sampler.py
@@ -157,6 +157,8 @@ class DWaveSampler(dimod.Sampler, dimod.Structured):
         ...                                  num_reads=100)
         >>> print(sampleset.first.sample[qubit_a] == 1 and sampleset.first.sample[qubit_b] == -1)
         True
+        ...
+        >>> sampler.close()
 
     See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/stable/concepts/index.html>`_
     for explanations of technical terms in descriptions of Ocean tools.

--- a/dwave/system/samplers/leap_hybrid_sampler.py
+++ b/dwave/system/samplers/leap_hybrid_sampler.py
@@ -97,7 +97,8 @@ class LeapHybridSampler(dimod.Sampler):
         >>> sampler = LeapHybridSampler(solver=solver)      # doctest: +SKIP
         >>> sampler.solver        # doctest: +SKIP
         BQMSolver(id='hybrid_binary_quadratic_model_version2')
-
+        ...
+        >>> sampler.close()       # doctest: +SKIP
     """
 
     _INTEGER_BQM_SIZE_THRESHOLD = 10000
@@ -221,10 +222,12 @@ class LeapHybridSampler(dimod.Sampler):
             >>> bqm = dimod.BQM.from_qubo(qubo)
             ...
             >>> # Find a good solution
-            >>> sampler = LeapHybridSampler()    # doctest: +SKIP
-            >>> sampleset = sampler.sample(bqm)           # doctest: +SKIP
-
+            >>> sampler = LeapHybridSampler()       # doctest: +SKIP
+            >>> sampleset = sampler.sample(bqm)     # doctest: +SKIP
+            ...
+            >>> sampler.close()                     # doctest: +SKIP
         """
+
         if not isinstance(bqm, dimod.BQM):
             bqm = dimod.BQM(bqm)
 
@@ -356,6 +359,8 @@ class LeapHybridDQMSampler:
         >>> print("{} beats {}".format(cases[sampleset.first.sample['my_hand']],
         ...                            cases[sampleset.first.sample['their_hand']]))   # doctest: +SKIP
         rock beats scissors
+        ...
+        >>> dqm_sampler.close()                       # doctest: +SKIP
     """
 
     @classproperty
@@ -620,8 +625,10 @@ class LeapHybridCQMSampler:
         The best (lowest-energy) solution found has :math:`i=j=2` as expected,
         a solution that is feasible because all the constraints (one in this
         example) are satisfied.
-
+        ...
+        >>> sampler.close()                                 # doctest: +SKIP
     """
+
     def __init__(self, **config):
         # strongly prefer hybrid solvers; requires kwarg-level override
         config.setdefault('client', 'hybrid')
@@ -866,6 +873,8 @@ class LeapHybridNLSampler:
         ... f"objective value {model.objective.state(0)} for order " \    # doctest: +SKIP
         ... f"{job_order.state(0)}.")     # doctest: +SKIP
         State 0 of 8 has an objective value 50.0 for order [1. 2. 0.].
+        ...
+        >>> sampler.close()       # doctest: +SKIP
     """
 
     def __init__(self, **config):

--- a/dwave/system/samplers/leap_hybrid_sampler.py
+++ b/dwave/system/samplers/leap_hybrid_sampler.py
@@ -140,15 +140,15 @@ class LeapHybridSampler(dimod.Sampler):
             raise ValueError("selected solver does not support the 'bqm' problem type.")
 
     def close(self):
-        """Close the underlying cloud-client in order to release system
-        resources like threads.
+        """Close the underlying cloud client to release system resources such as
+        threads.
 
         .. note::
 
             The method blocks for all the currently scheduled work (sampling
             requests) to finish.
 
-        See: :meth:`~dwave.cloud.client.base.Client.close`.
+        See: :meth:`~dwave.cloud.client.Client.close`.
         """
         self.client.close()
 
@@ -399,15 +399,15 @@ class LeapHybridDQMSampler:
             raise ValueError("selected solver does not support the 'dqm' problem type.")
 
     def close(self):
-        """Close the underlying cloud-client in order to release system
-        resources like threads.
+        """Close the underlying cloud client to release system resources such as
+        threads.
 
         .. note::
 
             The method blocks for all the currently scheduled work (sampling
             requests) to finish.
 
-        See: :meth:`~dwave.cloud.client.base.Client.close`.
+        See: :meth:`~dwave.cloud.client.Client.close`.
         """
         self.client.close()
 
@@ -659,15 +659,15 @@ class LeapHybridCQMSampler:
             raise ValueError("selected solver does not support the 'cqm' problem type.")
 
     def close(self):
-        """Close the underlying cloud-client in order to release system
-        resources like threads.
+        """Close the underlying cloud client to release system resources such as
+        threads.
 
         .. note::
 
             The method blocks for all the currently scheduled work (sampling
             requests) to finish.
 
-        See: :meth:`~dwave.cloud.client.base.Client.close`.
+        See: :meth:`~dwave.cloud.client.Client.close`.
         """
         self.client.close()
 
@@ -909,15 +909,15 @@ class LeapHybridNLSampler:
         self._executor = concurrent.futures.ThreadPoolExecutor()
 
     def close(self):
-        """Close the underlying cloud-client in order to release system
-        resources like threads.
+        """Close the underlying cloud client to release system resources such as
+        threads.
 
         .. note::
 
             The method blocks for all the currently scheduled work (sampling
             requests) to finish.
 
-        See: :meth:`~dwave.cloud.client.base.Client.close`.
+        See: :meth:`~dwave.cloud.client.Client.close`.
         """
         self.client.close()
         self._executor.shutdown()

--- a/dwave/system/samplers/leap_hybrid_sampler.py
+++ b/dwave/system/samplers/leap_hybrid_sampler.py
@@ -138,6 +138,19 @@ class LeapHybridSampler(dimod.Sampler):
         if 'bqm' not in self.solver.supported_problem_types:
             raise ValueError("selected solver does not support the 'bqm' problem type.")
 
+    def close(self):
+        """Close the underlying cloud-client in order to release system
+        resources like threads.
+
+        .. note::
+
+            The method blocks for all the currently scheduled work (sampling
+            requests) to finish.
+
+        See: :meth:`~dwave.cloud.client.base.Client.close`.
+        """
+        self.client.close()
+
     @property
     def properties(self) -> Dict[str, Any]:
         """Solver properties as returned by a SAPI query.
@@ -379,6 +392,19 @@ class LeapHybridDQMSampler:
             raise ValueError("selected solver is not a hybrid solver.")
         if 'dqm' not in self.solver.supported_problem_types:
             raise ValueError("selected solver does not support the 'dqm' problem type.")
+
+    def close(self):
+        """Close the underlying cloud-client in order to release system
+        resources like threads.
+
+        .. note::
+
+            The method blocks for all the currently scheduled work (sampling
+            requests) to finish.
+
+        See: :meth:`~dwave.cloud.client.base.Client.close`.
+        """
+        self.client.close()
 
     @property
     def properties(self) -> Dict[str, Any]:
@@ -625,6 +651,19 @@ class LeapHybridCQMSampler:
         if 'cqm' not in self.solver.supported_problem_types:
             raise ValueError("selected solver does not support the 'cqm' problem type.")
 
+    def close(self):
+        """Close the underlying cloud-client in order to release system
+        resources like threads.
+
+        .. note::
+
+            The method blocks for all the currently scheduled work (sampling
+            requests) to finish.
+
+        See: :meth:`~dwave.cloud.client.base.Client.close`.
+        """
+        self.client.close()
+
     @classproperty
     def default_solver(cls) -> Dict[str, str]:
         """Features used to select the latest accessible hybrid CQM solver."""
@@ -859,6 +898,20 @@ class LeapHybridNLSampler:
             raise ValueError("selected solver does not support the 'nl' problem type.")
 
         self._executor = concurrent.futures.ThreadPoolExecutor()
+
+    def close(self):
+        """Close the underlying cloud-client in order to release system
+        resources like threads.
+
+        .. note::
+
+            The method blocks for all the currently scheduled work (sampling
+            requests) to finish.
+
+        See: :meth:`~dwave.cloud.client.base.Client.close`.
+        """
+        self.client.close()
+        self._executor.shutdown()
 
     @classproperty
     def default_solver(cls) -> Dict[str, str]:

--- a/dwave/system/testing.py
+++ b/dwave/system/testing.py
@@ -353,6 +353,9 @@ class MockDWaveSampler(dimod.Sampler, dimod.Structured):
             # topology-dependent arguments:
             self.properties.update(properties)
 
+    def close(self):
+        pass
+
     @classmethod
     def from_qpu_sampler(cls, sampler):
         return cls(properties=sampler.properties,

--- a/tests/qpu/test_dwavecliquesampler.py
+++ b/tests/qpu/test_dwavecliquesampler.py
@@ -18,8 +18,7 @@ import unittest
 
 import dimod
 
-from dwave.cloud.exceptions import (
-    ConfigFileError, SolverNotFoundError, UseAfterCloseError)
+import dwave.cloud.exceptions
 from dwave.system import DWaveCliqueSampler
 
 from parameterized import parameterized
@@ -33,7 +32,9 @@ def get_sampler(topology):
     try:
         _SAMPLERS[topology] = DWaveCliqueSampler(solver=dict(topology__type=topology.lower()))
         return _SAMPLERS[topology]
-    except (ValueError, ConfigFileError, SolverNotFoundError):
+    except (ValueError,
+            dwave.cloud.exceptions.ConfigFileError,
+            dwave.cloud.exceptions.SolverNotFoundError):
         raise unittest.SkipTest(f"no {topology}-structured QPU available")
 
 
@@ -68,9 +69,10 @@ class TestDWaveCliqueSampler(unittest.TestCase):
         # if the range was not adjusted, this would raise an error.
         sampler.sample(bqm, chain_strength=chain_strength).resolve()
 
+    @unittest.skipUnless(hasattr(dwave.cloud.exceptions, 'UseAfterClose'), 'dwave-cloud-client>=0.13.3 required')
     def test_close(self):
         sampler = DWaveCliqueSampler()
         sampler.close()
 
-        with self.assertRaises(UseAfterCloseError):
+        with self.assertRaises(dwave.cloud.exceptions.UseAfterCloseError):
             sampler.sample_qubo({(0, 1): 1})

--- a/tests/qpu/test_dwavesampler.py
+++ b/tests/qpu/test_dwavesampler.py
@@ -19,7 +19,8 @@ from unittest import mock
 import numpy
 
 import dimod
-from dwave.cloud.exceptions import ConfigFileError, SolverNotFoundError
+from dwave.cloud.exceptions import (
+    ConfigFileError, SolverNotFoundError, UseAfterCloseError)
 from dwave.cloud.client import Client
 
 from dwave.system.samplers import DWaveSampler
@@ -38,6 +39,15 @@ class TestDWaveSampler(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.qpu.client.close()
+
+    def test_close(self):
+        sampler = DWaveSampler()
+        sampler.close()
+
+        h, J = self.nonzero_ising_problem(sampler)
+
+        with self.assertRaises(UseAfterCloseError):
+            sampler.sample_ising(h, J)
 
     @staticmethod
     def nonzero_ising_problem(sampler):

--- a/tests/qpu/test_leaphybrid_common.py
+++ b/tests/qpu/test_leaphybrid_common.py
@@ -20,7 +20,8 @@ import unittest
 from parameterized import parameterized_class
 
 import dimod
-from dwave.cloud.exceptions import ConfigFileError, SolverNotFoundError
+from dwave.cloud.exceptions import (
+    ConfigFileError, SolverNotFoundError, UseAfterCloseError)
 from dwave.cloud.testing import isolated_environ
 from dwave.system import LeapHybridSampler, LeapHybridDQMSampler, LeapHybridCQMSampler
 
@@ -43,7 +44,7 @@ class TestLegacySolverSelection(unittest.TestCase):
 
         self.assertIn(self.problem_type, sampler.solver.supported_problem_types)
 
-        sampler.client.close()
+        sampler.close()
 
     def test_new_positive(self):
         # given valid solver spec in env, init succeeds
@@ -57,7 +58,7 @@ class TestLegacySolverSelection(unittest.TestCase):
 
             self.assertIn(self.problem_type, sampler.solver.supported_problem_types)
 
-        sampler.client.close()
+        sampler.close()
 
     def test_new_negative(self):
         # given invalid solver spec in env, init fails
@@ -83,7 +84,7 @@ class TestLegacySolverSelection(unittest.TestCase):
 
             self.assertIn(self.problem_type, sampler.solver.supported_problem_types)
 
-        sampler.client.close()
+        sampler.close()
 
 
 @parameterized_class(
@@ -93,17 +94,23 @@ class TestLegacySolverSelection(unittest.TestCase):
         (LeapHybridCQMSampler, "sample_cqm", lambda self: dimod.CQM.from_bqm(dimod.BQM.from_qubo({'ab': 1}))),
     ])
 @unittest.skipIf(os.getenv('SKIP_INT_TESTS'), "Skipping integration test.")
-class TestSamplesetInterface(unittest.TestCase):
+class TestSamplerInterface(unittest.TestCase):
 
-    def test_wait_id_availability(self):
-        # verify https://github.com/dwavesystems/dwave-system/issues/540 is fixed
+    @classmethod
+    def setUpClass(cls):
         try:
-            sampler = self.sampler_cls()
-        except (ValueError, ConfigFileError):
-            raise unittest.SkipTest(f"{self.sampler_cls} not available")
+            cls.sampler = cls.sampler_cls()
+        except (ValueError, ConfigFileError, SolverNotFoundError):
+            raise unittest.SkipTest(f"{cls.sampler_cls} not available")
 
+    @classmethod
+    def tearDownClass(cls):
+        cls.sampler.close()
+
+    def test_sampleset_wait_id_availability(self):
+        # verify https://github.com/dwavesystems/dwave-system/issues/540 is fixed
         problem = self.problem_gen()
-        ss = getattr(sampler, self.sample_meth)(problem)
+        ss = getattr(self.sampler, self.sample_meth)(problem)
 
         with self.subTest("sampleset.wait_id() exists"):
             pid = ss.wait_id()
@@ -113,3 +120,11 @@ class TestSamplesetInterface(unittest.TestCase):
             ss.resolve()
             pid_post = ss.wait_id()
             self.assertEqual(pid, pid_post)
+
+    def test_close(self):
+        sampler = self.sampler_cls()
+        sampler.close()
+
+        with self.assertRaises(UseAfterCloseError):
+            problem = self.problem_gen()
+            getattr(sampler, self.sample_meth)(problem)

--- a/tests/qpu/test_leaphybrid_common.py
+++ b/tests/qpu/test_leaphybrid_common.py
@@ -23,6 +23,7 @@ import dimod
 from dwave.cloud.exceptions import (
     ConfigFileError, SolverNotFoundError, UseAfterCloseError)
 from dwave.cloud.testing import isolated_environ
+
 from dwave.system import LeapHybridSampler, LeapHybridDQMSampler, LeapHybridCQMSampler
 
 

--- a/tests/test_dwavecliquesampler.py
+++ b/tests/test_dwavecliquesampler.py
@@ -214,3 +214,10 @@ class TestFailover(unittest.TestCase):
         self.assertIsNot(G, sampler.target_graph)
         self.assertIsNot(qlr, sampler.qpu_linear_range)
         self.assertIsNot(qqr, sampler.qpu_quadratic_range)
+
+    @unittest.mock.patch('dwave.system.samplers.clique.DWaveSampler')
+    def test_close(self, mock_child_sampler):
+        sampler = DWaveCliqueSampler()
+        sampler.close()
+
+        mock_child_sampler.return_value.close.assert_called_once()

--- a/tests/test_dwavesampler.py
+++ b/tests/test_dwavesampler.py
@@ -135,6 +135,15 @@ class TestDWaveSampler(unittest.TestCase):
             solver=solver,
             defaults={'solver': {'order_by': '-num_active_qubits'}})
 
+    @mock.patch('dwave.system.samplers.dwave_sampler.Client')
+    def test_close(self, MockClient):
+        """DWaveSampler.close() will close the underlying client."""
+
+        sampler = DWaveSampler()
+        sampler.close()
+
+        MockClient.from_config.return_value.close.assert_called_once()
+
     def test_sample_ising_variables(self):
 
         sampler = self.sampler

--- a/tests/test_leaphybridcqmsampler.py
+++ b/tests/test_leaphybridcqmsampler.py
@@ -71,6 +71,7 @@ class TestTimeLimit(unittest.TestCase):
             new = dimod.ConstrainedQuadraticModel().from_file(f)
 
         self.assertEqual(sampler.sample_cqm(new), sampler.sample_cqm(cqm))
+        sampler.close()
 
     @unittest.mock.patch('dwave.system.samplers.leap_hybrid_sampler.Client')
     def test_close(self, mock_client):

--- a/tests/test_leaphybridcqmsampler.py
+++ b/tests/test_leaphybridcqmsampler.py
@@ -71,7 +71,6 @@ class TestTimeLimit(unittest.TestCase):
             new = dimod.ConstrainedQuadraticModel().from_file(f)
 
         self.assertEqual(sampler.sample_cqm(new), sampler.sample_cqm(cqm))
-        sampler.close()
 
     @unittest.mock.patch('dwave.system.samplers.leap_hybrid_sampler.Client')
     def test_close(self, mock_client):

--- a/tests/test_leaphybridcqmsampler.py
+++ b/tests/test_leaphybridcqmsampler.py
@@ -71,3 +71,14 @@ class TestTimeLimit(unittest.TestCase):
             new = dimod.ConstrainedQuadraticModel().from_file(f)
 
         self.assertEqual(sampler.sample_cqm(new), sampler.sample_cqm(cqm))
+
+    @unittest.mock.patch('dwave.system.samplers.leap_hybrid_sampler.Client')
+    def test_close(self, mock_client):
+        mock_solver = mock_client.from_config.return_value.get_solver.return_value
+        mock_solver.properties = {'category': 'hybrid'}
+        mock_solver.supported_problem_types = ['cqm']
+
+        sampler = LeapHybridCQMSampler()
+        sampler.close()
+
+        mock_client.from_config.return_value.close.assert_called_once()

--- a/tests/test_leaphybriddqmsolver.py
+++ b/tests/test_leaphybriddqmsolver.py
@@ -60,3 +60,14 @@ class TestLeapHybridDQMSampler(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             sampler.sample_dqm(dqm, time_limit=10000000)
+
+    @unittest.mock.patch('dwave.system.samplers.leap_hybrid_sampler.Client')
+    def test_close(self, mock_client):
+        mock_solver = mock_client.from_config.return_value.get_solver.return_value
+        mock_solver.properties = {'category': 'hybrid'}
+        mock_solver.supported_problem_types = ['dqm']
+
+        sampler = LeapHybridDQMSampler()
+        sampler.close()
+
+        mock_client.from_config.return_value.close.assert_called_once()

--- a/tests/test_leaphybridnlsampler.py
+++ b/tests/test_leaphybridnlsampler.py
@@ -123,3 +123,14 @@ class TestNLSampler(unittest.TestCase):
             with self.assertWarns(UserWarning, msg=msg):
                 result = sampler.sample(model, time_limit=time_limit)
                 result.result()
+
+    @unittest.mock.patch('dwave.system.samplers.leap_hybrid_sampler.Client')
+    def test_close(self, mock_client):
+        mock_solver = mock_client.from_config.return_value.get_solver.return_value
+        mock_solver.properties = {'category': 'hybrid'}
+        mock_solver.supported_problem_types = ['nl']
+
+        sampler = LeapHybridNLSampler()
+        sampler.close()
+
+        mock_client.from_config.return_value.close.assert_called_once()

--- a/tests/test_leaphybridsolver.py
+++ b/tests/test_leaphybridsolver.py
@@ -110,6 +110,17 @@ class TestLeapHybridSampler(unittest.TestCase):
             defaults=defaults)
 
     @mock.patch('dwave.system.samplers.leap_hybrid_sampler.Client')
+    def test_close(self, mock_client):
+        mock_solver = mock_client.from_config.return_value.get_solver.return_value
+        mock_solver.properties = {'category': 'hybrid'}
+        mock_solver.supported_problem_types = ['bqm']
+
+        sampler = LeapHybridSampler()
+        sampler.close()
+
+        mock_client.from_config.return_value.close.assert_called_once()
+
+    @mock.patch('dwave.system.samplers.leap_hybrid_sampler.Client')
     def test_sample_bqm(self, mock_client):
 
         mock_client.from_config.side_effect = MockClient


### PR DESCRIPTION
Close #77.

Note: ~tests will fail because we need to release `dwave-cloud-client==0.13.3` first.~ We skip tests that require `UseAfterCloseError` from cloud client 0.13.3.

Follow-up: add support for context manager protocol to all samplers.