### PR TITLE
Generate energy scales for a custom annealing schedule 

### DIFF
--- a/docs/utilities.rst
+++ b/docs/utilities.rst
@@ -13,6 +13,7 @@ Utilities
 
    anneal_schedule_with_offset
    common_working_graph
+   energy_scales_custom_schedule
 
 .. currentmodule:: dwave.system.coupling_groups
 

--- a/dwave/system/utilities.py
+++ b/dwave/system/utilities.py
@@ -232,14 +232,14 @@ def anneal_schedule_with_offset(
 
 
 def energy_scales_custom_schedule(
-        default_schedule: Union[np.typing.ArrayLike, list, list[list[float]], None] = None,
-        s: Union[np.typing.ArrayLike, list, None] = None,
-        A: Union[np.typing.ArrayLike, list, None] = None,
-        B: Union[np.typing.ArrayLike, list, None] = None,
-        c: Union[np.typing.ArrayLike, list, None] = None,
-        custom_schedule: Union[np.typing.ArrayLike, list, list[list[float]], None] = None,
-        custom_t: Union[np.typing.ArrayLike, list, None] = None,
-        custom_s: Union[np.typing.ArrayLike, list, None] = None,
+        default_schedule: Union[np.typing.ArrayLike, list[list[float]], None] = None,
+        s: Union[np.typing.ArrayLike, list[float], None] = None,
+        A: Union[np.typing.ArrayLike, list[float], None] = None,
+        B: Union[np.typing.ArrayLike, list[float], None] = None,
+        c: Union[np.typing.ArrayLike, list[float], None] = None,
+        custom_schedule: Union[np.typing.ArrayLike, list[list[float]], None] = None,
+        custom_t: Union[np.typing.ArrayLike, list[float], None] = None,
+        custom_s: Union[np.typing.ArrayLike, list[float], None] = None,
     ) -> np.ndarray:
     r"""Generates the energy scales for a custom anneal schedule.
 
@@ -368,7 +368,7 @@ def energy_scales_custom_schedule(
         custom_t = _asarray('custom_t', custom_t, 1)
         custom_s = _asarray('custom_s', custom_s, 1)
 
-    precision_s = - np.log10(np.median(np.diff(s)))
+    precision_s = -np.log10(np.median(np.diff(s)))
     custom_s = np.round(custom_s, decimals=int(precision_s))
 
     out = np.empty((0, 5))

--- a/dwave/system/utilities.py
+++ b/dwave/system/utilities.py
@@ -231,7 +231,7 @@ def anneal_schedule_with_offset(
     return np.column_stack((s, A_offset, B_offset, c_offset))
 
 
-def slope(t_span, s_span, s, A, B, c, interval):
+def _slope(t_span, s_span, s, A, B, c, interval):
     "Return energy scales for a sloped interval."
     t_interp = np.interp(
         s[interval],
@@ -416,7 +416,7 @@ def energy_scales_custom_schedule(
                 if index == len(custom_s) - 1:
                     interval = (s <= custom_s[index]) & (s >= custom_s[index - 1])
 
-            out_interval = slope(
+            out_interval = _slope(
                 [custom_t[index - 1], custom_t[index]],
                 sorted([custom_s[index- 1], custom_s[index]]),
                 s,

--- a/dwave/system/utilities.py
+++ b/dwave/system/utilities.py
@@ -272,8 +272,8 @@ def energy_scales_custom_schedule(
     :ref:`qpu_qa_anneal_sched` section of the :ref:`qpu_annealing` page.
 
     This function accepts a quantum computer's default anneal schedule and your
-    :ref:`parameter_qpu_anneal_schedule` parameter's schedule, and returns the
-    energy scales as a function of time.
+    custom schedule (as defined by the :ref:`parameter_qpu_anneal_schedule`
+    parameter), and returns the energy scales as a function of time.
 
     Args:
         default_schedule:
@@ -406,15 +406,15 @@ def energy_scales_custom_schedule(
 
         else:   # This is a sloped interval
 
-            if custom_s[index - 1] != 1:   # Forward-anneal interval
-
-                interval = (s < custom_s[index]) & (s >= custom_s[index - 1])
-                if index == len(custom_s) - 1:  # Last interval should include the 1
-                    interval = (s <= custom_s[index]) & (s >= custom_s[index - 1])
-
-            else:# Reverse-anneal interval
+            if custom_s[index - 1] == 1:            # Reverse-anneal interval
 
                 interval = (s >= custom_s[index]) & (s <= 1)
+
+            else:                                   # Forward-anneal interval
+                interval = (s < custom_s[index]) & (s >= custom_s[index - 1])
+                # Last interval should include the 1
+                if index == len(custom_s) - 1:
+                    interval = (s <= custom_s[index]) & (s >= custom_s[index - 1])
 
             out_interval = slope(
                 [custom_t[index - 1], custom_t[index]],

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -236,7 +236,7 @@ class TestEnergyScalesCustomSchedule(unittest.TestCase):
         out= energy_scales_custom_schedule(
             default_schedule=self.schedule_default,
             custom_schedule=simple_forward_schedule)
-        self.assertTrue(len(out) == len(self.schedule_default))
+        self.assertEqual(len(out), len(self.schedule_default))
 
         # Schedule for one, vectors for the other, as lists
         out= energy_scales_custom_schedule(
@@ -291,7 +291,7 @@ class TestEnergyScalesCustomSchedule(unittest.TestCase):
         out= energy_scales_custom_schedule(
             default_schedule=self.schedule_default,
             custom_schedule=schedule)
-        self.assertTrue(np.shape(out) == (11,5))
+        self.assertEqual(np.shape(out), (11,5))
 
         # Simple forward schedule with noisy s intervals
         schedule = np.asarray([
@@ -303,7 +303,7 @@ class TestEnergyScalesCustomSchedule(unittest.TestCase):
         out= energy_scales_custom_schedule(
             default_schedule=self.schedule_default,
             custom_schedule=schedule)
-        self.assertTrue(np.shape(out) == (11,5))
+        self.assertEqual(np.shape(out), (11,5))
 
         # Test that at the interval seams, the interpolated time is closest
         np.testing.assert_equal(
@@ -322,7 +322,7 @@ class TestEnergyScalesCustomSchedule(unittest.TestCase):
         out= energy_scales_custom_schedule(
             default_schedule=self.schedule_default,
             custom_schedule=schedule)
-        self.assertTrue(np.shape(out) == (11 + 3,5))    #Three pauses
+        self.assertEqual(np.shape(out), (11 + 3,5))    #Three pauses
 
         # Forward schedule with pauses and noisy intervals
         schedule = np.asarray([
@@ -336,7 +336,7 @@ class TestEnergyScalesCustomSchedule(unittest.TestCase):
         out= energy_scales_custom_schedule(
             default_schedule=self.schedule_default,
             custom_schedule=schedule)
-        self.assertTrue(np.shape(out) == (11 + 3,5))    #Three pauses
+        self.assertEqual(np.shape(out), (11 + 3,5))    #Three pauses
         # Where interpolated time is closest to custom time, custom s is closest to s
         min_t_inx = [np.argmin(np.abs(out[:,0] - t)) for t in np.asarray(schedule)[:,0]]
         np.testing.assert_allclose(
@@ -352,7 +352,7 @@ class TestEnergyScalesCustomSchedule(unittest.TestCase):
         out= energy_scales_custom_schedule(
             default_schedule=self.schedule_default,
             custom_schedule=schedule)
-        self.assertTrue(np.shape(out) == (2*0.7*10 + 1,5))
+        self.assertEqual(np.shape(out), (2*0.7*10 + 1,5))
 
         # Messy reverse anneal schedule
         t_expected = np.asarray(

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -356,9 +356,9 @@ class TestEnergyScalesCustomSchedule(unittest.TestCase):
 
         # Messy reverse anneal schedule
         t_expected = np.asarray(
-            [0, 6.66, 13.33, 80, 83.33, 87.03, 90, 100, 153, 170, 200])
+            [0, 6.66, 13.33, 20, 35, 50, 80, 83.33, 86.6, 90, 100, 150, 170, 200])
         B_expected = np.asarray(
-            [16., 14., 12.,  5.,  7.,  9., 12., 12., 12., 14., 16.])
+            [16., 14., 12., 9.,  7.,  5.,  5.,  7.,  9., 12., 12., 12., 14., 16.])
         schedule = np.asarray([
             [0, 1],
             [20, 0.7],

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -21,7 +21,8 @@ import dwave_networkx as dnx
 
 from dwave.cloud.testing import isolated_environ
 
-from dwave.system import anneal_schedule_with_offset, common_working_graph
+from dwave.system import (anneal_schedule_with_offset, common_working_graph,
+    energy_scales_custom_schedule)
 from dwave.system.utilities import FeatureFlags
 
 
@@ -207,3 +208,169 @@ class TestAnnealScheduleWithOffset(unittest.TestCase):
                 B = np.asarray(anneal_schedule)[:,2],
                 c = np.asarray(anneal_schedule)[:,3],
                 )
+
+
+class TestEnergyScalesCustomSchedule(unittest.TestCase):
+
+    schedule_default = [
+        [ 0. ,  9.3,  0. ,  0.1],
+        [ 0.1,  9. ,  0.5,  0.2],
+        [ 0.2,  8. ,  1.2,  0.4],
+        [ 0.3,  7. ,  1.7,  0.5],
+        [ 0.4,  6. ,  3. ,  0.7],
+        [ 0.5,  5. ,  5. ,  0.8],
+        [ 0.6,  4. ,  7. ,  1. ],
+        [ 0.7,  3. ,  9. ,  2. ],
+        [ 0.8,  2. , 12. ,  3. ],
+        [ 0.9,  1. , 14. ,  4. ],
+        [ 1. ,  0. , 16. ,  8. ]]
+
+    def test_input_verification(self):
+
+        simple_forward_schedule = [
+            [0, 0],
+            [20, 0.3],
+            [100, 1]]
+
+        # Schedules for both, as lists
+        out= energy_scales_custom_schedule(
+            default_schedule=self.schedule_default,
+            custom_schedule=simple_forward_schedule)
+        self.assertTrue(len(out) == len(self.schedule_default))
+
+        # Schedule for one, vectors for the other, as lists
+        out= energy_scales_custom_schedule(
+            s=[s/10 for s in range(11)],
+            A=[a for a in range(10,-1,-1)],
+            B=[b for b in range(11)],
+            c=[c/8 for c in range(11)],
+            custom_schedule=simple_forward_schedule)
+
+        # Numpy schedule and mix of Numpy and list for vectors
+        out= energy_scales_custom_schedule(
+            s=[s/10 for s in range(11)],
+            A=np.asarray([a for a in range(10,-1,-1)]),
+            B=[b for b in range(11)],
+            c=np.asarray([c/8 for c in range(11)]),
+            custom_schedule=np.asarray(simple_forward_schedule))
+
+        # Both schedule and vector
+        with self.assertRaises(ValueError):
+            energy_scales_custom_schedule(
+                default_schedule=self.schedule_default,
+                s=[s/10 for s in range(11)],
+                custom_schedule=simple_forward_schedule)
+
+        # Both schedule and vector
+        with self.assertRaises(ValueError):
+            energy_scales_custom_schedule(
+                default_schedule=self.schedule_default,
+                s=[s/10 for s in range(11)],
+                custom_schedule=simple_forward_schedule)
+
+        # Missing schedule
+        with self.assertRaises(ValueError):
+            energy_scales_custom_schedule(
+                default_schedule=self.schedule_default)
+
+        # Missing vector
+        with self.assertRaises(ValueError):
+            energy_scales_custom_schedule(
+                s=[s/10 for s in range(11)],
+                A=np.asarray([a for a in range(10,-1,-1)]),
+                B=[b for b in range(11)],
+                custom_schedule=simple_forward_schedule)
+
+    def test_various_schedules(self):
+
+        # Simple forward schedule that coincides with default schedule's s intervals
+        schedule = [
+            [0, 0],
+            [20, 0.3],
+            [100, 1]]
+        out= energy_scales_custom_schedule(
+            default_schedule=self.schedule_default,
+            custom_schedule=schedule)
+        self.assertTrue(np.shape(out) == (11,5))
+
+        # Simple forward schedule with noisy s intervals
+        schedule = np.asarray([
+            [0, 0],
+            [20, 0.31],
+            [50, 0.69],
+            [80, 0.9],
+            [100, 1]])
+        out= energy_scales_custom_schedule(
+            default_schedule=self.schedule_default,
+            custom_schedule=schedule)
+        self.assertTrue(np.shape(out) == (11,5))
+
+        # Test that at the interval seams, the interpolated time is closest
+        np.testing.assert_equal(
+            [np.argmin(np.abs(out[:,1] - s)) for s in np.asarray(schedule)[:,1]],
+            [np.argmin(np.abs(out[:,0] - t)) for t in np.asarray(schedule)[:,0]])
+
+        # Forward schedule with pauses
+        schedule = np.asarray([
+            [0, 0],
+            [20, 0.3],
+            [50, 0.3],
+            [80, 0.8],
+            [90, 0.8],
+            [100, 0.8],
+            [200, 1]])
+        out= energy_scales_custom_schedule(
+            default_schedule=self.schedule_default,
+            custom_schedule=schedule)
+        self.assertTrue(np.shape(out) == (11 + 3,5))    #Three pauses
+
+        # Forward schedule with pauses and noisy intervals
+        schedule = np.asarray([
+            [0, 0],
+            [20, 0.31],
+            [50, 0.31],
+            [80, 0.78],
+            [90, 0.78],
+            [100, 0.78],
+            [200, 1]])
+        out= energy_scales_custom_schedule(
+            default_schedule=self.schedule_default,
+            custom_schedule=schedule)
+        self.assertTrue(np.shape(out) == (11 + 3,5))    #Three pauses
+        # Where interpolated time is closest to custom time, custom s is closest to s
+        min_t_inx = [np.argmin(np.abs(out[:,0] - t)) for t in np.asarray(schedule)[:,0]]
+        np.testing.assert_allclose(
+            out[min_t_inx][:,1],
+            schedule[:,1],
+            atol=0.1)
+
+        # Simple reverse schedule that coincides with default schedule's s intervals
+        schedule = [
+            [0, 1],
+            [20, 0.3],
+            [100, 1]]
+        out= energy_scales_custom_schedule(
+            default_schedule=self.schedule_default,
+            custom_schedule=schedule)
+        self.assertTrue(np.shape(out) == (2*0.7*10 + 1,5))
+
+        # Messy reverse anneal schedule
+        t_expected = np.asarray(
+            [0, 6.66, 13.33, 80, 83.33, 87.03, 90, 100, 153, 170, 200])
+        B_expected = np.asarray(
+            [16., 14., 12.,  5.,  7.,  9., 12., 12., 12., 14., 16.])
+        schedule = np.asarray([
+            [0, 1],
+            [20, 0.7],
+            [50, 0.51],
+            [80, 0.51],
+            [90, 0.78],
+            [100, 0.78],
+            [150, 0.78],
+            [170, 0.9],
+            [200, 1]])
+        out= energy_scales_custom_schedule(
+            default_schedule=self.schedule_default,
+            custom_schedule=schedule)
+        np.testing.assert_allclose(out[:,0], t_expected, atol=1)
+        np.testing.assert_allclose(out[:,3], B_expected, atol=1)


### PR DESCRIPTION
For DOC-759, will need to be referenced from [Varying the Global Anneal Schedule](https://docs.dwavequantum.com/en/latest/quantum_research/annealing.html#varying-the-global-anneal-schedule) page once in the SDK.