### PR TITLE
Add problem info to the NL sampler result

### DIFF
--- a/dwave/system/samplers/__init__.py
+++ b/dwave/system/samplers/__init__.py
@@ -12,6 +12,22 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+import typing
+
+
+class ResultInfoDict(typing.TypedDict, total=False):
+    """Returned in ``SampleSet.info`` and ``LeapHybridNLSampler.SampleResult.info``.
+
+    Not all fields defined below are always set, and additional might be set.
+    """
+
+    timing: dict[str, float]
+    warnings: list[str]
+    problem_id: str
+    problem_label: str
+    problem_data_id: str
+
+
 from dwave.system.samplers.clique import *
 from dwave.system.samplers.dwave_sampler import *
 from dwave.system.samplers.leap_hybrid_sampler import *

--- a/dwave/system/samplers/leap_hybrid_sampler.py
+++ b/dwave/system/samplers/leap_hybrid_sampler.py
@@ -981,6 +981,10 @@ class LeapHybridNLSampler(_ScopedSamplerMixin):
             info = dict(
                 timing=timing,
                 warnings=timing.pop('warnings', []),
+                # match SampleSet.info fields (see :meth:`~dwave.cloud.computation.Future._get_problem_info`)
+                problem_id=future.id,
+                problem_label=future.label,
+                problem_data_id=problem_data_id,
             )
             for msg in info['warnings']:
                 # note: no point using stacklevel, as this is a different thread

--- a/dwave/system/samplers/leap_hybrid_sampler.py
+++ b/dwave/system/samplers/leap_hybrid_sampler.py
@@ -27,6 +27,7 @@ import dwave.optimization
 import numpy
 from dwave.cloud.client import Client
 
+from dwave.system.samplers import ResultInfoDict
 from dwave.system.utilities import classproperty, FeatureFlags
 
 
@@ -918,7 +919,7 @@ class LeapHybridNLSampler(_ScopedSamplerMixin):
 
     class SampleResult(NamedTuple):
         model: dwave.optimization.Model
-        info: dict
+        info: ResultInfoDict
 
     def sample(self, model: dwave.optimization.Model,
                time_limit: Optional[float] = None, **kwargs

--- a/dwave/system/samplers/leap_hybrid_sampler.py
+++ b/dwave/system/samplers/leap_hybrid_sampler.py
@@ -945,12 +945,12 @@ class LeapHybridNLSampler(_ScopedSamplerMixin):
 
         Returns:
             :class:`~concurrent.futures.Future` [SampleResult]:
-                Named tuple containing nonlinear model and general result info
-                (such as timing information and problem data id), in a Future.
+                Named tuple, in a Future, containing the nonlinear model and general
+                result information such as timing and the identity of the problem data.
 
         .. versionchanged:: 1.31.0
-            The return type includes timing information as part of the ``info``
-            field dictionary, which now replaces the old ``timing`` field.
+            The return value includes timing information as part of the ``info``
+            field dictionary, which now replaces the previous ``timing`` field.
         """
 
         if not isinstance(model, dwave.optimization.Model):

--- a/tests/test_leaphybridnlsampler.py
+++ b/tests/test_leaphybridnlsampler.py
@@ -109,7 +109,7 @@ class TestNLSampler(unittest.TestCase):
         with self.subTest('timing returned in sample future'):
             self.assertIsInstance(result, concurrent.futures.Future)
             self.assertIsInstance(result.result(), LeapHybridNLSampler.SampleResult)
-            self.assertEqual(result.result().timing, mock_timing_info)
+            self.assertEqual(result.result().info['timing'], mock_timing_info)
 
         with self.subTest('model states updated'):
             self.assertEqual(result.result().model.states.size(), num_states)

--- a/tests/test_leaphybridnlsampler.py
+++ b/tests/test_leaphybridnlsampler.py
@@ -71,16 +71,20 @@ class TestNLSampler(unittest.TestCase):
         self.assertEqual(model.states.size(), 2)
 
         # upload is tested in dwave-cloud-client, we can just mock it here
+        mock_problem_id = '321'
         mock_problem_data_id = '123'
-        mock_timing_info = {'qpu_access_time': 1, 'run_time': 2}
+        mock_problem_label = 'mock-label'
+        mock_timing = {'qpu_access_time': 1, 'run_time': 2}
+        mock_warnings = ['solved by classical presolve techniques']
 
         # note: instead of simply mocking `sampler.solver`, we mock a set of
         # solver methods minimally required to fully test `NLSolver.sample_problem`
 
         upload_nlm.return_value.result.return_value = mock_problem_data_id
 
-        base_sample_problem.return_value = Future(solver=sampler.solver, id_="x")
+        base_sample_problem.return_value = Future(solver=sampler.solver, id_=mock_problem_id)
         base_sample_problem.return_value._set_message({"answer": {}})
+        base_sample_problem.return_value.label = mock_problem_label
 
         def mock_decode_response(msg, answer_data: io.IOBase):
             # copy model states to the "received" answer_data
@@ -88,7 +92,7 @@ class TestNLSampler(unittest.TestCase):
             answer_data.seek(0)
             return {
                 'problem_type': 'nl',
-                'timing': mock_timing_info,
+                'timing': mock_timing | dict(warnings=mock_warnings),
                 'shape': {},
                 'answer': answer_data
             }
@@ -96,31 +100,35 @@ class TestNLSampler(unittest.TestCase):
 
         time_limit = 5
 
-        result = sampler.sample(model, time_limit=time_limit)
+        result = sampler.sample(model, time_limit=time_limit, label=mock_problem_label)
 
         with self.subTest('low-level sample_nlm called'):
             base_sample_problem.assert_called_with(
-                mock_problem_data_id, label=None, upload_params=None, time_limit=time_limit)
+                mock_problem_data_id, label=mock_problem_label,
+                upload_params=None, time_limit=time_limit)
 
         with self.subTest('max_num_states is respected on upload'):
             upload_nlm.assert_called_with(
                 model, max_num_states=sampler.properties['maximum_number_of_states'])
 
-        with self.subTest('timing returned in sample future'):
+        with self.subTest('timing returned in sample result'):
             self.assertIsInstance(result, concurrent.futures.Future)
             self.assertIsInstance(result.result(), LeapHybridNLSampler.SampleResult)
-            self.assertEqual(result.result().info['timing'], mock_timing_info)
+            self.assertEqual(result.result().info['timing'], mock_timing)
+            # warnings separate from timing
+            self.assertEqual(result.result().info['warnings'], mock_warnings)
+
+        with self.subTest('problem info returned in sample result'):
+            self.assertEqual(result.result().info['problem_id'], mock_problem_id)
+            # self.assertEqual(result.result().info['problem_label'], mock_problem_label)
+            self.assertEqual(result.result().info['problem_data_id'], mock_problem_data_id)
 
         with self.subTest('model states updated'):
             self.assertEqual(result.result().model.states.size(), num_states)
             self.assertEqual(model.states.size(), num_states)
 
         with self.subTest('warnings raised'):
-            # add a warning to timing info (inplace)
-            msg = 'solved by classical presolve techniques'
-            mock_timing_info['warnings'] = [msg]
-
-            with self.assertWarns(UserWarning, msg=msg):
+            with self.assertWarns(UserWarning, msg=mock_warnings[0]):
                 result = sampler.sample(model, time_limit=time_limit)
                 result.result()
 


### PR DESCRIPTION
Close #528.

Opted for the second option from #528, renaming `timing` to `info` and adding general problem info there, together with timing info and warnings.

The `info` field returned in `LeapHybridNLSampler.SampleResult` named tuple is a `dict`, now consistent with `SampleSet.info`, e.g.:
```python
{
    "timing": {...},
    "warnings": [...],
    "problem_id": "...",
    "problem_label": "...",
    "problem_data_id": "..."
}
```

This change is technically breaking backwards-compatibility, but given that:
- the result type from [`LeapHybridNLSampler.sample()`](https://docs.dwavequantum.com/en/latest/ocean/api_ref_system/generated/dwave.system.samplers.LeapHybridNLSampler.sample.html#dwave.system.samplers.LeapHybridNLSampler.sample) hasn't been documented in full (name of the `timing` field is not specified),
- no example either in docs, dwave-examples or elsewhere I could find actually uses the result,

I think we should be OK making this change.