### PR TITLE
Release 1.32.0

### DIFF
--- a/dwave/system/package_info.py
+++ b/dwave/system/package_info.py
@@ -14,7 +14,7 @@
 
 __all__ = ['__version__', '__author__', '__authoremail__', '__description__']
 
-__version__ = '1.31.0'
+__version__ = '1.32.0'
 __author__ = 'D-Wave Systems Inc.'
 __authoremail__ = 'tools@dwavesys.com'
 __description__ = 'All things D-Wave System.'


### PR DESCRIPTION
### New Features

- Add `ParallelEmbeddingComposite`, a generalization of the `TilingComposite` that can handle bigger and non-Chimera source graphs on any structured graph supported by `DWaveSampler` (including Zephyr). See [\#569](https://github.com/dwavesystems/dwave-system/pull/569).

### Deprecation Notes

- `TilingComposite` is deprecated in favor of `ParallelEmbeddingComposite` and it will be removed in dwave-system 2.0. See [\#577](https://github.com/dwavesystems/dwave-system/pull/577).

### Upgrade Notes

- Switch from pkgutil to native namespace package. See [\#571](https://github.com/dwavesystems/dwave-system/pull/571).