### PR TITLE
Fix docbuild warnings on scoped close

### DIFF
--- a/docs/embedding.rst
+++ b/docs/embedding.rst
@@ -117,7 +117,7 @@ Callable Objects
 ----------------
 
 .. autosummary::
-   :toctree: minimize_energy
+   :toctree: generated/
 
    chain_breaks.MinimizeEnergy
 

--- a/dwave/system/composites/cutoffcomposite.py
+++ b/dwave/system/composites/cutoffcomposite.py
@@ -55,7 +55,8 @@ class CutOffComposite(dimod.ComposedSampler):
             value. Defaults to :func:`operator.lt`.
 
     .. versionadded:: 1.30.0
-        Support for context manager protocol and :meth:`.close` method.
+        Support for context manager protocol and :meth:`~dimod.Scoped.close`
+        method.
 
     Examples:
         This example removes one interaction, ``'ac': -0.7``, before embedding
@@ -236,7 +237,8 @@ class PolyCutOffComposite(dimod.ComposedPolySampler):
             value. Defaults to :func:`operator.lt`.
 
     .. versionadded:: 1.30.0
-        Support for context manager protocol and :meth:`.close` method.
+        Support for context manager protocol and :meth:`~dimod.Scoped.close`
+        method.
 
     Examples:
         This example removes one interaction, ``'ac': 0.2``, before submitting

--- a/dwave/system/composites/cutoffcomposite.py
+++ b/dwave/system/composites/cutoffcomposite.py
@@ -55,8 +55,8 @@ class CutOffComposite(dimod.ComposedSampler):
             value. Defaults to :func:`operator.lt`.
 
     .. versionadded:: 1.30.0
-        Support for context manager protocol and :meth:`~dimod.Scoped.close`
-        method.
+        Support for context manager protocol with :meth:`dimod.Scoped`
+        implemented.
 
     Examples:
         This example removes one interaction, ``'ac': -0.7``, before embedding
@@ -237,8 +237,8 @@ class PolyCutOffComposite(dimod.ComposedPolySampler):
             value. Defaults to :func:`operator.lt`.
 
     .. versionadded:: 1.30.0
-        Support for context manager protocol and :meth:`~dimod.Scoped.close`
-        method.
+        Support for context manager protocol with :meth:`dimod.Scoped`
+        implemented.
 
     Examples:
         This example removes one interaction, ``'ac': 0.2``, before submitting

--- a/dwave/system/composites/embedding.py
+++ b/dwave/system/composites/embedding.py
@@ -74,7 +74,8 @@ class EmbeddingComposite(dimod.ComposedSampler):
             Defaults to :func:`dimod.child_structure_dfs`.
 
     .. versionadded:: 1.30.0
-        Support for context manager protocol and :meth:`.close` method.
+        Support for context manager protocol and :meth:`~dimod.Scoped.close`
+        method.
 
     Examples:
 
@@ -335,7 +336,8 @@ class LazyFixedEmbeddingComposite(EmbeddingComposite, dimod.Structured):
             arguments.
 
     .. versionadded:: 1.30.0
-        Support for context manager protocol and :meth:`.close` method.
+        Support for context manager protocol and :meth:`~dimod.Scoped.close`
+        method.
 
     Examples:
 
@@ -530,7 +532,8 @@ class FixedEmbeddingComposite(LazyFixedEmbeddingComposite):
             keyword arguments are ignored.
 
     .. versionadded:: 1.30.0
-        Support for context manager protocol and :meth:`.close` method.
+        Support for context manager protocol and :meth:`~dimod.Scoped.close`
+        method.
 
     Examples:
         To embed a triangular problem (a problem with a three-node complete graph,
@@ -610,7 +613,8 @@ class AutoEmbeddingComposite(EmbeddingComposite):
             arguments.
 
     .. versionadded:: 1.30.0
-        Support for context manager protocol and :meth:`.close` method.
+        Support for context manager protocol and :meth:`~dimod.Scoped.close`
+        method.
 
     """
     def __init__(self, child_sampler, **kwargs):

--- a/dwave/system/composites/embedding.py
+++ b/dwave/system/composites/embedding.py
@@ -74,8 +74,8 @@ class EmbeddingComposite(dimod.ComposedSampler):
             Defaults to :func:`dimod.child_structure_dfs`.
 
     .. versionadded:: 1.30.0
-        Support for context manager protocol and :meth:`~dimod.Scoped.close`
-        method.
+        Support for context manager protocol with :meth:`dimod.Scoped`
+        implemented.
 
     Examples:
 
@@ -336,8 +336,8 @@ class LazyFixedEmbeddingComposite(EmbeddingComposite, dimod.Structured):
             arguments.
 
     .. versionadded:: 1.30.0
-        Support for context manager protocol and :meth:`~dimod.Scoped.close`
-        method.
+        Support for context manager protocol with :meth:`dimod.Scoped`
+        implemented.
 
     Examples:
 
@@ -532,8 +532,8 @@ class FixedEmbeddingComposite(LazyFixedEmbeddingComposite):
             keyword arguments are ignored.
 
     .. versionadded:: 1.30.0
-        Support for context manager protocol and :meth:`~dimod.Scoped.close`
-        method.
+        Support for context manager protocol with :meth:`dimod.Scoped`
+        implemented.
 
     Examples:
         To embed a triangular problem (a problem with a three-node complete graph,
@@ -613,8 +613,8 @@ class AutoEmbeddingComposite(EmbeddingComposite):
             arguments.
 
     .. versionadded:: 1.30.0
-        Support for context manager protocol and :meth:`~dimod.Scoped.close`
-        method.
+        Support for context manager protocol with :meth:`dimod.Scoped`
+        implemented.
 
     """
     def __init__(self, child_sampler, **kwargs):

--- a/dwave/system/composites/linear_ancilla.py
+++ b/dwave/system/composites/linear_ancilla.py
@@ -42,8 +42,8 @@ class LinearAncillaComposite(dimod.ComposedSampler, dimod.Structured):
             that has flux bias controls.
 
     .. versionadded:: 1.30.0
-        Support for context manager protocol and :meth:`~dimod.Scoped.close`
-        method.
+        Support for context manager protocol with :meth:`dimod.Scoped`
+        implemented.
 
     Examples:
         This example submits a two-qubit problem consisting of linear biases with opposed signs 

--- a/dwave/system/composites/linear_ancilla.py
+++ b/dwave/system/composites/linear_ancilla.py
@@ -42,7 +42,8 @@ class LinearAncillaComposite(dimod.ComposedSampler, dimod.Structured):
             that has flux bias controls.
 
     .. versionadded:: 1.30.0
-        Support for context manager protocol and :meth:`.close` method.
+        Support for context manager protocol and :meth:`~dimod.Scoped.close`
+        method.
 
     Examples:
         This example submits a two-qubit problem consisting of linear biases with opposed signs 

--- a/dwave/system/composites/reversecomposite.py
+++ b/dwave/system/composites/reversecomposite.py
@@ -39,7 +39,8 @@ class ReverseAdvanceComposite(dimod.ComposedSampler):
             A dimod sampler.
 
     .. versionadded:: 1.30.0
-        Support for context manager protocol and :meth:`.close` method.
+        Support for context manager protocol and :meth:`~dimod.Scoped.close`
+        method.
 
     Examples:
        This example runs 100 reverse anneals each for three schedules on a problem
@@ -206,7 +207,8 @@ class ReverseBatchStatesComposite(dimod.ComposedSampler, dimod.Initialized):
             A dimod sampler.
 
     .. versionadded:: 1.30.0
-        Support for context manager protocol and :meth:`.close` method.
+        Support for context manager protocol and :meth:`~dimod.Scoped.close`
+        method.
 
     Examples:
        This example runs three reverse anneals from two configured and one 

--- a/dwave/system/composites/reversecomposite.py
+++ b/dwave/system/composites/reversecomposite.py
@@ -39,8 +39,8 @@ class ReverseAdvanceComposite(dimod.ComposedSampler):
             A dimod sampler.
 
     .. versionadded:: 1.30.0
-        Support for context manager protocol and :meth:`~dimod.Scoped.close`
-        method.
+        Support for context manager protocol with :meth:`dimod.Scoped`
+        implemented.
 
     Examples:
        This example runs 100 reverse anneals each for three schedules on a problem
@@ -207,8 +207,8 @@ class ReverseBatchStatesComposite(dimod.ComposedSampler, dimod.Initialized):
             A dimod sampler.
 
     .. versionadded:: 1.30.0
-        Support for context manager protocol and :meth:`~dimod.Scoped.close`
-        method.
+        Support for context manager protocol with :meth:`dimod.Scoped`
+        implemented.
 
     Examples:
        This example runs three reverse anneals from two configured and one 

--- a/dwave/system/composites/tiling.py
+++ b/dwave/system/composites/tiling.py
@@ -76,7 +76,8 @@ class TilingComposite(dimod.Composite, dimod.Structured, dimod.Sampler):
            cell.
 
     .. versionadded:: 1.30.0
-        Support for context manager protocol and :meth:`.close` method.
+        Support for context manager protocol and :meth:`~dimod.Scoped.close`
+        method.
 
     Examples:
        This example submits a two-variable QUBO problem representing a logical

--- a/dwave/system/composites/tiling.py
+++ b/dwave/system/composites/tiling.py
@@ -76,8 +76,8 @@ class TilingComposite(dimod.Composite, dimod.Structured, dimod.Sampler):
            cell.
 
     .. versionadded:: 1.30.0
-        Support for context manager protocol and :meth:`~dimod.Scoped.close`
-        method.
+        Support for context manager protocol with :meth:`dimod.Scoped`
+        implemented.
 
     Examples:
        This example submits a two-variable QUBO problem representing a logical


### PR DESCRIPTION
Currently build issues multiple warnings on the `dimod.Scoped.close` method references and mostly links to cloud-client's close method.
```
 CutOffComposite:26: WARNING: more than one target found for cross-reference 'close': dwave.system.samplers.DWaveCliqueSampler.close, dwave.system.samplers.DWaveSampler.close, dwave.system.samplers.LeapHybridCQMSampler.close, dwave.system.samplers.LeapHybridDQMSampler.close, dwave.system.samplers.LeapHybridNLSampler.close, dwave.system.samplers.LeapHybridSampler.close
```

Also, [chain_breaks.MinimizeEnergy](https://docs.dwavequantum.com/en/latest/ocean/api_ref_system/embedding.html#callable-objects) always adding its own directory for the RST stub has long been an annoyance.  