### PR TITLE
Speed-up embedding composites for subgraph embeddings

### DIFF
--- a/dwave/embedding/chain_strength.py
+++ b/dwave/embedding/chain_strength.py
@@ -15,20 +15,21 @@
 """Utility functions for calculating chain strength.
 
 Examples:
-    This example uses :func:`uniform_torque_compensation`, given a prefactor of 2,
+    This example uses :func:`uniform_torque_compensation`, given a prefactor of 3,
     to calculate a chain strength that :class:`EmbeddingComposite` then uses.
 
+    >>> import numpy as np
     >>> from functools import partial
     >>> from dwave.system import EmbeddingComposite, DWaveSampler
     >>> from dwave.embedding.chain_strength import uniform_torque_compensation
     ...
-    >>> Q = {(0,0): 1, (1,1): 1, (2,3): 2, (1,2): -2, (0,3): -2}
+    >>> Q = np.triu(np.ones((5, 5)))        # K5 with all biases set to 1.0
     >>> sampler = EmbeddingComposite(DWaveSampler())
     >>> # partial() can be used when the BQM or embedding is not accessible
-    >>> chain_strength = partial(uniform_torque_compensation, prefactor=2)
+    >>> chain_strength = partial(uniform_torque_compensation, prefactor=3)
     >>> sampleset = sampler.sample_qubo(Q, chain_strength=chain_strength, return_embedding=True)
     >>> sampleset.info['embedding_context']['chain_strength']
-    1.224744871391589
+    1.5
 
 """
 import math

--- a/dwave/embedding/transforms.py
+++ b/dwave/embedding/transforms.py
@@ -185,7 +185,8 @@ class EmbeddedStructure(dict):
         if self.max_chain_length != 1:
             raise TypeError("Embedding without chains required for relabeling")
 
-        mapping = {n: next(iter(c)) for n, c in self.items()}
+        # TODO: drop var filtering after https://github.com/dwavesystems/dimod/issues/1408 is fixed
+        mapping = {n: next(iter(c)) for n, c in self.items() if n in source_bqm.variables}
         target_bqm = source_bqm.relabel_variables(mapping, inplace=False)
 
         return target_bqm

--- a/dwave/embedding/transforms.py
+++ b/dwave/embedding/transforms.py
@@ -16,12 +16,11 @@ import collections.abc as abc
 import itertools
 import typing
 import warnings
+from collections import defaultdict
+from functools import cached_property
 
 import numpy as np
 import dimod
-
-from collections import defaultdict
-from copy import deepcopy
 
 from dwave.embedding.chain_breaks import majority_vote, broken_chains
 from dwave.embedding.exceptions import MissingEdgeError, MissingChainError, InvalidNodeError, DisconnectedChainError
@@ -121,16 +120,11 @@ class EmbeddedStructure(dict):
         """callable: Return the chain strength selected for embedding."""
         return self._chain_strength
 
-    @property
+    @cached_property
     def max_chain_length(self):
         """Maximum chain length in the embedding."""
         # we can cache the max chain length since we're immutable
-        try:
-            return self._max_chain_length
-        except AttributeError:
-            pass
-        self._max_chain_length = len(max(self.values(), default=[], key=len))
-        return self._max_chain_length
+        return len(max(self.values(), default=[], key=len))
 
     def chain_edges(self, u):
         """Iterate over edges contained in the chain for u.

--- a/dwave/embedding/transforms.py
+++ b/dwave/embedding/transforms.py
@@ -543,16 +543,15 @@ def _relabel_sampleset(target_sampleset: dimod.SampleSet,
     mapping = {next(iter(c)): n for n, c in embedding.items()}
     source_sampleset = target_sampleset.relabel_variables(mapping, inplace=True)
 
-    # to make the interface compatible with `unembed_sampleset`
+    # to make the unembedding interface backwards-compatible
     if chain_break_fraction:
         source_sampleset = dimod.append_data_vectors(
             source_sampleset, chain_break_fraction=np.zeros(len(source_sampleset)))
 
     if return_embedding:
-        if chain_break_method is None:
-            chain_break_method = majority_vote
+        # we explicitly mark no chain break resolution was needed during unembedding
         embedding_context = dict(
-            embedding=embedding, chain_break_method=chain_break_method.__name__)
+            embedding=embedding, chain_break_method=None)
         source_sampleset.info.update(embedding_context=embedding_context)
 
     return source_sampleset

--- a/dwave/embedding/transforms.py
+++ b/dwave/embedding/transforms.py
@@ -14,6 +14,7 @@
 
 import collections.abc as abc
 import itertools
+import typing
 import warnings
 
 import numpy as np
@@ -120,6 +121,17 @@ class EmbeddedStructure(dict):
         """callable: Return the chain strength selected for embedding."""
         return self._chain_strength
 
+    @property
+    def max_chain_length(self):
+        """Maximum chain length in the embedding."""
+        # we can cache the max chain length since we're immutable
+        try:
+            return self._max_chain_length
+        except AttributeError:
+            pass
+        self._max_chain_length = len(max(self.values(), default=[], key=len))
+        return self._max_chain_length
+
     def chain_edges(self, u):
         """Iterate over edges contained in the chain for u.
 
@@ -134,7 +146,6 @@ class EmbeddedStructure(dict):
         emb_u = self[u]
         for i, j in self._chain_edges[u]:
             yield emb_u[i], emb_u[j]
-
 
     def interaction_edges(self, u, *args):
         """Iterate over edges between in the chains for u and v.
@@ -175,6 +186,15 @@ class EmbeddedStructure(dict):
         EmbeddedStructure class, but exists because dict is the parent class."""
         raise NotImplementedError("EmbeddedStructure does not support the"
                                   " fromkeys method")
+
+    def _relabel_bqm(self, source_bqm: dimod.BQM) -> dimod.BQM:
+        if self.max_chain_length != 1:
+            raise TypeError("Embedding without chains required for relabeling")
+
+        mapping = {n: next(iter(c)) for n, c in self.items()}
+        target_bqm = source_bqm.relabel_variables(mapping, inplace=False)
+
+        return target_bqm
 
     def embed_bqm(self, source_bqm, chain_strength=None, smear_vartype=None):
         """Embed a binary quadratic model onto a target graph.
@@ -226,6 +246,10 @@ class EmbeddedStructure(dict):
             :func:`.embed_ising`, :func:`.embed_qubo`
 
         """
+        # short-circuit the expensive embedding in case of a simple 1-1 mapping
+        if self.max_chain_length == 1:
+            return self._relabel_bqm(source_bqm)
+
         return_vartype = source_bqm.vartype
         if smear_vartype is None:
             smear_vartype = return_vartype
@@ -510,6 +534,36 @@ def embed_qubo(source_Q, embedding, target_adjacency, chain_strength=None):
     return target_Q
 
 
+def _relabel_sampleset(target_sampleset: dimod.SampleSet,
+                       embedding: EmbeddedStructure,
+                       source_bqm: dimod.BQM,
+                       chain_break_method: typing.Optional[typing.Any] = None,
+                       chain_break_fraction: bool = False,
+                       return_embedding: bool = False
+                       ) -> dimod.SampleSet:
+    """Unembed a sample set in the special case of 1-to-1 variable embedding."""
+
+    if embedding.max_chain_length != 1:
+        raise TypeError("Embedding without chains required for relabeling")
+
+    mapping = {next(iter(c)): n for n, c in embedding.items()}
+    source_sampleset = target_sampleset.relabel_variables(mapping, inplace=True)
+
+    # to make the interface compatible with `unembed_sampleset`
+    if chain_break_fraction:
+        source_sampleset = dimod.append_data_vectors(
+            source_sampleset, chain_break_fraction=np.zeros(len(source_sampleset)))
+
+    if return_embedding:
+        if chain_break_method is None:
+            chain_break_method = majority_vote
+        embedding_context = dict(
+            embedding=embedding, chain_break_method=chain_break_method.__name__)
+        source_sampleset.info.update(embedding_context=embedding_context)
+
+    return source_sampleset
+
+
 def unembed_sampleset(target_sampleset, embedding, source_bqm,
                       chain_break_method=None, chain_break_fraction=False,
                       return_embedding=False):
@@ -570,6 +624,15 @@ def unembed_sampleset(target_sampleset, embedding, source_bqm,
                [ 1,  1,  1]], dtype=int8)
 
     """
+
+    # short-circuit the expensive unembedding in case of a simple 1-1 mapping
+    if hasattr(embedding, 'max_chain_length') and embedding.max_chain_length == 1:
+        return _relabel_sampleset(target_sampleset=target_sampleset,
+                                  embedding=embedding,
+                                  source_bqm=source_bqm,
+                                  chain_break_method=chain_break_method,
+                                  chain_break_fraction=chain_break_fraction,
+                                  return_embedding=return_embedding)
 
     if chain_break_method is None:
         chain_break_method = majority_vote

--- a/dwave/system/composites/embedding.py
+++ b/dwave/system/composites/embedding.py
@@ -50,6 +50,10 @@ class EmbeddingComposite(dimod.ComposedSampler):
     D-Wave quantum computer. A new minor-embedding is calculated each time one 
     of its sampling methods is called.
 
+    In case a native embedding is found (one to one mapping between source and
+    target variables), embedding and unembedding steps are simplified as they
+    are reduced to variable relabeling.
+
     Args:
         child_sampler (:class:`dimod.Sampler`):
             A dimod sampler, such as a :obj:`DWaveSampler`, that accepts
@@ -76,6 +80,10 @@ class EmbeddingComposite(dimod.ComposedSampler):
     .. versionadded:: 1.30.0
         Support for context manager protocol with :meth:`dimod.Scoped`
         implemented.
+
+    .. versionchanged:: 1.33.0
+        For native embeddings, chain strength is not calculated anymore (it's
+        set to ``None`` in the returned ``embedding_context``).
 
     Examples:
 

--- a/dwave/system/composites/embedding.py
+++ b/dwave/system/composites/embedding.py
@@ -82,8 +82,10 @@ class EmbeddingComposite(dimod.ComposedSampler):
         implemented.
 
     .. versionchanged:: 1.33.0
-        For native embeddings, chain strength is not calculated anymore (it's
-        set to ``None`` in the returned ``embedding_context``).
+        For native embeddings, chain strength is not calculated anymore, and
+        chain break resolution method is ignored (both ``chain_strength`` and
+        ``chain_break_method`` are set to ``None`` in the returned
+        ``embedding_context``).
 
     Examples:
 
@@ -216,6 +218,11 @@ class EmbeddingComposite(dimod.ComposedSampler):
             **parameters:
                 Parameters for the sampling method, specified by the child
                 sampler.
+
+        .. versionchanged:: 1.33.0
+            For native embeddings, ``chain_strength``, ``chain_break_method``
+            and ``embedding_parameters`` parameters are ignored.
+            ``chain_break_fraction`` are set to zero for all samples.
 
         Returns:
             :obj:`~dimod.SampleSet`

--- a/releasenotes/notes/speed-up-embedding-composites-for-subgraphs-f246b8d1336cb898.yaml
+++ b/releasenotes/notes/speed-up-embedding-composites-for-subgraphs-f246b8d1336cb898.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Speed-up embedding/unembedding in all embedding composites for the special
+    case of one-to-one embeddings, i.e. subgraphs.
+
+    See `#579 <https://github.com/dwavesystems/dwave-system/issues/579>`_.

--- a/tests/test_embedding_composite.py
+++ b/tests/test_embedding_composite.py
@@ -259,6 +259,10 @@ class TestEmbeddingComposite(unittest.TestCase):
         self.assertIn('chain_strength', sampleset.info['embedding_context'])
         self.assertIsNone(sampleset.info['embedding_context']['chain_strength'])
 
+        self.assertIn('timing', sampleset.info['embedding_context'])
+        self.assertIn('embedding', sampleset.info['embedding_context']['timing'])
+        self.assertIn('unembedding', sampleset.info['embedding_context']['timing'])
+
         # default False
         sampleset = sampler.sample_ising({'a': -1}, {'ac': 1})
         self.assertNotIn('embedding_context', sampleset.info)
@@ -285,6 +289,10 @@ class TestEmbeddingComposite(unittest.TestCase):
 
         self.assertIn('chain_strength', sampleset.info['embedding_context'])
         self.assertEqual(round(sampleset.info['embedding_context']['chain_strength'], 3), 2)
+
+        self.assertIn('timing', sampleset.info['embedding_context'])
+        self.assertIn('embedding', sampleset.info['embedding_context']['timing'])
+        self.assertIn('unembedding', sampleset.info['embedding_context']['timing'])
 
         # default False
         sampleset = sampler.sample_ising({}, {'ab': 1, 'bc': 1, 'ca': 1})


### PR DESCRIPTION
Embedding step is ~100x faster and unembedding is ~20x faster (for subgraphs).

(On my laptop, for a Z12 graph, that's 1.7s vs 17ms for embedding and 170ms vs 9ms for unembedding.)

Close #579.