### PR TITLE
Release 1.33.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,7 +257,7 @@ workflows:
               dependency-specifiers:
                 - "dwave-cloud-client~=0.12.0"
                 - "dwave-cloud-client~=0.13.6"
-                - "dwave-cloud-client~=0.14.0rc"
+                - "dwave-cloud-client~=0.14.0"
               integration-test-python-version: &integration-python-versions [*latest-python]
             exclude:
               - python-version: "3.13"

--- a/dwave/system/package_info.py
+++ b/dwave/system/package_info.py
@@ -14,7 +14,7 @@
 
 __all__ = ['__version__', '__author__', '__authoremail__', '__description__']
 
-__version__ = '1.33.0rc1'
+__version__ = '1.33.0'
 __author__ = 'D-Wave Systems Inc.'
 __authoremail__ = 'tools@dwavesys.com'
 __description__ = 'All things D-Wave System.'


### PR DESCRIPTION
### New Features

-   Begin using reno for changelog.

    We began using [Reno](https://docs.openstack.org/reno/) as a changelog tool after the release of 1.32.0. Content added before that release is not included. See [releases](https://github.com/dwavesystems/dwave-system/releases) for previous release notes.

<!-- -->

-   Add support for the new solver identity concept available in `dwave-cloud-client>=0.14.0`.

<!-- -->

-   Speed-up embedding/unembedding in all embedding composites for the special case of one-to-one embeddings, i.e. subgraphs.

    See [\#579](https://github.com/dwavesystems/dwave-system/issues/579).

<!-- -->

-   chain\_strength and initial\_state are now supported as sampling options in ParallelEmbeddingComposite. ParallelEmbeddingComposite is updated with an ew sample\_multiple helper function to allow different bqms, initial\_states and chain\_strengths on all embeddings.
