### PR TITLE
Verify `problem_data_id` returned in sampleset.info with latest client

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,7 +231,7 @@ workflows:
               python-version: &python-versions ["3.9", "3.10", "3.11", "3.12", &latest-python "3.13"]
               dependency-specifiers:
                 - "dwave-cloud-client~=0.12.0"
-                - "dwave-cloud-client~=0.13.0"
+                - "dwave-cloud-client~=0.13.5"
               integration-test-python-version: &integration-python-versions [*latest-python]
             exclude:
               - python-version: "3.13"

--- a/tests/qpu/test_leaphybrid_common.py
+++ b/tests/qpu/test_leaphybrid_common.py
@@ -22,6 +22,7 @@ from parameterized import parameterized_class
 
 import dimod
 from dwave.cloud.exceptions import ConfigFileError, SolverNotFoundError
+from dwave.cloud.package_info import __version__ as cc_version
 from dwave.cloud.testing import isolated_environ
 
 from dwave.system import LeapHybridSampler, LeapHybridDQMSampler, LeapHybridCQMSampler
@@ -121,6 +122,15 @@ class TestSamplerInterface(unittest.TestCase):
             ss.resolve()
             pid_post = ss.wait_id()
             self.assertEqual(pid, pid_post)
+
+    @unittest.skipIf(tuple(map(int, cc_version.split('.'))) < (0, 13, 5),
+                     "'dwave-cloud-client>=0.13.5' required")
+    def test_problem_data_id_available(self):
+        problem = self.problem_gen()
+        ss = getattr(self.sampler, self.sample_meth)(problem)
+
+        self.assertIn('problem_id', ss.info)
+        self.assertIn('problem_data_id', ss.info)
 
     def test_close(self):
         n_initial = threading.active_count()


### PR DESCRIPTION
Actually implemented in https://github.com/dwavesystems/dwave-cloud-client/pull/690, hence it requires `dwave-cloud-client>=0.13.5`, but we still support ~0.12.0 if this feature is not required.

Close #398.

Note: `problem_data_id` retrieval for the NL solver is implemented in https://github.com/dwavesystems/dwave-system/pull/565.