### PR TITLE
Release 1.34.0

### DIFF
--- a/dwave/system/package_info.py
+++ b/dwave/system/package_info.py
@@ -14,7 +14,7 @@
 
 __all__ = ['__version__', '__author__', '__authoremail__', '__description__']
 
-__version__ = '1.33.0'
+__version__ = '1.34.0'
 __author__ = 'D-Wave Systems Inc.'
 __authoremail__ = 'tools@dwavesys.com'
 __description__ = 'All things D-Wave System.'


### PR DESCRIPTION
### New Features

-   Add support for Python 3.14.

<!-- -->

-   Add `.wait_id` method to a future returned by `LeapHybridNLSampler`. See [\#602](https://github.com/dwavesystems/dwave-system/issues/602).

### Upgrade Notes

-   Drop support for Python 3.9.

<!-- -->

-   Remove `vfyc` solver property and `max_answers` solver parameter from `DWaveMockSampler` to reflect the current state of solver properties returned by SAPI. See [\#600](https://github.com/dwavesystems/dwave-system/pull/600).

### Bug Fixes

-   Fix handling of initial\_state kwarg for the sampling routine: instead of handling this parameter incorrectly an warning is thrown (parameter not mocked), as per other unsupported arguments. See [\#587](https://github.com/dwavesystems/dwave-system/issues/587).
