### PR TITLE
Support dwave-optimization 0.6.x and 0.7.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ exec(open(os.path.join(".", "dwave", "system", "package_info.py")).read())
 
 
 install_requires = ['dimod>=0.12.18,<0.14.0',
-                    'dwave-optimization>=0.1.0,<0.6',
+                    'dwave-optimization>=0.1.0,<0.8',
                     'dwave-cloud-client>=0.12.0,<0.14.0',
                     'dwave-networkx>=0.8.10',
                     'dwave-preprocessing>=0.5.0',


### PR DESCRIPTION
Life the maximum version of `dwave-optimization` to `0.7`