### PR TITLE
Fix broken doctest on ``broken_chains()``

### DIFF
--- a/dwave/embedding/chain_breaks.py
+++ b/dwave/embedding/chain_breaks.py
@@ -46,13 +46,15 @@ def broken_chains(samples, chains):
         broken.
 
     Examples:
+
+        >>> import numpy as np
+        ...
         >>> samples = np.array([[-1, +1, -1, +1], [-1, -1, +1, +1]], dtype=np.int8)
         >>> chains = [[0, 1], [2, 3]]
         >>> dwave.embedding.broken_chains(samples, chains)
         array([[True, True],
                [ False,  False]])
 
-        >>> samples = np.array([[-1, +1, -1, +1], [-1, -1, +1, +1]], dtype=np.int8)
         >>> chains = [[0, 2], [1, 3]]
         >>> dwave.embedding.broken_chains(samples, chains)
         array([[False, False],


### PR DESCRIPTION
CircleCI is showing just this failure but I might need to fix another that shows up locally (or it might be a difference in Python versions)
This is to deal with the doctest failure in [this PR](https://github.com/dwavesystems/dwave-system/pull/585)