### PR TITLE
Feature/parallel embeddings

### DIFF
--- a/dwave/system/composites/__init__.py
+++ b/dwave/system/composites/__init__.py
@@ -18,3 +18,4 @@ from dwave.system.composites.linear_ancilla import *
 from dwave.system.composites.tiling import *
 from dwave.system.composites.virtual_graph import *
 from dwave.system.composites.reversecomposite import *
+from dwave.system.composites.parallel_embeddings import *

--- a/dwave/system/composites/parallel_embeddings.py
+++ b/dwave/system/composites/parallel_embeddings.py
@@ -1,0 +1,274 @@
+# Copyright 2018 D-Wave Systems Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+"""
+A :ref:`dimod composite <index_dimod>` that parallelizes small problems
+on a structured sampler.
+
+The :class:`.ParallelEmbeddingComposite` class takes a problem and 
+parallelizes across disjoint embeddings on a target graph.
+This allows multiple independent sampling processes to be conducted in 
+parallel. 
+
+See the :ref:`index_concepts` section
+for explanations of technical terms in descriptions of Ocean tools.
+"""
+
+import dimod
+import dwave_networkx as dnx
+
+import dwave.embedding
+from dwave.embedding.utils import adjacency_to_edges, target_to_source
+from minorminer.utils.parallel_embeddings import find_multiple_embeddings
+
+__all__ = ["ParallelEmbeddingComposite"]
+
+
+class ParallelEmbeddingComposite(dimod.Composite, dimod.Structured, dimod.Sampler):
+    """Composite to parallelize sampling of a small problem on a structured sampler
+
+    Enables parallel sampling on a structured (target) sampler by use of multiple
+    disjoint embeddings.
+    Embeddings, particularly for large subgraphs of large target graphs
+    can be difficult to obtain. Relying on the defaults of this routine may result
+    in slow embedding, see :minorminer.util.parallel_embedding for methods. Note
+    that parallelization of job submissions can mitigate for network latency,
+    programming time and readout time in the case of QPU samplers, subject to
+    additional complexity in the embedding process.
+
+    If a list of embeddings is not provided, the function
+    :code:minorminer.utils.parallel_embeddings.find_multiple_embeddings is called
+    by default to attempt a maximum number of embeddings. If the target and source
+    graph match processor architecture on a Chimera, Pegasus or Zephyr then
+    tiling of a known embedding in a regular pattern may be a useful embedding
+    strategy and find_sublattice_embeddings can be considered.
+    See minorminer.utils.parallel_embedding documentation for customizable options
+    including specification of the time_out and maximum number of embeddings.
+    See tests/test_parallel_embeddings.py for use cases beyond the examples
+    provided.
+
+    Args:
+       sampler (:class:`~dimod.Sampler`): Structured dimod sampler such as a
+           :class:`~dwave.system.samplers.DWaveSampler`.
+       embeddings (list, optional): A list of embeddings. Each embedding is
+           assumed to be a dictionary with source-graph nodes as keys and iterables
+           on target-graph nodes to as values. The embeddings can include keys not
+           required by the source graph.
+       source (nx.Graph, optional): A source graph must be provided if embeddings
+           are not specified. The source graph nodes should be supported by
+           every embedding.
+       find_embeddings (Callable, optional): A function that returns
+           embeddings when it is not provided. The first two arguments are
+           assumed to be the source and target graph.
+       find_embeddings_args (dict, optional): key word arguments for the
+           find_embeddings function. The default
+           is an empty dictionary.
+       one_to_iterable (bool, default=False): This parameter should be fixed to
+           match the value type returned by find_embeddings. If False the
+           values in every dictionary are target nodes (defining a subgraph
+           embedding), these are transformed to tuples for compatibility with embed_bqm
+           and unembed_sampleset. If True, the values are iterables over target
+           nodes and no transformation is required.
+
+    Examples:
+       A 4-loop can be embedded on the order of N//4 times on a processor
+       with N nodes.
+
+
+       A NOT gate QUBO can be embedded on a Chimera[m=1,t=4] graph.
+       It is possible to tile many copies of this problem on a target
+       graph which is Chimera, Pegasus or Zephyr structured.
+       >>> from dwave.system import DWaveSampler, EmbeddingComposite
+       >>> from dwave.system import TilingComposite
+       ...
+       >>> sampler = EmbeddingComposite(TilingComposite(DWaveSampler(), 1, 1, 4))
+       >>> Q = {(1, 1): -1, (1, 2): 2, (2, 1): 0, (2, 2): -1}
+       >>> sampleset = sampler.sample_qubo(Q)
+       >>> len(sampleset)> 1
+       True
+
+    See the :ref:`index_concepts` section
+    for explanations of technical terms in descriptions of Ocean tools.
+
+    """
+
+    nodelist = None
+    """list: List of active qubits for the structured solver."""
+
+    edgelist = None
+    """list: List of active couplers for the structured solver."""
+
+    parameters = None
+    """dict[str, list]: Parameters in the form of a dict."""
+
+    properties = None
+    """dict: Properties in the form of a dict."""
+
+    children = None
+    """list: The single wrapped structured sampler."""
+
+    embeddings = []
+
+    """list: Embeddings into each available tile on the structured solver."""
+
+    def __init__(
+        self,
+        sampler,
+        embeddings=None,
+        source=None,
+        find_embeddings=None,
+        find_embeddings_args=None,
+        one_to_iterable=False,
+    ):
+
+        self.parameters = sampler.parameters.copy()
+        self.properties = properties = {"child_properties": sampler.properties}
+
+        # dimod.Structured abstract base class automatically populates adjacency
+        # and structure as mixins based on nodelist and edgelist
+        if source is not None:
+            self.nodelist = sorted(source.nodes)
+            self.edgelist = sorted(source.edges)
+        elif embeddings is None:
+            raise ValueError("Either the source or embeddings must be provided")
+
+        self.children = [sampler]
+
+        if not isinstance(sampler, dimod.Structured):
+            # Parallelization by embedding only makes sense for a structured
+            # target.
+            raise ValueError("given child sampler should be structured")
+
+        if embeddings is not None:
+            # if one_to_iterable is False:
+            #    _embeddings = [{k: (v,) for k, v in emb} for emb in embeddings]
+            # else:
+            _embeddings = embeddings.copy()
+            # Cheap consistency checks and inference of structure
+            if len(embeddings) == 0:
+                raise ValueError(
+                    "embeddings should be a non-empty list of dictionaries"
+                )
+
+            if self.nodelist is None:
+                self.nodelist = {v for v in embeddings[0].keys()}
+            else:
+                nodeset = set(self.nodelist)
+                if not all(
+                    nodeset.is_subset({v for v in emb.keys()}) for emb in embeddings
+                ):
+                    raise ValueError(
+                        "source graph is inconsistent with the embeddings specified"
+                    )
+            if self.edgelist is None:
+                # potentially slow, but thorough. Find the intersection graph:
+                __, __, target_adjacency = sampler.structure
+                edgeset = set(
+                    adjacency_to_edges(
+                        target_to_source(target_adjacency, embeddings[0])
+                    )
+                )  # Assume first.
+                for emb in embeddings[1:]:
+                    edgeset0 = set(
+                        adjacency_to_edges(
+                            target_to_source(target_adjacency, embeddings[0])
+                        )
+                    )
+                    edgeset = edgeset.intersection(edgeset0)
+                self.edgelist = sorted(edgeset)
+        else:
+            if source is None:
+                raise ValueError("A source graph must be provided to infer embeddings")
+
+            if find_embeddings is None:
+                find_embeddings = find_multiple_embeddings
+            if find_embeddings_args is None:
+                find_embeddings_args = {}
+            _embeddings = find_embeddings(
+                source, self.child.to_networkx_graph(), **find_embeddings_args
+            )
+            if one_to_iterable is False:
+                _embeddings = [{k: (v,) for k, v in emb.items()} for emb in _embeddings]
+
+            print(_embeddings)
+        self.children = [sampler]
+        self.embeddings = properties["embeddings"] = _embeddings
+
+    @dimod.bqm_structured
+    def sample(self, bqm, **kwargs):
+        """Sample from the specified binary quadratic model.
+
+        Args:
+            bqm (:obj:`~dimod.BinaryQuadraticModel`):
+                Binary quadratic model to be sampled from.
+
+            **kwargs:
+                Optional keyword arguments for the sampling method, specified per solver.
+
+        Returns:
+            :class:`~dimod.SampleSet`
+
+        Examples:
+            This example submits a simple Ising problem of just two variables on a
+            D-Wave system.
+            Because the problem fits in a single :term:`Chimera` unit cell, it is tiled
+            across the solver's entire Chimera graph, resulting in multiple samples
+            (the exact number depends on the working Chimera graph of the D-Wave system).
+
+            >>> from dwave.system import DWaveSampler, EmbeddingComposite
+            >>> from dwave.system import TilingComposite
+            ...
+            >>> sampler = EmbeddingComposite(TilingComposite(DWaveSampler(), 1, 1, 4))
+            >>> sampleset = sampler.sample_ising({},{('a', 'b'): 1})
+            >>> len(sampleset) > 1
+            True
+
+        See the :ref:`index_concepts` section
+        for explanations of technical terms in descriptions of Ocean tools.
+
+        """
+
+        # apply the embeddings to the given problem to tile it across the child sampler
+        embedded_bqm = dimod.BinaryQuadraticModel.empty(bqm.vartype)
+
+        __, __, target_adjacency = self.child.structure
+        for embedding in self.embeddings:
+            embedded_bqm.update(
+                dwave.embedding.embed_bqm(bqm, embedding, target_adjacency)
+            )
+
+        # solve the problem on the child system
+        tiled_response = self.child.sample(embedded_bqm, **kwargs)
+
+        responses = []
+
+        for embedding in self.embeddings:
+            embedding = {
+                v: chain for v, chain in embedding.items() if v in bqm.variables
+            }
+
+            responses.append(
+                dwave.embedding.unembed_sampleset(tiled_response, embedding, bqm)
+            )
+        if self.num_embeddings == 1:
+            return responses[0]
+        else:
+            answer = dimod.concatenate(responses)
+            answer.info.update(tiled_response.info)
+            return answer
+
+    @property
+    def num_embeddings(self):
+        """Number of embedding available for replicating the problem."""
+        return len(self.embeddings)

--- a/dwave/system/composites/parallel_embeddings.py
+++ b/dwave/system/composites/parallel_embeddings.py
@@ -68,14 +68,14 @@ class ParallelEmbeddingComposite(dimod.Composite, dimod.Structured, dimod.Sample
        source (nx.Graph, optional): A source graph must be provided if embeddings
            are not specified. The source graph nodes should be supported by
            every embedding.
-       find_embeddings (Callable, optional): A function that returns
+       embedder (Callable, optional): A function that returns
            embeddings when it is not provided. The first two arguments are
            assumed to be the source and target graph.
-       find_embeddings_args (dict, optional): key word arguments for the
-           find_embeddings function. The default
+       embedder_kwargs (dict, optional): key word arguments for the
+           embedder function. The default
            is an empty dictionary.
        one_to_iterable (bool, default=False): This parameter should be fixed to
-           match the value type returned by find_embeddings. If False the
+           match the value type returned by embedder. If False the
            values in every dictionary are target nodes (defining a subgraph
            embedding), these are transformed to tuples for compatibility with embed_bqm
            and unembed_sampleset. If True, the values are iterables over target
@@ -127,8 +127,8 @@ class ParallelEmbeddingComposite(dimod.Composite, dimod.Structured, dimod.Sample
         sampler,
         embeddings=None,
         source=None,
-        find_embeddings=None,
-        find_embeddings_args=None,
+        embedder=None,
+        embedder_kwargs=None,
         one_to_iterable=False,
     ):
 
@@ -191,17 +191,16 @@ class ParallelEmbeddingComposite(dimod.Composite, dimod.Structured, dimod.Sample
             if source is None:
                 raise ValueError("A source graph must be provided to infer embeddings")
 
-            if find_embeddings is None:
-                find_embeddings = find_multiple_embeddings
-            if find_embeddings_args is None:
-                find_embeddings_args = {}
-            _embeddings = find_embeddings(
-                source, self.child.to_networkx_graph(), **find_embeddings_args
+            if embedder is None:
+                embedder = find_multiple_embeddings
+            if embedder_kwargs is None:
+                embedder_kwargs = {}
+            _embeddings = embedder(
+                source, self.child.to_networkx_graph(), **embedder_kwargs
             )
             if one_to_iterable is False:
                 _embeddings = [{k: (v,) for k, v in emb.items()} for emb in _embeddings]
 
-            print(_embeddings)
         self.children = [sampler]
         self.embeddings = properties["embeddings"] = _embeddings
 

--- a/dwave/system/composites/parallel_embeddings.py
+++ b/dwave/system/composites/parallel_embeddings.py
@@ -225,7 +225,9 @@ class ParallelEmbeddingComposite(dimod.Composite, dimod.Structured, dimod.Sample
 
     @dimod.bqm_structured
     def sample(self, bqm, **kwargs):
-        """Sample from the specified binary quadratic model.
+        """Sample from the specified binary quadratic model. Samplesets are
+        concatenated together in the the same order as the embeddings class variable,
+        the info field is returned from the child sampler unmodified.
 
         Args:
             bqm (:obj:`~dimod.BinaryQuadraticModel`):

--- a/tests/test_parallel_embedding_composite.py
+++ b/tests/test_parallel_embedding_composite.py
@@ -101,13 +101,39 @@ class TestTiling(unittest.TestCase):
             mock_sampler.properties["topology"]["type"] == "pegasus"
             and "shape" in mock_sampler.properties["topology"]
         )
-        sampler = TilingComposite(mock_sampler, 1, 1)
+        # sampler = TilingComposite(mock_sampler, 1, 1)
+        tile = dnx.chimera_graph(1)
+        embedder = find_sublattice_embeddings
+        embedder_kwargs = {
+            "tile": tile,
+            "max_num_emb": None,
+            "use_tile_embedding": True,
+        }
+        sampler = ParallelEmbeddingComposite(
+            mock_sampler,
+            source=tile,
+            embedder=embedder,
+            embedder_kwargs=embedder_kwargs,
+        )
         h = {node: random.uniform(-1, 1) for node in sampler.structure.nodelist}
         J = {(u, v): random.uniform(-1, 1) for u, v in sampler.structure.edgelist}
 
         m_sub = 2
         n_sub = 3
-        sampler = TilingComposite(mock_sampler, m_sub, n_sub)
+        # sampler = TilingComposite(mock_sampler, m_sub, n_sub)
+        tile = dnx.chimera_graph(m=m_sub, n=n_sub)
+        embedder = find_sublattice_embeddings
+        embedder_kwargs = {
+            "tile": tile,
+            "max_num_emb": None,
+            "use_tile_embedding": True,
+        }
+        sampler = ParallelEmbeddingComposite(
+            mock_sampler,
+            source=tile,
+            embedder=embedder,
+            embedder_kwargs=embedder_kwargs,
+        )
         h = {node: random.uniform(-1, 1) for node in sampler.structure.nodelist}
         J = {(u, v): random.uniform(-1, 1) for u, v in sampler.structure.edgelist}
 
@@ -121,8 +147,20 @@ class TestTiling(unittest.TestCase):
 
     def test_sample_ising(self):
         mock_sampler = MockDWaveSampler()  # C4 structured sampler
-
-        sampler = TilingComposite(mock_sampler, 2, 2)
+        # sampler = TilingComposite(mock_sampler, 2, 2) Legacy
+        tile = dnx.chimera_graph(m=2, n=2)
+        embedder = find_sublattice_embeddings
+        embedder_kwargs = {
+            "tile": tile,
+            "max_num_emb": None,
+            "use_tile_embedding": True,
+        }
+        sampler = ParallelEmbeddingComposite(
+            mock_sampler,
+            source=tile,
+            embedder=embedder,
+            embedder_kwargs=embedder_kwargs,
+        )
 
         h = {node: random.uniform(-1, 1) for node in sampler.structure.nodelist}
         J = {(u, v): random.uniform(-1, 1) for u, v in sampler.structure.edgelist}
@@ -217,8 +255,6 @@ class TestTiling(unittest.TestCase):
             embedder=embedder,
             embedder_kwargs=embedder_kwargs,
         )
-        print(sampler.embeddings)
-        print(len(sampler.embeddings))
         # Given the above pegasus graph, check that the embeddings are as
         # follows:
         # 00XX  3344 7788
@@ -264,7 +300,21 @@ class TestTiling(unittest.TestCase):
             topology_shape=pegasus_shape,
             broken_edges=broken_edges,
         )
-        sampler = TilingComposite(mock_sampler, 2, 2, 4)
+        # sampler = TilingComposite(mock_sampler, 2, 2, 4) Deprecated
+        tile = dnx.chimera_graph(2, 2, 4)
+        embedder = find_sublattice_embeddings
+        embedder_kwargs = {
+            "tile": tile,
+            "max_num_emb": None,
+            "use_tile_embedding": True,
+        }
+        sampler = ParallelEmbeddingComposite(
+            mock_sampler,
+            source=tile,
+            embedder=embedder,
+            embedder_kwargs=embedder_kwargs,
+        )
+
         self.assertTrue(len(sampler.embeddings) == 12)
 
         # P5 structured sampler with one missing internal edge that prevents
@@ -281,12 +331,38 @@ class TestTiling(unittest.TestCase):
             topology_shape=pegasus_shape,
             broken_edges=broken_edges,
         )
-        sampler = TilingComposite(mock_sampler, 2, 2, 4)
+        # sampler = TilingComposite(mock_sampler, 2, 2, 4)  # Deprecated
+        tile = dnx.chimera_graph(2, 2, 4)
+        embedder = find_sublattice_embeddings
+        embedder_kwargs = {
+            "tile": tile,
+            "max_num_emb": None,
+            "use_tile_embedding": True,
+        }
+        sampler = ParallelEmbeddingComposite(
+            mock_sampler,
+            source=tile,
+            embedder=embedder,
+            embedder_kwargs=embedder_kwargs,
+        )
         self.assertTrue(len(sampler.embeddings) == 11)
 
     def test_sample_ising(self):
-        sampler = TilingComposite(MockDWaveSampler(), 2, 2)
-
+        # sampler = TilingComposite(MockDWaveSampler(), 2, 2)  # Deprecated
+        mock_sampler = MockDWaveSampler()
+        tile = dnx.chimera_graph(m=2, n=2)
+        embedder = find_sublattice_embeddings
+        embedder_kwargs = {
+            "tile": tile,
+            "max_num_emb": None,
+            "use_tile_embedding": True,
+        }
+        sampler = ParallelEmbeddingComposite(
+            mock_sampler,
+            source=tile,
+            embedder=embedder,
+            embedder_kwargs=embedder_kwargs,
+        )
         h = {node: random.uniform(-1, 1) for node in sampler.structure.nodelist}
         J = {(u, v): random.uniform(-1, 1) for u, v in sampler.structure.edgelist}
 
@@ -303,7 +379,21 @@ class TestTiling(unittest.TestCase):
             self.assertAlmostEqual(dimod.ising_energy(sample, h, J), energy)
 
     def test_sample_qubo(self):
-        sampler = TilingComposite(MockDWaveSampler(), 2, 2)
+        # sampler = TilingComposite(MockDWaveSampler(), 2, 2)
+        mock_sampler = MockDWaveSampler()
+        tile = dnx.chimera_graph(m=2, n=2)
+        embedder = find_sublattice_embeddings
+        embedder_kwargs = {
+            "tile": tile,
+            "max_num_emb": None,
+            "use_tile_embedding": True,
+        }
+        sampler = ParallelEmbeddingComposite(
+            mock_sampler,
+            source=tile,
+            embedder=embedder,
+            embedder_kwargs=embedder_kwargs,
+        )
 
         Q = {(u, v): random.uniform(-1, 1) for u, v in sampler.structure.edgelist}
         Q.update(
@@ -326,7 +416,20 @@ class TestTiling(unittest.TestCase):
     def test_too_many_nodes(self):
         mock_sampler = MockDWaveSampler()  # C4 structured sampler
 
-        sampler = TilingComposite(mock_sampler, 2, 2)
+        # sampler = TilingComposite(mock_sampler, 2, 2)  # Deprecated
+        tile = dnx.chimera_graph(m=2, n=2)
+        embedder = find_sublattice_embeddings
+        embedder_kwargs = {
+            "tile": tile,
+            "max_num_emb": None,
+            "use_tile_embedding": True,
+        }
+        sampler = ParallelEmbeddingComposite(
+            mock_sampler,
+            source=tile,
+            embedder=embedder,
+            embedder_kwargs=embedder_kwargs,
+        )
 
         h = {0: -1, 1: 1}
         J = {}

--- a/tests/test_parallel_embedding_composite.py
+++ b/tests/test_parallel_embedding_composite.py
@@ -1,0 +1,294 @@
+# Copyright 2018 D-Wave Systems Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+import unittest
+import random
+
+import dimod
+import dwave_networkx as dnx
+
+from dwave.system.testing import MockDWaveSampler
+from dwave.system.composites import TilingComposite, ParallelEmbeddingComposite
+
+
+class TestParallelEmbeddings(unittest.TestCase):
+
+    def test_most_basic(self):
+        # NB, mock_sampler (GreedySampler or ExactSolver) can solve to optimality.
+        mock_sampler = MockDWaveSampler()
+        embeddings = [
+            {0: (n,)} for n in mock_sampler.nodelist
+        ]  # Single nodes, some embedders don't like this ..
+        sampler = ParallelEmbeddingComposite(mock_sampler, embeddings=embeddings)
+        embeddings = [
+            {idx: (n,) for idx, n in enumerate(e)} for e in mock_sampler.edgelist
+        ]  # Matching
+        sampler = ParallelEmbeddingComposite(mock_sampler, embeddings=embeddings)
+
+
+class TestTiling(unittest.TestCase):
+    """Testing for purposes of TilingComposite deprecation"""
+
+    def test_pegasus_cell(self):
+        # Test trivial case of single cell (K4,4) embedding over defect free
+        mock_sampler = MockDWaveSampler(
+            topology_type="pegasus"
+        )  # P3 structured sampler
+        m = n = mock_sampler.properties["topology"]["shape"][0] - 1
+        self.assertTrue(
+            "topology" in mock_sampler.properties
+            and "type" in mock_sampler.properties["topology"]
+        )
+        self.assertTrue(
+            mock_sampler.properties["topology"]["type"] == "pegasus"
+            and "shape" in mock_sampler.properties["topology"]
+        )
+        source = dnx.chimera_graph(1)
+
+        # By find_multiple_embedding (default)
+        sampler = ParallelEmbeddingComposite(mock_sampler, source=source)
+        h = {node: random.uniform(-1, 1) for node in sampler.structure.nodelist}
+        J = {(u, v): random.uniform(-1, 1) for u, v in sampler.structure.edgelist}
+        expected_number_of_cells = m * n * 3  # Upper bound without tiling
+        num_reads = 10
+        response = sampler.sample_ising(h, J, num_reads=num_reads)
+        self.assertLess(
+            sum(response.record.num_occurrences), expected_number_of_cells * num_reads
+        )
+
+        # By tiling (find_sublattice_embeddings)
+
+    def test_pegasus_multi_cell(self):
+        # Test case of 2x3 nice cell embedding over defect free
+        mock_sampler = MockDWaveSampler(
+            topology_type="pegasus", topology_shape=[8]
+        )  # P8 structured sampler
+        self.assertTrue(
+            "topology" in mock_sampler.properties
+            and "type" in mock_sampler.properties["topology"]
+        )
+        self.assertTrue(
+            mock_sampler.properties["topology"]["type"] == "pegasus"
+            and "shape" in mock_sampler.properties["topology"]
+        )
+        sampler = TilingComposite(mock_sampler, 1, 1)
+        h = {node: random.uniform(-1, 1) for node in sampler.structure.nodelist}
+        J = {(u, v): random.uniform(-1, 1) for u, v in sampler.structure.edgelist}
+
+        m_sub = 2
+        n_sub = 3
+        sampler = TilingComposite(mock_sampler, m_sub, n_sub)
+        h = {node: random.uniform(-1, 1) for node in sampler.structure.nodelist}
+        J = {(u, v): random.uniform(-1, 1) for u, v in sampler.structure.edgelist}
+
+        m = n = mock_sampler.properties["topology"]["shape"][0] - 1
+        expected_number_of_cells = (m // m_sub) * (n // 3) * 3
+        num_reads = 1
+        response = sampler.sample_ising(h, J, num_reads=num_reads)
+        self.assertTrue(
+            sum(response.record.num_occurrences) == expected_number_of_cells * num_reads
+        )
+
+    def test_sample_ising(self):
+        mock_sampler = MockDWaveSampler()  # C4 structured sampler
+
+        sampler = TilingComposite(mock_sampler, 2, 2)
+
+        h = {node: random.uniform(-1, 1) for node in sampler.structure.nodelist}
+        J = {(u, v): random.uniform(-1, 1) for u, v in sampler.structure.edgelist}
+
+        response = sampler.sample_ising(h, J)
+
+    def test_tile_around_hole(self):
+
+        # Create a Chimera C4 structured sampler with a node missing, so that
+        # we have a defect pattern:
+        # OOOX
+        # OOOO
+        # OOOO
+        # OOOO
+        # where O: complete cell, X: incomplete cell
+        mock_sampler = MockDWaveSampler(broken_nodes=[8 * 3])
+        hardware_graph = dnx.chimera_graph(4)  # C4
+
+        # Tile with 2x2 cells:
+        sampler = TilingComposite(mock_sampler, 2, 2, 4)
+        # Given the above chimera graph, check that the embeddings are as
+        # follows:
+        # 00XX
+        # 0011
+        # 2211
+        # 22XX
+        # where 0,1,2: belongs to correspoding embedding, X: not used in any
+        # embedding
+        self.assertSetEqual(
+            {v for s in sampler.embeddings[0].values() for v in s},
+            {
+                linear_index
+                for linear_index, (i, j, u, k) in hardware_graph.nodes(
+                    data="chimera_index"
+                )
+                if i in (0, 1) and j in (0, 1)
+            },
+        )
+        self.assertSetEqual(
+            {v for s in sampler.embeddings[1].values() for v in s},
+            {
+                linear_index
+                for linear_index, (i, j, u, k) in hardware_graph.nodes(
+                    data="chimera_index"
+                )
+                if i in (1, 2) and j in (2, 3)
+            },
+        )
+        self.assertSetEqual(
+            {v for s in sampler.embeddings[2].values() for v in s},
+            {
+                linear_index
+                for linear_index, (i, j, u, k) in hardware_graph.nodes(
+                    data="chimera_index"
+                )
+                if i in (2, 3) and j in (0, 1)
+            },
+        )
+
+    def test_tile_around_node_defects_pegasus(self):
+        pegasus_shape = [5]
+        # Create a pegasus P5 structured solver subject to node defects with the
+        # following (nice-coordinate) 3x4x4 cell-level structure:
+        # OOOX OOOO OOOO
+        # OOOO OOOO OOOO
+        # OOOO OOOO OOOO
+        # OOOO OOOO OOOX
+        # where O: complete cell, X: incomplete cell
+        broken_node_nice_coordinates = [(0, 0, 3, 0, 1), (2, 3, 3, 1, 3)]
+        broken_node_linear_coordinates = [
+            dnx.pegasus_coordinates(pegasus_shape[0]).nice_to_linear(coord)
+            for coord in broken_node_nice_coordinates
+        ]
+        mock_sampler = MockDWaveSampler(
+            topology_type="pegasus",
+            topology_shape=pegasus_shape,
+            broken_nodes=broken_node_linear_coordinates,
+        )
+        # Tile with 2x2 cells:
+        sampler = TilingComposite(mock_sampler, 2, 2, 4)
+
+        # Given the above pegasus graph, check that the embeddings are as
+        # follows:
+        # 00XX  3344 7788
+        # 0011  3344 7788
+        # 2211  5566 99XX
+        # 22XX  5566 99XX
+
+        # Check correct number of embeddings and size of each is sufficient,
+        # given chimera test checks detailed position:
+        self.assertTrue(len(sampler.embeddings) == 10)
+        self.assertFalse(any([len(emb) != 32 for emb in sampler.embeddings]))
+
+        # Can be refined to check exact positioning, but a lot of ugly code:
+        # For visualization in coordinate scheme use:
+        # for emb in sampler.embeddings:
+        #    print({key: dnx.pegasus_coordinates(pegasus_shape[0]).linear_to_nice(next(iter(val)))
+        #           for key,val in emb.items()})
+
+    def test_tile_around_edge_defects_pegasus(self):
+        pegasus_shape = [5]
+
+        # P5 structured sampler with one missing external edge that does not p
+        # prevent tesselation of 2x2 blocks (12 tiles, equivalent to full yield)
+        broken_edges_nice_coordinates = [(0, 1, 0, 0, 0), (0, 2, 0, 0, 0)]
+        broken_edges = [
+            tuple(
+                dnx.pegasus_coordinates(pegasus_shape[0]).nice_to_linear(coord)
+                for coord in broken_edges_nice_coordinates
+            )
+        ]
+        mock_sampler = MockDWaveSampler(
+            topology_type="pegasus",
+            topology_shape=pegasus_shape,
+            broken_edges=broken_edges,
+        )
+        sampler = TilingComposite(mock_sampler, 2, 2, 4)
+        self.assertTrue(len(sampler.embeddings) == 12)
+
+        # P5 structured sampler with one missing internal edge that prevents
+        # tesselation of 2x2 blocks (otherwise 12 tiles, with edge defect 11)
+        broken_edge_nice_coordinates = [(0, 0, 0, 0, 0), (0, 0, 0, 1, 0)]
+        broken_edges = [
+            tuple(
+                dnx.pegasus_coordinates(pegasus_shape[0]).nice_to_linear(coord)
+                for coord in broken_edge_nice_coordinates
+            )
+        ]
+        mock_sampler = MockDWaveSampler(
+            topology_type="pegasus",
+            topology_shape=pegasus_shape,
+            broken_edges=broken_edges,
+        )
+        sampler = TilingComposite(mock_sampler, 2, 2, 4)
+        self.assertTrue(len(sampler.embeddings) == 11)
+
+    def test_sample_ising(self):
+        sampler = TilingComposite(MockDWaveSampler(), 2, 2)
+
+        h = {node: random.uniform(-1, 1) for node in sampler.structure.nodelist}
+        J = {(u, v): random.uniform(-1, 1) for u, v in sampler.structure.edgelist}
+
+        response = sampler.sample_ising(h, J)
+
+        # nothing failed and we got at least one response back per tile
+        self.assertGreaterEqual(len(response), len(sampler.embeddings))
+
+        for sample in response.samples():
+            for v in h:
+                self.assertIn(v, sample)
+
+        for sample, energy in response.data(["sample", "energy"]):
+            self.assertAlmostEqual(dimod.ising_energy(sample, h, J), energy)
+
+    def test_sample_qubo(self):
+        sampler = TilingComposite(MockDWaveSampler(), 2, 2)
+
+        Q = {(u, v): random.uniform(-1, 1) for u, v in sampler.structure.edgelist}
+        Q.update(
+            {(node, node): random.uniform(-1, 1) for node in sampler.structure.nodelist}
+        )
+
+        response = sampler.sample_qubo(Q)
+
+        # nothing failed and we got at least one response back per tile
+        self.assertGreaterEqual(len(response), len(sampler.embeddings))
+
+        for sample in response.samples():
+            for u, v in Q:
+                self.assertIn(v, sample)
+                self.assertIn(u, sample)
+
+        for sample, energy in response.data(["sample", "energy"]):
+            self.assertAlmostEqual(dimod.qubo_energy(sample, Q), energy)
+
+    def test_too_many_nodes(self):
+        mock_sampler = MockDWaveSampler()  # C4 structured sampler
+
+        sampler = TilingComposite(mock_sampler, 2, 2)
+
+        h = {0: -1, 1: 1}
+        J = {}
+
+        response = sampler.sample_ising(h, J)
+
+        __, num_columns = response.record.sample.shape
+
+        self.assertEqual(num_columns, 2)


### PR DESCRIPTION
A composite for parallelizing job submissions across structured samplers (i.e. the QPU)

Using minorminer sublattice mappings, this composite should allow us to mark the TilingComposite as deprecated, tiling is a special case of the functionality supported (see examples and tests - all tests passed by TilingComposite are emulated in the new code) 

Closes several open issues including tiling support for Zephyr (Adv2) :
https://github.com/dwavesystems/dwave-system/issues/456
https://github.com/dwavesystems/dwave-system/issues/180
https://github.com/dwavesystems/dwave-system/issues/213
It provides an enhanced solution to some other closed cases, like support for advantage: https://github.com/dwavesystems/dwave-system/issues/213