### PR TITLE
Add support for context manager protocol to all samplers

### DIFF
--- a/dwave/system/samplers/clique.py
+++ b/dwave/system/samplers/clique.py
@@ -164,14 +164,14 @@ class DWaveCliqueSampler(dimod.Sampler, AbstractContextManager):
         Support for context manager protocol.
 
     Note:
-        The preferred and recommended way to use :class:`DWaveCliqueSampler` is
-        from a runtime context:
+        The recommended way to use :class:`DWaveCliqueSampler` is from a
+        `runtime context <https://docs.python.org/3/reference/datamodel.html#with-statement-context-managers>`_:
 
         >>> with DWaveCliqueSampler() as sampler:   # doctest: +SKIP
         ...     sampler.sample(...)
 
-        If this is not feasible in your code, don't forget to shutdown sampler
-        resources by calling :meth:`~DWaveCliqueSampler.close`:
+        Alternatively, call the :meth:`~DWaveCliqueSampler.close` method to
+        terminate the sampler resources:
 
         >>> sampler = DWaveCliqueSampler()      # doctest: +SKIP
         ...

--- a/dwave/system/samplers/clique.py
+++ b/dwave/system/samplers/clique.py
@@ -167,15 +167,15 @@ class DWaveCliqueSampler(dimod.Sampler, AbstractContextManager):
         The preferred and recommended way to use :class:`DWaveCliqueSampler` is
         from a runtime context:
 
-        >>> with DWaveCliqueSampler() as sampler:     # doctest: +SKIP
-        >>>     sampler.sample(...)
+        >>> with DWaveCliqueSampler() as sampler:   # doctest: +SKIP
+        ...     sampler.sample(...)
 
         If this is not feasible in your code, don't forget to shutdown sampler
         resources by calling :meth:`~DWaveCliqueSampler.close`:
 
-        >>> sampler = DWaveCliqueSampler()
+        >>> sampler = DWaveCliqueSampler()      # doctest: +SKIP
         ...
-        >>> sampler.close()
+        >>> sampler.close()     # doctest: +SKIP
 
     Examples:
         This example creates a BQM based on a 6-node clique (complete graph),
@@ -190,11 +190,10 @@ class DWaveCliqueSampler(dimod.Sampler, AbstractContextManager):
         ...
         >>> bqm = dimod.generators.ran_r(1, 6)
         ...
-        >>> sampler = DWaveCliqueSampler()   # doctest: +SKIP
-        >>> sampler.largest_clique_size > 5  # doctest: +SKIP
+        >>> with DWaveCliqueSampler() as sampler:   # doctest: +SKIP
+        ...     print(sampler.largest_clique_size > 5)
+        ...     sampleset = sampler.sample(bqm, num_reads=100)
         True
-        >>> sampleset = sampler.sample(bqm, num_reads=100)   # doctest: +SKIP
-        >>> sampler.close()     # doctest: +SKIP
 
     """
     def __init__(self, *,

--- a/dwave/system/samplers/dwave_sampler.py
+++ b/dwave/system/samplers/dwave_sampler.py
@@ -138,14 +138,14 @@ class DWaveSampler(dimod.Sampler, dimod.Structured, AbstractContextManager):
         ``client='base'``.
 
     Note:
-        The preferred and recommended way to use :class:`DWaveSampler` is from a
-        runtime context created by ``DWaveSampler()``:
+        The recommended way to use :class:`DWaveSampler` is from a
+        `runtime context <https://docs.python.org/3/reference/datamodel.html#with-statement-context-managers>`_:
 
         >>> with DWaveSampler() as sampler:
         ...     sampler.sample_ising(...)       # doctest: +SKIP
 
-        If this is not feasible in your code, don't forget to shutdown sampler
-        resources by calling :meth:`~DWaveSampler.close` when done:
+        Alternatively, call the :meth:`~DWaveSampler.close` method to
+        terminate the sampler resources:
 
         >>> sampler = DWaveSampler()
         ...

--- a/dwave/system/samplers/dwave_sampler.py
+++ b/dwave/system/samplers/dwave_sampler.py
@@ -141,8 +141,8 @@ class DWaveSampler(dimod.Sampler, dimod.Structured, AbstractContextManager):
         The preferred and recommended way to use :class:`DWaveSampler` is from a
         runtime context created by ``DWaveSampler()``:
 
-        >>> with DWaveSampler() as sampler:     # doctest: +SKIP
-        >>>     sampler.sample_ising(...)
+        >>> with DWaveSampler() as sampler:
+        ...     sampler.sample_ising(...)       # doctest: +SKIP
 
         If this is not feasible in your code, don't forget to shutdown sampler
         resources by calling :meth:`~DWaveSampler.close` when done:
@@ -166,16 +166,14 @@ class DWaveSampler(dimod.Sampler, dimod.Structured, AbstractContextManager):
 
         >>> from dwave.system import DWaveSampler
         ...
-        >>> sampler = DWaveSampler()
-        ...
-        >>> qubit_a = sampler.nodelist[0]
-        >>> qubit_b = next(iter(sampler.adjacency[qubit_a]))
-        >>> sampleset = sampler.sample_ising({qubit_a: -1, qubit_b: 1},
-        ...                                  {},
-        ...                                  num_reads=100)
-        >>> print(sampleset.first.sample[qubit_a] == 1 and sampleset.first.sample[qubit_b] == -1)
+        >>> with DWaveSampler() as sampler:
+        ...     qubit_a = sampler.nodelist[0]
+        ...     qubit_b = next(iter(sampler.adjacency[qubit_a]))
+        ...     sampleset = sampler.sample_ising({qubit_a: -1, qubit_b: 1},
+        ...                                      {},
+        ...                                      num_reads=100)
+        ...     print(sampleset.first.sample[qubit_a] == 1 and sampleset.first.sample[qubit_b] == -1)
         True
-        >>> sampler.close()
 
     See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/stable/concepts/index.html>`_
     for explanations of technical terms in descriptions of Ocean tools.
@@ -259,8 +257,8 @@ class DWaveSampler(dimod.Sampler, dimod.Structured, AbstractContextManager):
         Examples:
 
             >>> from dwave.system import DWaveSampler
-            >>> sampler = DWaveSampler()
-            >>> sampler.properties    # doctest: +SKIP
+            >>> with DWaveSampler() as sampler:     # doctest: +SKIP
+            ...     sampler.properties
             {'anneal_offset_ranges': [[-0.2197463755538704, 0.03821687759418928],
               [-0.2242514597680286, 0.01718456460967399],
               [-0.20860153999435985, 0.05511969218508182],
@@ -290,8 +288,8 @@ class DWaveSampler(dimod.Sampler, dimod.Structured, AbstractContextManager):
         Examples:
 
             >>> from dwave.system import DWaveSampler
-            >>> sampler = DWaveSampler()
-            >>> sampler.parameters    # doctest: +SKIP
+            >>> with DWaveSampler() as sampler:     # doctest: +SKIP
+            ...     sampler.parameters
             {'anneal_offsets': ['parameters'],
              'anneal_schedule': ['parameters'],
              'annealing_time': ['parameters'],
@@ -321,8 +319,8 @@ class DWaveSampler(dimod.Sampler, dimod.Structured, AbstractContextManager):
             First 5 entries of the coupler list for one Advantage system.
 
             >>> from dwave.system import DWaveSampler
-            >>> sampler = DWaveSampler()
-            >>> sampler.edgelist[:5]    # doctest: +SKIP
+            >>> with DWaveSampler() as sampler:     # doctest: +SKIP
+            ...     sampler.edgelist[:5]
             [(30, 31), (30, 45), (30, 2940), (30, 2955), (30, 2970)]
 
         See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/stable/concepts/index.html>`_
@@ -345,8 +343,8 @@ class DWaveSampler(dimod.Sampler, dimod.Structured, AbstractContextManager):
             First 5 entries of the node list for one Advantage system.
 
             >>> from dwave.system import DWaveSampler
-            >>> sampler = DWaveSampler()
-            >>> sampler.nodelist[:5]    # doctest: +SKIP
+            >>> with DWaveSampler() as sampler:     # doctest: +SKIP
+            ...     sampler.nodelist[:5]
             [30, 31, 32, 33, 34]
 
         See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/stable/concepts/index.html>`_
@@ -428,14 +426,13 @@ class DWaveSampler(dimod.Sampler, dimod.Structured, AbstractContextManager):
 
             >>> from dwave.system import DWaveSampler
             ...
-            >>> sampler = DWaveSampler()
-            ...
-            >>> qubit_a = sampler.nodelist[0]
-            >>> qubit_b = next(iter(sampler.adjacency[qubit_a]))
-            >>> sampleset = sampler.sample_ising({qubit_a: -1, qubit_b: 1},
-            ...                                  {},
-            ...                                  num_reads=100)
-            >>> print(sampleset.first.sample[qubit_a] == 1 and sampleset.first.sample[qubit_b] == -1)
+            >>> with DWaveSampler() as sampler:
+            ...     qubit_a = sampler.nodelist[0]
+            ...     qubit_b = next(iter(sampler.adjacency[qubit_a]))
+            ...     sampleset = sampler.sample_ising({qubit_a: -1, qubit_b: 1},
+            ...                                      {},
+            ...                                      num_reads=100)
+            ...     print(sampleset.first.sample[qubit_a] == 1 and sampleset.first.sample[qubit_b] == -1)
             True
 
         See `Ocean Glossary <https://docs.ocean.dwavesys.com/en/stable/concepts/index.html>`_
@@ -548,10 +545,9 @@ class DWaveSampler(dimod.Sampler, dimod.Structured, AbstractContextManager):
             This example sets a quench schedule on a D-Wave system.
 
             >>> from dwave.system import DWaveSampler
-            >>> sampler = DWaveSampler()
-            >>> quench_schedule=[[0.0, 0.0], [12.0, 0.6], [12.8, 1.0]]
-            >>> DWaveSampler().validate_anneal_schedule(quench_schedule)    # doctest: +SKIP
-            >>>
+            >>> with DWaveSampler() as sampler:     # doctest: +SKIP
+            ...     quench_schedule=[[0.0, 0.0], [12.0, 0.6], [12.8, 1.0]]
+            ...     DWaveSampler().validate_anneal_schedule(quench_schedule)
 
         """
         if 'anneal_schedule' not in self.parameters:
@@ -622,9 +618,9 @@ class DWaveSampler(dimod.Sampler, dimod.Structured, AbstractContextManager):
 
             >>> from dwave.system import DWaveSampler
             ...
-            >>> sampler = DWaveSampler()
-            >>> g = sampler.to_networkx_graph()      # doctest: +SKIP
-            >>> len(g.nodes) > 5000                  # doctest: +SKIP
+            >>> with DWaveSampler() as sampler:         # doctest: +SKIP
+            ...     g = sampler.to_networkx_graph()
+            ...     len(g.nodes) > 5000
             True
         """
         return qpu_graph(self.properties['topology']['type'],

--- a/dwave/system/samplers/leap_hybrid_sampler.py
+++ b/dwave/system/samplers/leap_hybrid_sampler.py
@@ -39,7 +39,7 @@ __all__ = ['LeapHybridSampler',
            ]
 
 
-class ClosableClientBaseMixin(AbstractContextManager):
+class _ClosableClientBaseMixin(AbstractContextManager):
     """A mixin that implements ``close`` method to close the underlying cloud
     client. It also implements a default context manager that closes resources
     on exit.
@@ -66,7 +66,7 @@ class ClosableClientBaseMixin(AbstractContextManager):
         return None
 
 
-class LeapHybridSampler(dimod.Sampler, ClosableClientBaseMixin):
+class LeapHybridSampler(dimod.Sampler, _ClosableClientBaseMixin):
     """A class for using Leap's cloud-based hybrid BQM solvers.
 
     Leap's quantum-classical hybrid binary quadratic models (BQM) solvers are
@@ -295,7 +295,7 @@ class LeapHybridSampler(dimod.Sampler, ClosableClientBaseMixin):
 LeapHybridBQMSampler = LeapHybridSampler
 
 
-class LeapHybridDQMSampler(ClosableClientBaseMixin):
+class LeapHybridDQMSampler(_ClosableClientBaseMixin):
     """A class for using Leap's cloud-based hybrid DQM solvers.
 
     Leap's quantum-classical hybrid DQM solvers are intended to solve arbitrary
@@ -543,7 +543,7 @@ class LeapHybridDQMSampler(ClosableClientBaseMixin):
         return max([5, t])
 
 
-class LeapHybridCQMSampler(ClosableClientBaseMixin):
+class LeapHybridCQMSampler(_ClosableClientBaseMixin):
     """A class for using Leap's cloud-based hybrid CQM solvers.
 
     Leap's quantum-classical hybrid CQM solvers are intended to solve
@@ -799,7 +799,7 @@ class LeapHybridCQMSampler(ClosableClientBaseMixin):
             )
 
 
-class LeapHybridNLSampler(ClosableClientBaseMixin):
+class LeapHybridNLSampler(_ClosableClientBaseMixin):
     r"""A class for using Leap's cloud-based hybrid nonlinear-model solvers.
 
     Leap's quantum-classical hybrid nonlinear-model solvers are intended to

--- a/dwave/system/samplers/leap_hybrid_sampler.py
+++ b/dwave/system/samplers/leap_hybrid_sampler.py
@@ -110,23 +110,8 @@ class LeapHybridSampler(dimod.Sampler, ClosableClientBaseMixin):
         >>> bqm = dimod.BQM.from_qubo(qubo)
         ...
         >>> # Find a good solution
-        >>> sampler = LeapHybridSampler()       # doctest: +SKIP
-        >>> sampleset = sampler.sample(bqm)     # doctest: +SKIP
-
-        This example specializes the default solver selection by filtering out
-        bulk BQM solvers. (Bulk solvers are throughput-optimal for heavy/batch
-        workloads, have a higher start-up latency, and are not well suited for
-        live workloads. Not all Leap accounts have access to bulk solvers.)
-
-        >>> from dwave.system import LeapHybridSampler
-        ...
-        >>> solver = LeapHybridSampler.default_solver
-        >>> solver.update(name__regex=".*(?<!bulk)$")       # name shouldn't end with "bulk"
-        >>> sampler = LeapHybridSampler(solver=solver)      # doctest: +SKIP
-        >>> sampler.solver        # doctest: +SKIP
-        BQMSolver(id='hybrid_binary_quadratic_model_version2')
-        ...
-        >>> sampler.close()       # doctest: +SKIP
+        >>> with LeapHybridSampler() as sampler:    # doctest: +SKIP
+        ...     sampleset = sampler.sample(bqm)
     """
 
     _INTEGER_BQM_SIZE_THRESHOLD = 10000
@@ -237,10 +222,8 @@ class LeapHybridSampler(dimod.Sampler, ClosableClientBaseMixin):
             >>> bqm = dimod.BQM.from_qubo(qubo)
             ...
             >>> # Find a good solution
-            >>> sampler = LeapHybridSampler()       # doctest: +SKIP
-            >>> sampleset = sampler.sample(bqm)     # doctest: +SKIP
-            ...
-            >>> sampler.close()                     # doctest: +SKIP
+            >>> with LeapHybridSampler() as sampler:    # doctest: +SKIP
+            ...     sampleset = sampler.sample(bqm)
         """
 
         if not isinstance(bqm, dimod.BQM):
@@ -368,14 +351,11 @@ class LeapHybridDQMSampler(ClosableClientBaseMixin):
         ...          dqm.set_quadratic('my_hand', 'their_hand',
         ...                            {(my_idx, their_idx): 1})
         ...
-        >>> dqm_sampler = LeapHybridDQMSampler()      # doctest: +SKIP
-        ...
-        >>> sampleset = dqm_sampler.sample_dqm(dqm)   # doctest: +SKIP
-        >>> print("{} beats {}".format(cases[sampleset.first.sample['my_hand']],
-        ...                            cases[sampleset.first.sample['their_hand']]))   # doctest: +SKIP
+        >>> with LeapHybridDQMSampler() as dqm_sampler:     # doctest: +SKIP
+        ...     sampleset = dqm_sampler.sample_dqm(dqm)
+        ...     print(f"{} beats {}".format(cases[sampleset.first.sample['my_hand']],
+        ...                                 cases[sampleset.first.sample['their_hand']]))
         rock beats scissors
-        ...
-        >>> dqm_sampler.close()                       # doctest: +SKIP
     """
 
     @classproperty
@@ -618,17 +598,15 @@ class LeapHybridCQMSampler(ClosableClientBaseMixin):
         a remote solver provided by the Leap quantum cloud service:
 
         >>> from dwave.system import LeapHybridCQMSampler   # doctest: +SKIP
-        >>> sampler = LeapHybridCQMSampler()                # doctest: +SKIP
-        >>> sampleset = sampler.sample_cqm(cqm)             # doctest: +SKIP
-        >>> print(sampleset.first)                          # doctest: +SKIP
+        >>> with LeapHybridCQMSampler() as sampler:         # doctest: +SKIP
+        ...     sampleset = sampler.sample_cqm(cqm)
+        ...     print(sampleset.first)
         Sample(sample={'i': 2.0, 'j': 2.0}, energy=-4.0, num_occurrences=1,
         ...            is_feasible=True, is_satisfied=array([ True]))
 
         The best (lowest-energy) solution found has :math:`i=j=2` as expected,
         a solution that is feasible because all the constraints (one in this
         example) are satisfied.
-        ...
-        >>> sampler.close()                                 # doctest: +SKIP
     """
 
     def __init__(self, **config):
@@ -852,18 +830,15 @@ class LeapHybridNLSampler(ClosableClientBaseMixin):
         >>> from dwave.optimization.generators import flow_shop_scheduling
         >>> from dwave.system import LeapHybridNLSampler
         ...
-        >>> sampler = LeapHybridNLSampler()     # doctest: +SKIP
-        ...
-        >>> processing_times = [[10, 5, 7], [20, 10, 15]]
-        >>> model = flow_shop_scheduling(processing_times=processing_times)
-        >>> results = sampler.sample(model, label="Small FSS problem")    # doctest: +SKIP
-        >>> job_order = next(model.iter_decisions())  # doctest: +SKIP
-        >>> print(f"State 0 of {model.objective.state_size()} has an "\   # doctest: +SKIP
-        ... f"objective value {model.objective.state(0)} for order " \    # doctest: +SKIP
-        ... f"{job_order.state(0)}.")     # doctest: +SKIP
+        >>> with LeapHybridNLSampler() as sampler:      # doctest: +SKIP
+        ...     processing_times = [[10, 5, 7], [20, 10, 15]]
+        ...     model = flow_shop_scheduling(processing_times=processing_times)
+        ...     results = sampler.sample(model, label="Small FSS problem")
+        ...     job_order = next(model.iter_decisions())
+        ...     print(f"State 0 of {model.objective.state_size()} has an "
+        ...           f"objective value {model.objective.state(0)} for order "
+        ...           f"{job_order.state(0)}.")
         State 0 of 8 has an objective value 50.0 for order [1. 2. 0.].
-        ...
-        >>> sampler.close()       # doctest: +SKIP
     """
 
     def __init__(self, **config):

--- a/tests/qpu/test_dwavesampler.py
+++ b/tests/qpu/test_dwavesampler.py
@@ -62,6 +62,15 @@ class TestDWaveSampler(unittest.TestCase):
                     h, J = self.nonzero_ising_problem(sampler)
                     sampler.sample_ising(h, J)
 
+        with self.subTest('verify context manager calls close'):
+            n_initial = threading.active_count()
+            with DWaveSampler():
+                n_active = threading.active_count()
+            n_closed = threading.active_count()
+
+            self.assertGreater(n_active, n_initial)
+            self.assertEqual(n_closed, n_initial)
+
     @staticmethod
     def nonzero_ising_problem(sampler):
         max_h = max(sampler.properties.get('h_range', [-1, 1]))

--- a/tests/qpu/test_leaphybrid_common.py
+++ b/tests/qpu/test_leaphybrid_common.py
@@ -143,3 +143,12 @@ class TestSamplerInterface(unittest.TestCase):
                 with self.assertRaises(UseAfterCloseError):
                     problem = self.problem_gen()
                     getattr(sampler, self.sample_meth)(problem)
+
+        with self.subTest('verify context manager calls close'):
+            n_initial = threading.active_count()
+            with self.sampler_cls():
+                n_active = threading.active_count()
+            n_closed = threading.active_count()
+
+            self.assertGreater(n_active, n_initial)
+            self.assertEqual(n_closed, n_initial)

--- a/tests/test_dwavecliquesampler.py
+++ b/tests/test_dwavecliquesampler.py
@@ -147,7 +147,6 @@ class TestDWaveCliqueSampler(unittest.TestCase):
         pegasus_sampler.sample(bqm, chain_strength=-0.5).resolve()
 
 
-
 class TestFailover(unittest.TestCase):
 
     @staticmethod
@@ -219,5 +218,12 @@ class TestFailover(unittest.TestCase):
     def test_close(self, mock_child_sampler):
         sampler = DWaveCliqueSampler()
         sampler.close()
+
+        mock_child_sampler.return_value.close.assert_called_once()
+
+    @unittest.mock.patch('dwave.system.samplers.clique.DWaveSampler')
+    def test_context_manager(self, mock_child_sampler):
+        with DWaveCliqueSampler() as sampler:
+            ...
 
         mock_child_sampler.return_value.close.assert_called_once()

--- a/tests/test_dwavesampler.py
+++ b/tests/test_dwavesampler.py
@@ -144,6 +144,17 @@ class TestDWaveSampler(unittest.TestCase):
 
         MockClient.from_config.return_value.close.assert_called_once()
 
+    @mock.patch('dwave.system.samplers.dwave_sampler.Client')
+    def test_context_manager(self, MockClient):
+        """DWaveSampler() can be used as a context manager and the underlying
+        client is closed on exit.
+        """
+
+        with DWaveSampler() as sampler:
+            ...
+
+        MockClient.from_config.return_value.close.assert_called_once()
+
     def test_sample_ising_variables(self):
 
         sampler = self.sampler

--- a/tests/test_leaphybridcqmsampler.py
+++ b/tests/test_leaphybridcqmsampler.py
@@ -78,7 +78,14 @@ class TestTimeLimit(unittest.TestCase):
         mock_solver.properties = {'category': 'hybrid'}
         mock_solver.supported_problem_types = ['cqm']
 
-        sampler = LeapHybridCQMSampler()
-        sampler.close()
+        with self.subTest('manual close'):
+            sampler = LeapHybridCQMSampler()
+            sampler.close()
+            mock_client.from_config.return_value.close.assert_called_once()
 
-        mock_client.from_config.return_value.close.assert_called_once()
+        mock_client.reset_mock()
+
+        with self.subTest('context manager'):
+            with LeapHybridCQMSampler():
+                ...
+            mock_client.from_config.return_value.close.assert_called_once()

--- a/tests/test_leaphybriddqmsolver.py
+++ b/tests/test_leaphybriddqmsolver.py
@@ -67,7 +67,14 @@ class TestLeapHybridDQMSampler(unittest.TestCase):
         mock_solver.properties = {'category': 'hybrid'}
         mock_solver.supported_problem_types = ['dqm']
 
-        sampler = LeapHybridDQMSampler()
-        sampler.close()
+        with self.subTest('manual close'):
+            sampler = LeapHybridDQMSampler()
+            sampler.close()
+            mock_client.from_config.return_value.close.assert_called_once()
 
-        mock_client.from_config.return_value.close.assert_called_once()
+        mock_client.reset_mock()
+
+        with self.subTest('context manager'):
+            with LeapHybridDQMSampler():
+                ...
+            mock_client.from_config.return_value.close.assert_called_once()

--- a/tests/test_leaphybridnlsampler.py
+++ b/tests/test_leaphybridnlsampler.py
@@ -130,7 +130,14 @@ class TestNLSampler(unittest.TestCase):
         mock_solver.properties = {'category': 'hybrid'}
         mock_solver.supported_problem_types = ['nl']
 
-        sampler = LeapHybridNLSampler()
-        sampler.close()
+        with self.subTest('manual close'):
+            sampler = LeapHybridNLSampler()
+            sampler.close()
+            mock_client.from_config.return_value.close.assert_called_once()
 
-        mock_client.from_config.return_value.close.assert_called_once()
+        mock_client.reset_mock()
+
+        with self.subTest('context manager'):
+            with LeapHybridNLSampler():
+                ...
+            mock_client.from_config.return_value.close.assert_called_once()

--- a/tests/test_leaphybridsolver.py
+++ b/tests/test_leaphybridsolver.py
@@ -115,10 +115,17 @@ class TestLeapHybridSampler(unittest.TestCase):
         mock_solver.properties = {'category': 'hybrid'}
         mock_solver.supported_problem_types = ['bqm']
 
-        sampler = LeapHybridSampler()
-        sampler.close()
+        with self.subTest('manual close'):
+            sampler = LeapHybridSampler()
+            sampler.close()
+            mock_client.from_config.return_value.close.assert_called_once()
 
-        mock_client.from_config.return_value.close.assert_called_once()
+        mock_client.reset_mock()
+
+        with self.subTest('context manager'):
+            with LeapHybridSampler():
+                ...
+            mock_client.from_config.return_value.close.assert_called_once()
 
     @mock.patch('dwave.system.samplers.leap_hybrid_sampler.Client')
     def test_sample_bqm(self, mock_client):


### PR DESCRIPTION
Now all of QPU (`DWaveSampler`, `DWaveCliqueSampler`), and hybrid (`LeapHybrid*Sampler`) samplers support `.close()` and runtime context use.

Close #91.

Composites will be addressed in a follow-up as per #555.