### PR TITLE
Expand uniform_torque_compensation docstring

### DIFF
--- a/dwave/embedding/chain_strength.py
+++ b/dwave/embedding/chain_strength.py
@@ -47,11 +47,11 @@ def uniform_torque_compensation(bqm, embedding=None, prefactor=1.414):
     the wavefunction representing the QPU's quantum state develops long-range
     order. A chain strength that increases the correlation of the chains' qubits
     together with the development of this long-range order produces efficient
-    quantum dynamics [Ray2020]_. Consequently, for hard, frustrated problems
-    with typical chain topology (path or tree-like chains), such as spin
-    glasses, choose a chain strength that grows in proportion to the root of
-    typical variable connectivity and the root mean square (RMS) of coupling
-    strength (:math:`\sqrt{\text{connectivity}} \times \text{coupling}_{RMS}`).
+    quantum dynamics [Ray2020]_. For many hard, frustrated problems (such as
+    spin glasses) with typical chain topology (path or tree-like chains), the
+    optimal chain strength is proportional to the root of typical variable
+    connectivity and the root mean square (RMS) of coupling strength
+    (:math:`\sqrt{\text{connectivity}} \times \text{coupling}_{RMS}`).
 
     This chain strength, chosen for its dynamically-efficient scaling, also
     meets another requirement, even in challenging models: it must be large


### PR DESCRIPTION
@jackraymond, please review. 

I added [this paper](https://ieeexplore.ieee.org/document/9259935/citations#citations) to the [SDK bibliography](https://docs.dwavequantum.com/en/latest/bibliography.html) in a [separate PR](https://github.com/dwavesystems/dwave-system/pull/566).

@arcondello, is the `embedding` parameter still needed in the [uniform_torque_compensation](https://docs.dwavequantum.com/en/latest/ocean/api_ref_system/generated/dwave.embedding.chain_strength.uniform_torque_compensation.html)? I don't see it [here](https://github.com/dwavesystems/dwave-system/blob/47c368e88f6b55312841bf76594af3786c3706e4/dwave/embedding/transforms.py#L247) but maybe it is specified elsewhere. 
 