### PR TITLE
Replace `dwave-networkx` with `dwave-graphs`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -260,9 +260,9 @@ workflows:
             parameters:
               python-version: &python-versions ["3.10", "3.11", "3.12", "3.13", &latest-python "3.14"]
               dependency-specifiers:
-                - "dwave-cloud-client~=0.12.0"
-                - "dwave-cloud-client~=0.13.6"
-                - "dwave-cloud-client~=0.14.1"
+                - "dwave-cloud-client[mocks]~=0.12.0"
+                - "dwave-cloud-client[mocks]~=0.13.6"
+                - "dwave-cloud-client[mocks]~=0.14.1"
               integration-test-python-version: &integration-python-versions [*latest-python]
             exclude:
               - python-version: "3.13"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,10 @@ jobs:
 
       - run:
           name: install pyenv
+          environment:
+            HOMEBREW_NO_ASK: "1"
           command: |
+            brew update
             brew install pyenv
 
       - run:

--- a/dwave/embedding/drawing.py
+++ b/dwave/embedding/drawing.py
@@ -14,7 +14,7 @@
 
 from math import ceil, sqrt
 
-from dwave_networkx import chimera_graph, draw_chimera
+from dwave.graphs import chimera_graph, draw_chimera
 
 __all__ = ['draw_chimera_bqm']
 
@@ -24,7 +24,7 @@ def draw_chimera_bqm(bqm, width=None, height=None):
     Args:
         bqm (:class:`~dimod.binary.BinaryQuadraticModel`):
             Binary quadratic model equivalent to a Chimera graph or subgraph
-            produced by :func:`~dwave_networkx.chimera_graph`, with nodes and
+            produced by :func:`~dwave.graphs.chimera_graph`, with nodes and
             edges labeled as integers.
         width (int, optional):
             Number of cells for the graph width. If ``width`` and ``height`` are

--- a/dwave/system/composites/embedding.py
+++ b/dwave/system/composites/embedding.py
@@ -576,10 +576,10 @@ class FixedEmbeddingComposite(LazyFixedEmbeddingComposite):
         with a Chimera unit-cell structure.
 
         >>> import dimod
-        >>> import dwave_networkx as dnx
+        >>> import dwave.graphs
         >>> from dwave.system import FixedEmbeddingComposite
         ...
-        >>> c1 = dnx.chimera_graph(1)
+        >>> c1 = dwave.graphs.chimera_graph(1)
         >>> embedding = {'a': [0, 4], 'b': [1], 'c': [5]}
         >>> structured_sampler = dimod.StructureComposite(dimod.ExactSolver(),
         ...                                               c1.nodes, c1.edges)

--- a/dwave/system/composites/parallel_embeddings.py
+++ b/dwave/system/composites/parallel_embeddings.py
@@ -198,7 +198,7 @@ class ParallelEmbeddingComposite(dimod.Composite, dimod.Structured, dimod.Sample
 
         >>> from dwave.system import DWaveSampler
         >>> from dwave.system import ParallelEmbeddingComposite
-        >>> from dwave_networkx import chimera_graph
+        >>> from dwave.graphs import chimera_graph
         >>> from minorminer.utils.parallel_embeddings import find_sublattice_embeddings
         ...
         >>> source = tile = chimera_graph(1, 1, 4)  # A 1:1 mapping assumed
@@ -217,7 +217,7 @@ class ParallelEmbeddingComposite(dimod.Composite, dimod.Structured, dimod.Sample
 
     See also:
 
-        The :func:`~dwave_networkx.drawing.draw_parallel_embeddings` function to
+        The :func:`~dwave.graphs.drawing.draw_parallel_embeddings` function to
         visualize found embeddings.
 
     """

--- a/dwave/system/composites/tiling.py
+++ b/dwave/system/composites/tiling.py
@@ -30,7 +30,7 @@ for explanations of technical terms in descriptions of Ocean tools.
 import warnings
 
 import dimod
-import dwave_networkx as dnx
+import dwave.graphs
 
 import dwave.embedding
 
@@ -55,17 +55,17 @@ class TilingComposite(dimod.Composite, dimod.Structured, dimod.Sampler):
     Notation *PN* referes to a Pegasus graph consisting of a 3x(N-1)x(N-1) grid
     of cells, where each unit cell is a bipartite graph with shore of size t,
     supplemented with odd couplers (see ``nice_coordinate`` definition in
-    the :func:`~dwave_networkx.pegasus_graph` function). The
+    the :func:`~dwave.graphs.pegasus_graph` function). The
     Advantage QPU supports a P16 Pegasus graph: its qubits may be mapped to a
     3x15x15 matrix of unit cells, each of 8 qubits. This code supports tiling of
     Chimera-structured problems, with an option of additional odd-couplers,
-    onto Pegasus. See also the :func:`~dwave_networkx.pegasus_graph` function.
+    onto Pegasus. See also the :func:`~dwave.graphs.pegasus_graph` function.
 
     Notation *CN* refers to a Chimera graph consisting of an NxN grid of unit
     cells, where each unit cell is a bipartite graph with shores of size t.
     (An earlier quantum computer, the D-Wave 2000Q, supported a C16 Chimera 
     graph: its 2048 qubits were logically mapped into a 16x16 matrix of unit 
-    cells of 8 qubits (t=4). See also the :func:`~dwave_networkx.chimera_graph` 
+    cells of 8 qubits (t=4). See also the :func:`~dwave.graphs.chimera_graph` 
     function.)
 
     A problem that can be minor-embedded in a single chimera unit cell, for
@@ -139,7 +139,7 @@ class TilingComposite(dimod.Composite, dimod.Structured, dimod.Sampler):
         self.parameters = sampler.parameters.copy()
         self.properties = properties = {'child_properties': sampler.properties}
 
-        tile = dnx.chimera_graph(sub_m, sub_n, t)
+        tile = dwave.graphs.chimera_graph(sub_m, sub_n, t)
         self.nodelist = sorted(tile.nodes)
         self.edgelist = sorted(sorted(edge) for edge in tile.edges)
         # dimod.Structured abstract base class automatically populates adjacency
@@ -191,19 +191,19 @@ class TilingComposite(dimod.Composite, dimod.Structured, dimod.Sampler):
 
         if num_sublattices==1:
             # Chimera defaults. Appended coordinates (treat as first and only sublattice)
-            system = dnx.chimera_graph(m, n, t,
-                                       node_list=sampler.structure.nodelist,
-                                       edge_list=sampler.structure.edgelist)
+            system = dwave.graphs.chimera_graph(m, n, t,
+                                                node_list=sampler.structure.nodelist,
+                                                edge_list=sampler.structure.edgelist)
 
             c2i = {(0, *chimera_index) : linear_index
                    for (linear_index, chimera_index)
                    in system.nodes(data='chimera_index')}
         else:
-            system = dnx.pegasus_graph(m,
-                                       node_list=sampler.structure.nodelist,
-                                       edge_list=sampler.structure.edgelist)
+            system = dwave.graphs.pegasus_graph(m,
+                                                node_list=sampler.structure.nodelist,
+                                                edge_list=sampler.structure.edgelist)
             # Vector specification in terms of nice coordinates:
-            c2i = {dnx.pegasus_coordinates(m+1).linear_to_nice(linear_index):
+            c2i = {dwave.graphs.pegasus_coordinates(m+1).linear_to_nice(linear_index):
                    linear_index for linear_index in system.nodes()}
 
         sub_c2i = {chimera_index: linear_index for (linear_index, chimera_index)

--- a/dwave/system/coupling_groups.py
+++ b/dwave/system/coupling_groups.py
@@ -12,7 +12,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-import dwave_networkx as dnx
+import dwave.graphs
 
 
 def coupling_groups(hardware_graph):
@@ -40,7 +40,7 @@ def coupling_groups(hardware_graph):
     if hardware_graph.graph.get('family') != 'zephyr':
         return
 
-    relabel = dnx.zephyr_coordinates(hardware_graph.graph['rows']).linear_to_zephyr
+    relabel = dwave.graphs.zephyr_coordinates(hardware_graph.graph['rows']).linear_to_zephyr
 
     for q in hardware_graph:
         groups = [], []

--- a/dwave/system/samplers/dwave_sampler.py
+++ b/dwave/system/samplers/dwave_sampler.py
@@ -24,7 +24,7 @@ from collections import defaultdict
 from typing import Optional, Dict, TYPE_CHECKING
 
 import dimod
-import dwave_networkx as dnx
+import dwave.graphs
 from dimod.exceptions import BinaryQuadraticModelStructureError
 from dwave.cloud.client import Client
 from dwave.cloud.exceptions import (
@@ -43,10 +43,10 @@ __all__ = ['DWaveSampler', 'qpu_graph']
 
 
 def qpu_graph(topology_type, topology_shape, nodelist, edgelist):
-    """Convert node and edge lists to a ``dwave-networkx`` graph.
+    """Convert node and edge lists to a ``dwave-graphs`` graph.
 
     Creates a QPU :term:`topology` (Chimera, Pegasus or Zephyr) graph compatible
-    with Ocean software's :ref:`index_dnx`.
+    with Ocean software's :ref:`index_graphs`.
 
     Args:
         topology_type (string):
@@ -62,30 +62,30 @@ def qpu_graph(topology_type, topology_shape, nodelist, edgelist):
             nodes.
 
     See also:
-            :func:`dwave_networkx.chimera_graph`,
-            :func:`dwave_networkx.pegasus_graph`,
-            :func:`dwave_networkx.zephyr_graph` for descriptions of the lattice
+            :func:`~dwave.graphs.chimera_graph`,
+            :func:`~dwave.graphs.pegasus_graph`,
+            :func:`~dwave.graphs.zephyr_graph` for descriptions of the lattice
             parameters and indexing.
     """
 
     if topology_type == 'chimera':
         if not (1 <= len(topology_shape) <=3):
             raise ValueError('topology_shape is incompatible with a chimera lattice.')
-        G = dnx.chimera_graph(*topology_shape,
-                              node_list=nodelist,
-                              edge_list=edgelist)
+        G = dwave.graphs.chimera_graph(*topology_shape,
+                                       node_list=nodelist,
+                                       edge_list=edgelist)
     elif topology_type == 'pegasus':
         if len(topology_shape) != 1:
             raise ValueError('topology_shape is incompatible with a pegasus lattice.')
-        G = dnx.pegasus_graph(topology_shape[0],
-                                  node_list=nodelist,
-                                  edge_list=edgelist)
+        G = dwave.graphs.pegasus_graph(topology_shape[0],
+                                       node_list=nodelist,
+                                       edge_list=edgelist)
     elif topology_type == 'zephyr':
         if len(topology_shape) not in (1, 2):
             raise ValueError('topology_shape is incompatible with a zephyr lattice.')
-        G = dnx.zephyr_graph(*topology_shape,
-                                 node_list=nodelist,
-                                 edge_list=edgelist)
+        G = dwave.graphs.zephyr_graph(*topology_shape,
+                                      node_list=nodelist,
+                                      edge_list=edgelist)
     else:
         # Alternative could be to create a standard network graph and
         # issue a warning. Requires new dependency on networkx.

--- a/dwave/system/utilities.py
+++ b/dwave/system/utilities.py
@@ -82,11 +82,11 @@ def common_working_graph(graph0, graph1):
         This example creates a graph that represents a part of a particular
         Advantage quantum computer's working graph.
 
-        >>> import dwave_networkx as dnx
+        >>> import dwave.graphs
         >>> from dwave.system import DWaveSampler, common_working_graph
         ...
         >>> sampler = DWaveSampler(solver={'topology__type': 'pegasus'})
-        >>> P3 = dnx.pegasus_graph(3)
+        >>> P3 = dwave.graphs.pegasus_graph(3)
         >>> p3_working_graph = common_working_graph(P3, sampler.adjacency)
 
     """

--- a/releasenotes/notes/drop-numpy1-8e2cc66742de768e.yaml
+++ b/releasenotes/notes/drop-numpy1-8e2cc66742de768e.yaml
@@ -1,0 +1,4 @@
+---
+upgrade:
+  - |
+    Drop NumPy 1.x support.

--- a/releasenotes/notes/replace-dnx-with-graphs-ce26e44541c0332a.yaml
+++ b/releasenotes/notes/replace-dnx-with-graphs-ce26e44541c0332a.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Use ``dwave-graphs`` instead of the deprecated ``dwave-networkx``. See
+    `#609 <https://github.com/dwavesystems/dwave-system/pull/609>`_.

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,13 +6,13 @@ dwave-graphs==1.0
 dwave-samplers==1.7.0
 homebase==1.0.1
 minorminer==0.2.22
-networkx~=3.0
+networkx==3.4.2         # latest that supports 3.10 (and numpy 2)
 
-numpy==1.23.5;python_version<"3.11"  # for compatibility with scipy 1.9.3
-numpy==2.3.2;python_version>="3.11"
+numpy==2.2.6; python_version < '3.11'    # latest that supports 3.10
+numpy==2.4.6; python_version >= '3.11'   # latest as of June 2026
 
-scipy==1.9.3;python_version<"3.11"
-scipy==1.16.1;python_version>="3.11"
+scipy==1.15.3; python_version < '3.11'
+scipy==1.16.2; python_version >= '3.11'
 
 # dev requirements
 reno==4.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
-dimod==0.12.21
+dimod==0.12.22
 dwave-optimization==0.6.4
 dwave-preprocessing==0.6.11
-dwave-cloud-client==0.14.1
-dwave-networkx==0.8.14
+dwave-cloud-client==0.14.6
+dwave-graphs==1.0
 dwave-samplers==1.7.0
 homebase==1.0.1
-minorminer==0.2.20
+minorminer==0.2.22
 networkx~=3.0
 
 numpy==1.23.5;python_version<"3.11"  # for compatibility with scipy 1.9.3

--- a/setup.py
+++ b/setup.py
@@ -25,15 +25,16 @@ exec(open(os.path.join(".", "dwave", "system", "package_info.py")).read())
 
 
 install_requires = ['dimod>=0.12.20,<0.14.0',
-                    'dwave-optimization>=0.1.0,<0.8',
                     'dwave-cloud-client>=0.12.0,<0.15.0',
                     'dwave-graphs>=1,<2',
+                    'dwave-optimization>=0.1.0,<0.8',
                     'dwave-preprocessing>=0.5.0',
-                    'homebase>=1.0.0,<2.0.0',
-                    'minorminer>=0.2.19,<0.3.0',    # lower bound for parallel embedding support
-                    'numpy>=1.21.6',   # minimum inherited from minorminer
                     'dwave-samplers>=1.0.0',
-                    'scipy>=1.7.3',
+                    'homebase>=1.0.0,<2.0.0',
+                    'networkx>=3.2,<4',         # oldest that supports numpy 2
+                    'minorminer>=0.2.19,<0.3.0',    # lower bound for parallel embedding support
+                    'numpy>=2,<3',      # minimum inherited from minorminer
+                    'scipy>=1.13',      # oldest that supports numpy 2
                     ]
 
 python_requires = '>=3.10'

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ exec(open(os.path.join(".", "dwave", "system", "package_info.py")).read())
 install_requires = ['dimod>=0.12.20,<0.14.0',
                     'dwave-optimization>=0.1.0,<0.8',
                     'dwave-cloud-client>=0.12.0,<0.15.0',
-                    'dwave-networkx>=0.8.10',
+                    'dwave-graphs>=1,<2',
                     'dwave-preprocessing>=0.5.0',
                     'homebase>=1.0.0,<2.0.0',
                     'minorminer>=0.2.19,<0.3.0',    # lower bound for parallel embedding support

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,3 +3,5 @@ parameterized==0.7.4
 
 coverage>=7.0.0     # native namespace package support added in 7.0.0
 codecov
+
+dwave-cloud-client[mocks]==0.14.6

--- a/tests/test_dwavecliquesampler.py
+++ b/tests/test_dwavecliquesampler.py
@@ -19,7 +19,7 @@ import unittest.mock
 from parameterized import parameterized
 
 import dimod
-import dwave_networkx as dnx
+import dwave.graphs
 
 from dwave.cloud import exceptions
 from dwave.cloud import computation
@@ -66,7 +66,7 @@ class MockChimeraDWaveSampler(MockDWaveSampler):
 
         self.properties.update(topology=dict(shape=[4, 4, 4], type='chimera'))
 
-        G = dnx.chimera_graph(4, 4, 4)
+        G = dwave.graphs.chimera_graph(4, 4, 4)
 
         self.nodelist = list(G.nodes)
         self.edgelist = list(G.edges)
@@ -90,7 +90,7 @@ class MockPegasusDWaveSampler(MockDWaveSampler):
 
         self.properties.update(topology=dict(shape=[6], type='pegasus'))
 
-        G = dnx.pegasus_graph(6)
+        G = dwave.graphs.pegasus_graph(6)
 
         self.nodelist = list(G.nodes)
         self.edgelist = list(G.edges)

--- a/tests/test_dwavesampler.py
+++ b/tests/test_dwavesampler.py
@@ -21,7 +21,7 @@ import numpy as np
 from parameterized import parameterized
 
 import dimod
-import dwave_networkx as dnx
+import dwave.graphs
 
 from dwave.cloud import exceptions
 from dwave.cloud import computation
@@ -34,7 +34,7 @@ from dwave.system.warnings import EnergyScaleWarning, TooFewSamplesWarning
 from dwave.system.exceptions import FailoverCondition, RetryCondition
 
 
-C16 = dnx.chimera_graph(16)
+C16 = dwave.graphs.chimera_graph(16)
 
 # remove one node from C16 to simulate a not-fully-yielded system
 C16.remove_node(42)
@@ -277,7 +277,7 @@ class TestDWaveSampler(unittest.TestCase):
         self.assertEqual(set(frozenset(e) for e in G.edges), set(frozenset(e) for e in G.edges))
 
         # Create chimera graph for comparison
-        chimeraG = dnx.chimera_graph(4, node_list=sampler.nodelist, edge_list=sampler.edgelist)
+        chimeraG = dwave.graphs.chimera_graph(4, node_list=sampler.nodelist, edge_list=sampler.edgelist)
 
         self.assertEqual(set(G), set(chimeraG))
 
@@ -292,7 +292,7 @@ class TestDWaveSampler(unittest.TestCase):
         G = sampler.to_networkx_graph()
 
         # Create pegasus graph for comparison
-        pegasusG = dnx.pegasus_graph(4, node_list=sampler.nodelist, edge_list=sampler.edgelist)
+        pegasusG = dwave.graphs.pegasus_graph(4, node_list=sampler.nodelist, edge_list=sampler.edgelist)
 
         self.assertEqual(set(G), set(pegasusG))
 
@@ -307,7 +307,7 @@ class TestDWaveSampler(unittest.TestCase):
         G = sampler.to_networkx_graph()
 
         # Create zephyr graph for comparison
-        zephyrG = dnx.zephyr_graph(4, node_list=sampler.nodelist, edge_list=sampler.edgelist)
+        zephyrG = dwave.graphs.zephyr_graph(4, node_list=sampler.nodelist, edge_list=sampler.edgelist)
 
         self.assertEqual(set(G), set(zephyrG))
 

--- a/tests/test_embedding_composite.py
+++ b/tests/test_embedding_composite.py
@@ -20,7 +20,7 @@ from collections.abc import Mapping
 from unittest import mock
 
 import dimod
-import dwave_networkx as dnx
+import dwave.graphs
 from parameterized import parameterized_class
 
 import dwave.embedding
@@ -327,7 +327,7 @@ class TestEmbeddingComposite(unittest.TestCase):
         EmbeddingComposite.return_embedding_default = False
 
     def test_warnings(self):
-        G = dnx.chimera_graph(12)
+        G = dwave.graphs.chimera_graph(12)
 
         sampler = EmbeddingComposite(
             dimod.StructureComposite(dimod.RandomSampler(), G.nodes, G.edges))
@@ -340,7 +340,7 @@ class TestEmbeddingComposite(unittest.TestCase):
         self.assertIn('warnings', ss.info)
 
     def test_warning_chain_strength(self):
-        G = dnx.chimera_graph(12)
+        G = dwave.graphs.chimera_graph(12)
 
         sampler = EmbeddingComposite(
             dimod.StructureComposite(dimod.RandomSampler(), G.nodes, G.edges))
@@ -358,7 +358,7 @@ class TestEmbeddingComposite(unittest.TestCase):
         self.assertEqual(count, 1)
 
     def test_warnings_chain_strength_len1(self):
-        G = dnx.chimera_graph(12)
+        G = dwave.graphs.chimera_graph(12)
 
         sampler = EmbeddingComposite(
             dimod.StructureComposite(dimod.RandomSampler(), G.nodes, G.edges))
@@ -396,7 +396,7 @@ class TestEmbeddingComposite(unittest.TestCase):
         self.assertCountEqual(interactions[0], ('b','c'))
 
     def test_warnings_as_class_variable(self):
-        G = dnx.chimera_graph(12)
+        G = dwave.graphs.chimera_graph(12)
 
         sampler = EmbeddingComposite(
             dimod.StructureComposite(dimod.RandomSampler(), G.nodes, G.edges))
@@ -484,7 +484,7 @@ class TestFixedEmbeddingComposite(unittest.TestCase):
         self.assertEqual(mock_unembed.call_count, 1)
 
     def test_keyer(self):
-        C4 = dnx.chimera_graph(4)
+        C4 = dwave.graphs.chimera_graph(4)
         nodelist = sorted(C4.nodes)
         edgelist = sorted(sorted(edge) for edge in C4.edges)
 
@@ -507,7 +507,7 @@ class TestFixedEmbeddingComposite(unittest.TestCase):
         S = {(0, 1): 1, (0, 2): 1, (0, 3): 1, (1, 2): 1, (1, 3): 1, (2, 3): 1}
         bqm = dimod.BinaryQuadraticModel.from_qubo(Q)
 
-        G = dnx.chimera_graph(4)
+        G = dwave.graphs.chimera_graph(4)
         sampler = dimod.StructureComposite(dimod.ExactSolver(), G.nodes, G.edges)
         embedding = {0: [55], 1: [48], 2: [50, 53], 3: [52, 51]}
         composite = FixedEmbeddingComposite(sampler, embedding)
@@ -516,7 +516,7 @@ class TestFixedEmbeddingComposite(unittest.TestCase):
         composite.sample(bqm, chain_break_method=cbm).resolve()
 
     def test_subgraph_relabeling(self):
-        Z12 = dnx.zephyr_graph(12)
+        Z12 = dwave.graphs.zephyr_graph(12)
         nodelist = sorted(Z12.nodes)
         edgelist = sorted(sorted(edge) for edge in Z12.edges)
 
@@ -535,7 +535,7 @@ class TestFixedEmbeddingComposite(unittest.TestCase):
 
     def test_relabeling_performance_gain(self):
         with self.subTest('native subgraph Z6 -> Z6'):
-            graph = dnx.zephyr_graph(6)
+            graph = dwave.graphs.zephyr_graph(6)
             nodelist = sorted(graph.nodes)
             edgelist = sorted(sorted(edge) for edge in graph.edges)
 

--- a/tests/test_parallel_embedding_composite.py
+++ b/tests/test_parallel_embedding_composite.py
@@ -20,7 +20,7 @@ import numpy as np
 import networkx as nx
 
 import dimod
-import dwave_networkx as dnx
+import dwave.graphs
 
 from dwave.system.testing import MockDWaveSampler
 from dwave.system.composites import ParallelEmbeddingComposite
@@ -191,7 +191,7 @@ class TestParallelEmbeddings(unittest.TestCase):
                 used_nodes.add(e[1])
                 embeddings.append({idx: (n,) for idx, n in enumerate(e)})
         sampler = ParallelEmbeddingComposite(mock_sampler, embeddings=embeddings)
-        source = tile = dnx.chimera_graph(1, 1, 4)  # A 1:1 mapping assumed
+        source = tile = dwave.graphs.chimera_graph(1, 1, 4)  # A 1:1 mapping assumed
         J = {e: -1 for e in tile.edges}  # A ferromagnet on the Chimera tile.
         embedder_kwargs = {"max_num_emb": None}
         sampler = ParallelEmbeddingComposite(
@@ -235,7 +235,7 @@ class TestTiling(unittest.TestCase):
         num_reads = 10
 
         t = 4
-        tile = dnx.chimera_graph(1, 1, t)
+        tile = dwave.graphs.chimera_graph(1, 1, t)
         source = nx.complete_graph(t)  # Embeds easily on a tile, chain length 2
 
         # By find_multiple_embedding (default)
@@ -290,7 +290,7 @@ class TestTiling(unittest.TestCase):
             and "shape" in mock_sampler.properties["topology"]
         )
         # sampler = TilingComposite(mock_sampler, 1, 1)
-        tile = dnx.chimera_graph(1)
+        tile = dwave.graphs.chimera_graph(1)
         embedder = find_sublattice_embeddings
         embedder_kwargs = {
             "tile": tile,
@@ -309,7 +309,7 @@ class TestTiling(unittest.TestCase):
         m_sub = 2
         n_sub = 3
         # sampler = TilingComposite(mock_sampler, m_sub, n_sub)
-        tile = dnx.chimera_graph(m=m_sub, n=n_sub)
+        tile = dwave.graphs.chimera_graph(m=m_sub, n=n_sub)
         embedder = find_sublattice_embeddings
         embedder_kwargs = {
             "tile": tile,
@@ -346,11 +346,11 @@ class TestTiling(unittest.TestCase):
         mock_sampler = MockDWaveSampler(
             broken_nodes=[8 * 3], topology_type="chimera", topology_shape=chimera_shape
         )
-        hardware_graph = dnx.chimera_graph(*chimera_shape)  # C4
+        hardware_graph = dwave.graphs.chimera_graph(*chimera_shape)  # C4
 
         # Tile with 2x2 cells:
         # sampler = TilingComposite(mock_sampler, 2, 2, 4)
-        tile = dnx.chimera_graph(2, 2, 4)
+        tile = dwave.graphs.chimera_graph(2, 2, 4)
         embedder = find_sublattice_embeddings
         embedder_kwargs = {
             "tile": tile,
@@ -414,7 +414,7 @@ class TestTiling(unittest.TestCase):
         # where O: complete cell, X: incomplete cell
         broken_node_nice_coordinates = [(0, 0, 3, 0, 1), (2, 3, 3, 1, 3)]
         broken_node_linear_coordinates = [
-            dnx.pegasus_coordinates(pegasus_shape[0]).nice_to_linear(coord)
+            dwave.graphs.pegasus_coordinates(pegasus_shape[0]).nice_to_linear(coord)
             for coord in broken_node_nice_coordinates
         ]
         mock_sampler = MockDWaveSampler(
@@ -425,7 +425,7 @@ class TestTiling(unittest.TestCase):
         # Tile with 2x2 cells:
 
         # sampler = TilingComposite(mock_sampler, 2, 2, 4)  # Before!
-        tile = dnx.chimera_graph(2, 2, 4)
+        tile = dwave.graphs.chimera_graph(2, 2, 4)
         embedder = find_sublattice_embeddings
         embedder_kwargs = {
             "tile": tile,
@@ -447,7 +447,7 @@ class TestTiling(unittest.TestCase):
 
         # For additional insight try:
         # import matplotlib.pyplot as plt
-        # from dwave_networkx import draw_parallel_embeddings
+        # from dwave.graphs import draw_parallel_embeddings
 
         # draw_parallel_embeddings(mock_sampler.to_networkx_graph(), sampler.embeddings)
         # plt.show()
@@ -475,7 +475,7 @@ class TestTiling(unittest.TestCase):
         broken_edges_nice_coordinates = [(0, 1, 0, 0, 0), (0, 2, 0, 0, 0)]
         broken_edges = [
             tuple(
-                dnx.pegasus_coordinates(pegasus_shape[0]).nice_to_linear(coord)
+                dwave.graphs.pegasus_coordinates(pegasus_shape[0]).nice_to_linear(coord)
                 for coord in broken_edges_nice_coordinates
             )
         ]
@@ -485,7 +485,7 @@ class TestTiling(unittest.TestCase):
             broken_edges=broken_edges,
         )
         # sampler = TilingComposite(mock_sampler, 2, 2, 4) Deprecated
-        tile = dnx.chimera_graph(2, 2, 4)
+        tile = dwave.graphs.chimera_graph(2, 2, 4)
         embedder = find_sublattice_embeddings
         embedder_kwargs = {
             "tile": tile,
@@ -506,7 +506,7 @@ class TestTiling(unittest.TestCase):
         broken_edge_nice_coordinates = [(0, 0, 0, 0, 0), (0, 0, 0, 1, 0)]
         broken_edges = [
             tuple(
-                dnx.pegasus_coordinates(pegasus_shape[0]).nice_to_linear(coord)
+                dwave.graphs.pegasus_coordinates(pegasus_shape[0]).nice_to_linear(coord)
                 for coord in broken_edge_nice_coordinates
             )
         ]
@@ -516,7 +516,7 @@ class TestTiling(unittest.TestCase):
             broken_edges=broken_edges,
         )
         # sampler = TilingComposite(mock_sampler, 2, 2, 4)  # Deprecated
-        tile = dnx.chimera_graph(2, 2, 4)
+        tile = dwave.graphs.chimera_graph(2, 2, 4)
         embedder = find_sublattice_embeddings
         embedder_kwargs = {
             "tile": tile,
@@ -534,7 +534,7 @@ class TestTiling(unittest.TestCase):
     def test_sample_ising(self):
         # sampler = TilingComposite(MockDWaveSampler(), 2, 2)  # Deprecated
         mock_sampler = MockDWaveSampler()
-        tile = dnx.chimera_graph(m=2, n=2)
+        tile = dwave.graphs.chimera_graph(m=2, n=2)
         embedder = find_sublattice_embeddings
         embedder_kwargs = {
             "tile": tile,
@@ -572,7 +572,7 @@ class TestTiling(unittest.TestCase):
     def test_sample_qubo(self):
         # sampler = TilingComposite(MockDWaveSampler(), 2, 2)
         mock_sampler = MockDWaveSampler()
-        tile = dnx.chimera_graph(m=2, n=2)
+        tile = dwave.graphs.chimera_graph(m=2, n=2)
         embedder = find_sublattice_embeddings
         embedder_kwargs = {
             "tile": tile,
@@ -608,7 +608,7 @@ class TestTiling(unittest.TestCase):
         mock_sampler = MockDWaveSampler()  # C4 structured sampler
 
         # sampler = TilingComposite(mock_sampler, 2, 2)  # Deprecated
-        tile = dnx.chimera_graph(m=2, n=2)
+        tile = dwave.graphs.chimera_graph(m=2, n=2)
         embedder = find_sublattice_embeddings
         embedder_kwargs = {
             "tile": tile,

--- a/tests/test_reverse_composite.py
+++ b/tests/test_reverse_composite.py
@@ -16,12 +16,12 @@ import unittest
 
 import dimod
 import dimod.testing as dtest
-import dwave_networkx
+import dwave.graphs
 from dimod import ExactSolver
 
 from dwave.system import ReverseBatchStatesComposite, ReverseAdvanceComposite
 
-C4 = dwave_networkx.chimera_graph(4, 4, 4)
+C4 = dwave.graphs.chimera_graph(4, 4, 4)
 
 
 class MockReverseSampler(dimod.Sampler, dimod.Structured):

--- a/tests/test_tiling_composite.py
+++ b/tests/test_tiling_composite.py
@@ -16,7 +16,7 @@ import unittest
 import random
 
 import dimod
-import dwave_networkx as dnx
+import dwave.graphs
 
 from dwave.system.testing import MockDWaveSampler
 from dwave.system.composites import TilingComposite
@@ -80,7 +80,7 @@ class TestTiling(unittest.TestCase):
         # OOOO
         # where O: complete cell, X: incomplete cell
         mock_sampler = MockDWaveSampler(broken_nodes=[8 * 3]) 
-        hardware_graph = dnx.chimera_graph(4)  # C4
+        hardware_graph = dwave.graphs.chimera_graph(4)  # C4
 
         # Tile with 2x2 cells:
         sampler = TilingComposite(mock_sampler, 2, 2, 4)
@@ -116,7 +116,7 @@ class TestTiling(unittest.TestCase):
         # where O: complete cell, X: incomplete cell
         broken_node_nice_coordinates = [(0,0,3,0,1), (2,3,3,1,3)]
         broken_node_linear_coordinates = [
-            dnx.pegasus_coordinates(pegasus_shape[0]).nice_to_linear(coord)
+            dwave.graphs.pegasus_coordinates(pegasus_shape[0]).nice_to_linear(coord)
             for coord in broken_node_nice_coordinates]
         mock_sampler = MockDWaveSampler(topology_type='pegasus',
                                         topology_shape=pegasus_shape,
@@ -139,7 +139,7 @@ class TestTiling(unittest.TestCase):
         #Can be refined to check exact positioning, but a lot of ugly code:
         #For visualization in coordinate scheme use:
         #for emb in sampler.embeddings:
-        #    print({key: dnx.pegasus_coordinates(pegasus_shape[0]).linear_to_nice(next(iter(val)))
+        #    print({key: dwave.graphs.pegasus_coordinates(pegasus_shape[0]).linear_to_nice(next(iter(val)))
         #           for key,val in emb.items()})
 
     def test_tile_around_edge_defects_pegasus(self):
@@ -149,7 +149,7 @@ class TestTiling(unittest.TestCase):
         # prevent tesselation of 2x2 blocks (12 tiles, equivalent to full yield)
         broken_edges_nice_coordinates = [(0,1,0,0,0), (0,2,0,0,0)]
         broken_edges = [tuple(
-            dnx.pegasus_coordinates(pegasus_shape[0]).nice_to_linear(coord)
+            dwave.graphs.pegasus_coordinates(pegasus_shape[0]).nice_to_linear(coord)
             for coord in broken_edges_nice_coordinates)]
         mock_sampler = MockDWaveSampler(topology_type='pegasus',
                                         topology_shape=pegasus_shape,
@@ -161,7 +161,7 @@ class TestTiling(unittest.TestCase):
         # tesselation of 2x2 blocks (otherwise 12 tiles, with edge defect 11)
         broken_edge_nice_coordinates = [(0,0,0,0,0), (0,0,0,1,0)]
         broken_edges = [tuple(
-            dnx.pegasus_coordinates(pegasus_shape[0]).nice_to_linear(coord)
+            dwave.graphs.pegasus_coordinates(pegasus_shape[0]).nice_to_linear(coord)
             for coord in broken_edge_nice_coordinates)]
         mock_sampler = MockDWaveSampler(topology_type='pegasus',
                                         topology_shape=pegasus_shape,

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -12,13 +12,10 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-import os
 import unittest
 
 import numpy as np
-
-import dwave_networkx as dnx
-
+import dwave.graphs
 from dwave.cloud.testing import isolated_environ
 
 from dwave.system import (anneal_schedule_with_offset, common_working_graph,
@@ -29,7 +26,7 @@ from dwave.system.utilities import FeatureFlags
 class TestCommonWorkingGraph(unittest.TestCase):
     def test_single_tile(self):
 
-        G1 = dnx.chimera_graph(1)
+        G1 = dwave.graphs.chimera_graph(1)
         with self.assertWarns(DeprecationWarning):
             G = common_working_graph(G1, G1)
 
@@ -46,8 +43,8 @@ class TestCommonWorkingGraph(unittest.TestCase):
                 self.assertTrue((i, j) in G.edges() or (j, i) in G.edges())
 
     def test_c1_c2_tiles(self):
-        G1 = dnx.chimera_graph(1)
-        G2 = dnx.chimera_graph(2)
+        G1 = dwave.graphs.chimera_graph(1)
+        G2 = dwave.graphs.chimera_graph(2)
 
         with self.assertWarns(DeprecationWarning):
             G = common_working_graph(G1, G1)
@@ -55,9 +52,9 @@ class TestCommonWorkingGraph(unittest.TestCase):
         self.assertEqual(len(G), 8)
 
     def test_missing_node(self):
-        G1 = dnx.chimera_graph(1)
+        G1 = dwave.graphs.chimera_graph(1)
         G1.remove_node(2)
-        G2 = dnx.chimera_graph(2)
+        G2 = dwave.graphs.chimera_graph(2)
 
         with self.assertWarns(DeprecationWarning):
             G = common_working_graph(G1, G1)
@@ -67,7 +64,7 @@ class TestCommonWorkingGraph(unittest.TestCase):
 
     def test_sampler_adjacency(self):
         adj = {0: {1, 2}, 1: {2}, 2: {0, 1}}
-        G = dnx.chimera_graph(1)
+        G = dwave.graphs.chimera_graph(1)
 
         with self.assertWarns(DeprecationWarning):
             H = common_working_graph(adj, G)


### PR DESCRIPTION
#### Summary

- Use `dwave-graphs` instead of the deprecated `dwave-networkx`.
- Drop NumPy 1.x support.

#### AI AI Generation Disclosure

No AI tools used.